### PR TITLE
Feat: ES module support (Node)

### DIFF
--- a/runtimes/node-14.5/server.js
+++ b/runtimes/node-14.5/server.js
@@ -24,11 +24,15 @@ const server = micro(async (req, res) => {
     try {
         let userFunction = require(USER_CODE_PATH + '/' + process.env.INTERNAL_RUNTIME_ENTRYPOINT);
 
-        if (!(userFunction || userFunction.constructor || userFunction.call || userFunction.apply || userFunction.default)) {
+        if (!(userFunction || userFunction.constructor || userFunction.call || userFunction.apply)) {
             throw new Error("User function is not valid.")
         }
 
         if(userFunction.default) {
+            if (!(userFunction.default.constructor || userFunction.default.call || userFunction.default.apply)) {
+                throw new Error("User function is not valid.")
+            }
+            
             await userFunction.default(request, response);
         } else {
             await userFunction(request, response);

--- a/runtimes/node-14.5/server.js
+++ b/runtimes/node-14.5/server.js
@@ -24,11 +24,15 @@ const server = micro(async (req, res) => {
     try {
         let userFunction = require(USER_CODE_PATH + '/' + process.env.INTERNAL_RUNTIME_ENTRYPOINT);
 
-        if (!(userFunction || userFunction.constructor || userFunction.call || userFunction.apply)) {
+        if (!(userFunction || userFunction.constructor || userFunction.call || userFunction.apply || userFunction.default)) {
             throw new Error("User function is not valid.")
         }
 
-        await userFunction(request, response);
+        if(userFunction.default) {
+            await userFunction.default(request, response);
+        } else {
+            await userFunction(request, response);
+        }
     } catch (e) {
         send(res, 500, {
             code: 500,

--- a/runtimes/node-15.5/server.js
+++ b/runtimes/node-15.5/server.js
@@ -24,11 +24,15 @@ const server = micro(async (req, res) => {
     try {
         let userFunction = require(USER_CODE_PATH + '/' + process.env.INTERNAL_RUNTIME_ENTRYPOINT);
 
-        if (!(userFunction || userFunction.constructor || userFunction.call || userFunction.apply || userFunction.default)) {
+        if (!(userFunction || userFunction.constructor || userFunction.call || userFunction.apply)) {
             throw new Error("User function is not valid.")
         }
 
         if(userFunction.default) {
+            if (!(userFunction.default.constructor || userFunction.default.call || userFunction.default.apply)) {
+                throw new Error("User function is not valid.")
+            }
+            
             await userFunction.default(request, response);
         } else {
             await userFunction(request, response);

--- a/runtimes/node-15.5/server.js
+++ b/runtimes/node-15.5/server.js
@@ -24,11 +24,15 @@ const server = micro(async (req, res) => {
     try {
         let userFunction = require(USER_CODE_PATH + '/' + process.env.INTERNAL_RUNTIME_ENTRYPOINT);
 
-        if (!(userFunction || userFunction.constructor || userFunction.call || userFunction.apply)) {
+        if (!(userFunction || userFunction.constructor || userFunction.call || userFunction.apply || userFunction.default)) {
             throw new Error("User function is not valid.")
         }
 
-        await userFunction(request, response);
+        if(userFunction.default) {
+            await userFunction.default(request, response);
+        } else {
+            await userFunction(request, response);
+        }
     } catch (e) {
         send(res, 500, {
             code: 500,

--- a/runtimes/node-16.0/server.js
+++ b/runtimes/node-16.0/server.js
@@ -24,11 +24,15 @@ const server = micro(async (req, res) => {
     try {
         let userFunction = require(USER_CODE_PATH + '/' + process.env.INTERNAL_RUNTIME_ENTRYPOINT);
 
-        if (!(userFunction || userFunction.constructor || userFunction.call || userFunction.apply || userFunction.default)) {
+        if (!(userFunction || userFunction.constructor || userFunction.call || userFunction.apply)) {
             throw new Error("User function is not valid.")
         }
 
         if(userFunction.default) {
+            if (!(userFunction.default.constructor || userFunction.default.call || userFunction.default.apply)) {
+                throw new Error("User function is not valid.")
+            }
+            
             await userFunction.default(request, response);
         } else {
             await userFunction(request, response);

--- a/runtimes/node-16.0/server.js
+++ b/runtimes/node-16.0/server.js
@@ -24,11 +24,15 @@ const server = micro(async (req, res) => {
     try {
         let userFunction = require(USER_CODE_PATH + '/' + process.env.INTERNAL_RUNTIME_ENTRYPOINT);
 
-        if (!(userFunction || userFunction.constructor || userFunction.call || userFunction.apply)) {
+        if (!(userFunction || userFunction.constructor || userFunction.call || userFunction.apply || userFunction.default)) {
             throw new Error("User function is not valid.")
         }
 
-        await userFunction(request, response);
+        if(userFunction.default) {
+            await userFunction.default(request, response);
+        } else {
+            await userFunction(request, response);
+        }
     } catch (e) {
         send(res, 500, {
             code: 500,

--- a/runtimes/node-17.0/server.js
+++ b/runtimes/node-17.0/server.js
@@ -24,11 +24,15 @@ const server = micro(async (req, res) => {
     try {
         let userFunction = require(USER_CODE_PATH + '/' + process.env.INTERNAL_RUNTIME_ENTRYPOINT);
 
-        if (!(userFunction || userFunction.constructor || userFunction.call || userFunction.apply || userFunction.default)) {
+        if (!(userFunction || userFunction.constructor || userFunction.call || userFunction.apply)) {
             throw new Error("User function is not valid.")
         }
 
         if(userFunction.default) {
+            if (!(userFunction.default.constructor || userFunction.default.call || userFunction.default.apply)) {
+                throw new Error("User function is not valid.")
+            }
+            
             await userFunction.default(request, response);
         } else {
             await userFunction(request, response);

--- a/runtimes/node-17.0/server.js
+++ b/runtimes/node-17.0/server.js
@@ -24,11 +24,15 @@ const server = micro(async (req, res) => {
     try {
         let userFunction = require(USER_CODE_PATH + '/' + process.env.INTERNAL_RUNTIME_ENTRYPOINT);
 
-        if (!(userFunction || userFunction.constructor || userFunction.call || userFunction.apply)) {
+        if (!(userFunction || userFunction.constructor || userFunction.call || userFunction.apply || userFunction.default)) {
             throw new Error("User function is not valid.")
         }
 
-        await userFunction(request, response);
+        if(userFunction.default) {
+            await userFunction.default(request, response);
+        } else {
+            await userFunction(request, response);
+        }
     } catch (e) {
         send(res, 500, {
             code: 500,


### PR DESCRIPTION
Issue: https://github.com/open-runtimes/open-runtimes/issues/63

If you have `index.ts`:
![CleanShot 2022-03-25 at 09 08 27](https://user-images.githubusercontent.com/19310830/160080634-4d9f9a5c-8295-444a-82d1-1913c5e25919.png)

It will build to `index.js`:

![CleanShot 2022-03-25 at 09 08 30](https://user-images.githubusercontent.com/19310830/160080656-b1a7c75f-16b1-4ce6-99f4-6fb861cb8205.png)

OPR for Node now supports this, and executes properly:

![CleanShot 2022-03-25 at 09 08 22](https://user-images.githubusercontent.com/19310830/160080701-698cdbca-f960-4d7f-94c7-d059e061b903.png)

