### PR TITLE
Fix: Implemented one-time include

### DIFF
--- a/runtimes/php-8.0/server.php
+++ b/runtimes/php-8.0/server.php
@@ -68,7 +68,7 @@ $server->on("Request", function($req, $res) use(&$userFunction) {
     $response = new Response($res);
 
     try {
-        if($userFunction == null) {
+        if($userFunction === null) {
             $userFunction = include(USER_CODE_PATH . '/' . getenv('INTERNAL_RUNTIME_ENTRYPOINT'));
         }
 

--- a/runtimes/php-8.0/server.php
+++ b/runtimes/php-8.0/server.php
@@ -30,8 +30,9 @@ class Response {
     }
 }
 
+$userFunction = null;
 
-$server->on("Request", function($req, $res) {
+$server->on("Request", function($req, $res) use(&$userFunction) {
     $body =  json_decode($req->getContent(), true);
     $body['payload'] = \is_string($body['payload']) ? $body['payload'] : \json_encode($body['payload'], JSON_FORCE_OBJECT);
 
@@ -67,7 +68,9 @@ $server->on("Request", function($req, $res) {
     $response = new Response($res);
 
     try {
-        $userFunction = include(USER_CODE_PATH . '/' . getenv('INTERNAL_RUNTIME_ENTRYPOINT'));
+        if($userFunction == null) {
+            $userFunction = include(USER_CODE_PATH . '/' . getenv('INTERNAL_RUNTIME_ENTRYPOINT'));
+        }
 
         if (!is_callable($userFunction)) {
             return throw new Exception('Function not valid');

--- a/runtimes/php-8.1/server.php
+++ b/runtimes/php-8.1/server.php
@@ -68,7 +68,7 @@ $server->on("Request", function($req, $res) use(&$userFunction) {
     $response = new Response($res);
 
     try {
-        if($userFunction == null) {
+        if($userFunction === null) {
             $userFunction = include(USER_CODE_PATH . '/' . getenv('INTERNAL_RUNTIME_ENTRYPOINT'));
         }
 

--- a/runtimes/php-8.1/server.php
+++ b/runtimes/php-8.1/server.php
@@ -30,8 +30,9 @@ class Response {
     }
 }
 
+$userFunction = null;
 
-$server->on("Request", function($req, $res) {
+$server->on("Request", function($req, $res) use(&$userFunction) {
     $body =  json_decode($req->getContent(), true);
     $body['payload'] = \is_string($body['payload']) ? $body['payload'] : \json_encode($body['payload'], JSON_FORCE_OBJECT);
 
@@ -67,7 +68,9 @@ $server->on("Request", function($req, $res) {
     $response = new Response($res);
 
     try {
-        $userFunction = include(USER_CODE_PATH . '/' . getenv('INTERNAL_RUNTIME_ENTRYPOINT'));
+        if($userFunction == null) {
+            $userFunction = include(USER_CODE_PATH . '/' . getenv('INTERNAL_RUNTIME_ENTRYPOINT'));
+        }
 
         if (!is_callable($userFunction)) {
             return throw new Exception('Function not valid');


### PR DESCRIPTION
Problematic code:
```
<?

function myFunc() {
        return "myFunc";
}

return function($req, $res) {
  $res->json([ 'n' => \mt_rand() / \mt_getrandmax() ]);
};
```

Failed due to:
```
Fatal error: Cannot redeclare myFunc() (previously declared in /usr/code-start/index.php:4) in /usr/code-start/index.php on line 3
```

This PR makes sure we only import the code once, and share it between executions. Code above now works.