### PR TITLE
Docs: Node reserved key

### DIFF
--- a/runtimes/node-14.5/README.md
+++ b/runtimes/node-14.5/README.md
@@ -97,6 +97,7 @@ module.exports = (req, res) => {
 
 - The default entrypoint is `index.js`. If your entrypoint differs, make sure to configure it using `INTERNAL_RUNTIME_ENTRYPOINT` environment variable, for instance, `INTERNAL_RUNTIME_ENTRYPOINT=src/app.js`.
 
+- Library `micro` that we use under-the-hood reserved key `code` of the response JSON to have functionality of setting a response code. Please avoid using this keyword in your response when using `res.json()`.
 
 ## Authors
 

--- a/runtimes/node-14.5/README.md
+++ b/runtimes/node-14.5/README.md
@@ -97,7 +97,7 @@ module.exports = (req, res) => {
 
 - The default entrypoint is `index.js`. If your entrypoint differs, make sure to configure it using `INTERNAL_RUNTIME_ENTRYPOINT` environment variable, for instance, `INTERNAL_RUNTIME_ENTRYPOINT=src/app.js`.
 
-- Library `micro` that we use under-the-hood reserved key `code` of the response JSON to have functionality of setting a response code. Please avoid using this keyword in your response when using `res.json()`.
+- Library `micro` that we use under-the-hood reserves key `code` of the response JSON. Avoid using this keyword in your response when using `res.json()`.
 
 ## Authors
 

--- a/runtimes/node-14.5/server.js
+++ b/runtimes/node-14.5/server.js
@@ -19,7 +19,13 @@ const server = micro(async (req, res) => {
 
     const response = {
         send: (text, status = 200) => send(res, status, text),
-        json: (json, status = 200) => send(res, status, json),
+        json: (json, status = 200) => {
+            if(json.code) {
+                throw new Error("Key 'code' is a reserved key. It cannot be used in the response. Use a different key instead.");
+            }
+
+            send(res, status, json);
+        },
     };
     try {
         let userFunction = require(USER_CODE_PATH + '/' + process.env.INTERNAL_RUNTIME_ENTRYPOINT);

--- a/runtimes/node-15.5/README.md
+++ b/runtimes/node-15.5/README.md
@@ -97,6 +97,7 @@ module.exports = (req, res) => {
 
 - The default entrypoint is `index.js`. If your entrypoint differs, make sure to configure it using `INTERNAL_RUNTIME_ENTRYPOINT` environment variable, for instance, `INTERNAL_RUNTIME_ENTRYPOINT=src/app.js`.
 
+- Library `micro` that we use under-the-hood reserved key `code` of the response JSON to have functionality of setting a response code. Please avoid using this keyword in your response when using `res.json()`.
 
 ## Authors
 

--- a/runtimes/node-15.5/README.md
+++ b/runtimes/node-15.5/README.md
@@ -97,7 +97,7 @@ module.exports = (req, res) => {
 
 - The default entrypoint is `index.js`. If your entrypoint differs, make sure to configure it using `INTERNAL_RUNTIME_ENTRYPOINT` environment variable, for instance, `INTERNAL_RUNTIME_ENTRYPOINT=src/app.js`.
 
-- Library `micro` that we use under-the-hood reserved key `code` of the response JSON to have functionality of setting a response code. Please avoid using this keyword in your response when using `res.json()`.
+- Library `micro` that we use under-the-hood reserves key `code` of the response JSON. Avoid using this keyword in your response when using `res.json()`.
 
 ## Authors
 

--- a/runtimes/node-15.5/server.js
+++ b/runtimes/node-15.5/server.js
@@ -19,7 +19,13 @@ const server = micro(async (req, res) => {
 
     const response = {
         send: (text, status = 200) => send(res, status, text),
-        json: (json, status = 200) => send(res, status, json),
+        json: (json, status = 200) => {
+            if(json.code) {
+                throw new Error("Key 'code' is a reserved key. It cannot be used in the response. Use a different key instead.");
+            }
+
+            send(res, status, json);
+        },
     };
     try {
         let userFunction = require(USER_CODE_PATH + '/' + process.env.INTERNAL_RUNTIME_ENTRYPOINT);

--- a/runtimes/node-16.0/README.md
+++ b/runtimes/node-16.0/README.md
@@ -97,6 +97,7 @@ module.exports = (req, res) => {
 
 - The default entrypoint is `index.js`. If your entrypoint differs, make sure to configure it using `INTERNAL_RUNTIME_ENTRYPOINT` environment variable, for instance, `INTERNAL_RUNTIME_ENTRYPOINT=src/app.js`.
 
+- Library `micro` that we use under-the-hood reserved key `code` of the response JSON to have functionality of setting a response code. Please avoid using this keyword in your response when using `res.json()`.
 
 ## Authors
 

--- a/runtimes/node-16.0/README.md
+++ b/runtimes/node-16.0/README.md
@@ -97,7 +97,7 @@ module.exports = (req, res) => {
 
 - The default entrypoint is `index.js`. If your entrypoint differs, make sure to configure it using `INTERNAL_RUNTIME_ENTRYPOINT` environment variable, for instance, `INTERNAL_RUNTIME_ENTRYPOINT=src/app.js`.
 
-- Library `micro` that we use under-the-hood reserved key `code` of the response JSON to have functionality of setting a response code. Please avoid using this keyword in your response when using `res.json()`.
+- Library `micro` that we use under-the-hood reserves key `code` of the response JSON. Avoid using this keyword in your response when using `res.json()`.
 
 ## Authors
 

--- a/runtimes/node-16.0/server.js
+++ b/runtimes/node-16.0/server.js
@@ -19,7 +19,13 @@ const server = micro(async (req, res) => {
 
     const response = {
         send: (text, status = 200) => send(res, status, text),
-        json: (json, status = 200) => send(res, status, json),
+        json: (json, status = 200) => {
+            if(json.code) {
+                throw new Error("Key 'code' is a reserved key. It cannot be used in the response. Use a different key instead.");
+            }
+
+            send(res, status, json);
+        },
     };
     try {
         let userFunction = require(USER_CODE_PATH + '/' + process.env.INTERNAL_RUNTIME_ENTRYPOINT);

--- a/runtimes/node-17.0/README.md
+++ b/runtimes/node-17.0/README.md
@@ -97,6 +97,7 @@ module.exports = (req, res) => {
 
 - The default entrypoint is `index.js`. If your entrypoint differs, make sure to configure it using `INTERNAL_RUNTIME_ENTRYPOINT` environment variable, for instance, `INTERNAL_RUNTIME_ENTRYPOINT=src/app.js`.
 
+- Library `micro` that we use under-the-hood reserved key `code` of the response JSON to have functionality of setting a response code. Please avoid using this keyword in your response when using `res.json()`.
 
 ## Authors
 

--- a/runtimes/node-17.0/README.md
+++ b/runtimes/node-17.0/README.md
@@ -97,7 +97,7 @@ module.exports = (req, res) => {
 
 - The default entrypoint is `index.js`. If your entrypoint differs, make sure to configure it using `INTERNAL_RUNTIME_ENTRYPOINT` environment variable, for instance, `INTERNAL_RUNTIME_ENTRYPOINT=src/app.js`.
 
-- Library `micro` that we use under-the-hood reserved key `code` of the response JSON to have functionality of setting a response code. Please avoid using this keyword in your response when using `res.json()`.
+- Library `micro` that we use under-the-hood reserves key `code` of the response JSON. Avoid using this keyword in your response when using `res.json()`.
 
 ## Authors
 

--- a/runtimes/node-17.0/server.js
+++ b/runtimes/node-17.0/server.js
@@ -19,7 +19,13 @@ const server = micro(async (req, res) => {
 
     const response = {
         send: (text, status = 200) => send(res, status, text),
-        json: (json, status = 200) => send(res, status, json),
+        json: (json, status = 200) => {
+            if(json.code) {
+                throw new Error("Key 'code' is a reserved key. It cannot be used in the response. Use a different key instead.");
+            }
+
+            send(res, status, json);
+        },
     };
     try {
         let userFunction = require(USER_CODE_PATH + '/' + process.env.INTERNAL_RUNTIME_ENTRYPOINT);


### PR DESCRIPTION
Improved docs of Node runtimes, to mention reserved keyword `code`. People should avoid using this, as this is not consistent behaviour in all runtimes.
