### PR TITLE
fix: make entrypoints consistent

### DIFF
--- a/runtimes/dart-2.12/Dockerfile
+++ b/runtimes/dart-2.12/Dockerfile
@@ -17,4 +17,4 @@ RUN dart --disable-analytics
 
 EXPOSE 3000
 
-CMD ["tail", "-f", "/dev/null"]
+CMD ["/usr/local/src/start.sh"]

--- a/runtimes/dart-2.13/Dockerfile
+++ b/runtimes/dart-2.13/Dockerfile
@@ -17,4 +17,4 @@ RUN dart --disable-analytics
 
 EXPOSE 3000
 
-CMD ["tail", "-f", "/dev/null"]
+CMD ["/usr/local/src/start.sh"]

--- a/runtimes/dart-2.14/Dockerfile
+++ b/runtimes/dart-2.14/Dockerfile
@@ -17,4 +17,4 @@ RUN dart --disable-analytics
 
 EXPOSE 3000
 
-CMD ["tail", "-f", "/dev/null"]
+CMD ["/usr/local/src/start.sh"]

--- a/runtimes/dart-2.15/Dockerfile
+++ b/runtimes/dart-2.15/Dockerfile
@@ -17,4 +17,4 @@ RUN dart --disable-analytics
 
 EXPOSE 3000
 
-CMD ["tail", "-f", "/dev/null"]
+CMD ["/usr/local/src/start.sh"]


### PR DESCRIPTION
Dart runtimes use a different `entrypoint` compared to the other runtimes. 
This PR fixes it