### PR TITLE
feat: increase source compatibility for newer Java versions

### DIFF
--- a/runtimes/java-11.0/build.gradle
+++ b/runtimes/java-11.0/build.gradle
@@ -4,7 +4,7 @@ plugins {
 
 group = 'io.openruntimes'
 version = '1.0.0'
-sourceCompatibility = '8'
+sourceCompatibility = '11'
 
 repositories {
 	mavenCentral()

--- a/runtimes/java-17.0/build.gradle
+++ b/runtimes/java-17.0/build.gradle
@@ -4,7 +4,7 @@ plugins {
 
 group = 'io.openruntimes'
 version = '1.0.0'
-sourceCompatibility = '8'
+sourceCompatibility = '11'
 
 repositories {
 	mavenCentral()

--- a/runtimes/java-18.0/build.gradle
+++ b/runtimes/java-18.0/build.gradle
@@ -4,7 +4,7 @@ plugins {
 
 group = 'io.openruntimes'
 version = '1.0.0'
-sourceCompatibility = '8'
+sourceCompatibility = '11'
 
 repositories {
 	mavenCentral()


### PR DESCRIPTION
The `sourceCompatibility` for our Java 11, 17 and 18 runtimes were stuck at Java 8 which prevented us from using new Java features like the `var` declarations. 

This PR upgrades the `sourceCompatibility` flag to Java 11 to ensure better support for new features.

### Before 
![Screenshot 2022-07-09 at 6 40 30 PM](https://user-images.githubusercontent.com/20852629/178110534-165b40f0-d604-42f2-9ca7-2d35c92e0dbd.png)

<details> 
<summary>Detailed Logs</summary>

```bash
Docker Error: /usr/local/src/src/main/java/io/openruntimes/java/Wrapper.java:25: warning: as of release , 'var' is a restricted type name and cannot be used for type declarations or as the element type of an array
    var client = new Client();
        ^
/usr/local/src/src/main/java/io/openruntimes/java/Wrapper.java:28: warning: as of release , 'var' is a restricted type name and cannot be used for type declarations or as the element type of an array
    var account = new Account(client);
        ^
/usr/local/src/src/main/java/io/openruntimes/java/Wrapper.java:29: warning: as of release , 'var' is a restricted type name and cannot be used for type declarations or as the element type of an array
    var avatars = new Avatars(client);
        ^
/usr/local/src/src/main/java/io/openruntimes/java/Wrapper.java:30: warning: as of release , 'var' is a restricted type name and cannot be used for type declarations or as the element type of an array
    var database = new Databases(client, "YOUR_DATABASE_ID");
        ^
/usr/local/src/src/main/java/io/openruntimes/java/Wrapper.java:31: warning: as of release , 'var' is a restricted type name and cannot be used for type declarations or as the element type of an array
    var functions = new Functions(client);
        ^
/usr/local/src/src/main/java/io/openruntimes/java/Wrapper.java:32: warning: as of release , 'var' is a restricted type name and cannot be used for type declarations or as the element type of an array
    var health = new Health(client);
        ^
/usr/local/src/src/main/java/io/openruntimes/java/Wrapper.java:33: warning: as of release , 'var' is a restricted type name and cannot be used for type declarations or as the element type of an array
    var locale = new Locale(client);
        ^
/usr/local/src/src/main/java/io/openruntimes/java/Wrapper.java:34: warning: as of release , 'var' is a restricted type name and cannot be used for type declarations or as the element type of an array
    var storage = new Storage(client);
        ^
/usr/local/src/src/main/java/io/openruntimes/java/Wrapper.java:35: warning: as of release , 'var' is a restricted type name and cannot be used for type declarations or as the element type of an array
    var teams = new Teams(client);
        ^
/usr/local/src/src/main/java/io/openruntimes/java/Wrapper.java:36: warning: as of release , 'var' is a restricted type name and cannot be used for type declarations or as the element type of an array
    var users = new Users(client);
        ^
/usr/local/src/src/main/java/io/openruntimes/java/Wrapper.java:38: warning: as of release , 'var' is a restricted type name and cannot be used for type declarations or as the element type of an array
    var env = req.getEnv();
        ^
/usr/local/src/src/main/java/io/openruntimes/java/Wrapper.java:25: error: cannot find symbol
    var client = new Client();
    ^
  symbol:   class var
  location: class Wrapper
/usr/local/src/src/main/java/io/openruntimes/java/Wrapper.java:28: error: cannot find symbol
    var account = new Account(client);
    ^
  symbol:   class var
  location: class Wrapper
/usr/local/src/src/main/java/io/openruntimes/java/Wrapper.java:29: error: cannot find symbol
    var avatars = new Avatars(client);
    ^
  symbol:   class var
  location: class Wrapper
/usr/local/src/src/main/java/io/openruntimes/java/Wrapper.java:30: error: cannot find symbol
    var database = new Databases(client, "YOUR_DATABASE_ID");
    ^
  symbol:   class var
  location: class Wrapper
/usr/local/src/src/main/java/io/openruntimes/java/Wrapper.java:31: error: cannot find symbol
    var functions = new Functions(client);
    ^
  symbol:   class var
  location: class Wrapper
/usr/local/src/src/main/java/io/openruntimes/java/Wrapper.java:32: error: cannot find symbol
    var health = new Health(client);
    ^
  symbol:   class var
  location: class Wrapper
/usr/local/src/src/main/java/io/openruntimes/java/Wrapper.java:33: error: cannot find symbol
    var locale = new Locale(client);
    ^
  symbol:   class var
  location: class Wrapper
/usr/local/src/src/main/java/io/openruntimes/java/Wrapper.java:34: error: cannot find symbol
    var storage = new Storage(client);
    ^
  symbol:   class var
  location: class Wrapper
/usr/local/src/src/main/java/io/openruntimes/java/Wrapper.java:35: error: cannot find symbol
    var teams = new Teams(client);
    ^
  symbol:   class var
  location: class Wrapper
/usr/local/src/src/main/java/io/openruntimes/java/Wrapper.java:36: error: cannot find symbol
    var users = new Users(client);
    ^
  symbol:   class var
  location: class Wrapper
/usr/local/src/src/main/java/io/openruntimes/java/Wrapper.java:38: error: cannot find symbol
    var env = req.getEnv();
    ^
  symbol:   class var
  location: class Wrapper
Note: /usr/local/src/src/main/java/io/openruntimes/java/RuntimeRequest.java uses unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.
 errors
 warnings

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':compileJava'.
> Compilation failed; see the compiler error output for details.

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 16s
Downloading https://services.gradle.org/distributions/gradle-7.4.1-bin.zip
...........10%...........20%...........30%...........40%...........50%...........60%...........70%...........80%...........90%...........100%

Welcome to Gradle .1!

Here are the highlights of this release:
 - Aggregated test and JaCoCo reports
 - Marking additional test source directories as tests in IntelliJ
 - Support for Adoptium JDKs in Java toolchains

For more details see https://docs.gradle.org/7.4.1/release-notes.html

Starting a Gradle Daemon (subsequent builds will be faster)

> Task :compileJava FAILED
 actionable task:  executed
```

</details>

### After 

![Screenshot 2022-07-09 at 6 40 44 PM](https://user-images.githubusercontent.com/20852629/178110546-e1a8c964-29ab-4a00-9287-6ff346e96525.png)


![Screenshot 2022-07-09 at 6 41 01 PM](https://user-images.githubusercontent.com/20852629/178110559-6b43bd50-a3c6-4cd0-9e1f-e82b766cc65a.png)
 