### PR TITLE
Feat: Improve caching in Deno 1.21

### DIFF
--- a/runtimes/deno-1.21/build.sh
+++ b/runtimes/deno-1.21/build.sh
@@ -6,19 +6,14 @@ set -e
 # Prepare separate directory to prevent changing user's files
 cp -R /usr/code/* /usr/builds
 
-# Prepare Deno cache folder
-mkdir -p /usr/builds/deno-cache
 
-# Set Deno Cache directory
-export DENO_DIR="/usr/builds/deno-cache"
-
-# Cache Server Depdenencies
-cd /usr/local/src/
-deno cache server.ts
-
-# Cache user function depdenencies
+# Cache server and user function dependencies
 cd /usr/builds
-deno cache $INTERNAL_RUNTIME_ENTRYPOINT
+deno vendor /usr/local/src/server.ts $INTERNAL_RUNTIME_ENTRYPOINT
+mkdir -p vendor
+
+# Check for build error
+deno check $INTERNAL_RUNTIME_ENTRYPOINT
 
 # Finish build by preparing tar to use for starting the runtime
 tar --exclude code.tar.gz -zcf /usr/code/code.tar.gz .

--- a/runtimes/deno-1.21/start.sh
+++ b/runtimes/deno-1.21/start.sh
@@ -3,6 +3,16 @@ cp /tmp/code.tar.gz /usr/workspace/code.tar.gz
 cd /usr/workspace 
 tar -zxf /usr/workspace/code.tar.gz -C /usr/code-start
 rm /usr/workspace/code.tar.gz
-export DENO_DIR="/usr/code-start/deno-cache"
 cd /usr/local/src/
-denon run --allow-net --allow-write --allow-read --allow-env server.ts
+
+# Prepare dependencies
+cp -R /usr/code-start/vendor .
+mkdir -p vendor
+
+# Run script, using import map if we have one
+FILE=vendor/import_map.json
+if [ -f "$FILE" ]; then
+    denon run --import-map=vendor/import_map.json --no-check --allow-net --allow-write --allow-read --allow-env server.ts
+else 
+    denon run --no-check --allow-net --allow-write --allow-read --allow-env server.ts
+fi


### PR DESCRIPTION
`deno cache` didn't really serve a purpose here. We have seen extremely long cold starts, most likely due to the re-downloading of dependencies on the first request:

<img width="170" alt="image" src="https://user-images.githubusercontent.com/19310830/178785497-6e87c40b-0486-497a-8ec3-671bd0b4b3b5.png">

This new `vendor` approach is downloading dependencies into `vendor` folder, making sure all is downloaded during the build step.

---

This PR also moves "check" into the build step, and runs execution with `--no-check` to improve cold start speed even more.