### PR TITLE
Fix 86 python package dependencies

### DIFF
--- a/runtimes/python-3.10/Dockerfile
+++ b/runtimes/python-3.10/Dockerfile
@@ -1,5 +1,7 @@
 FROM python:3.10-alpine3.15
 
+RUN apk --no-cache add musl-dev linux-headers g++
+
 LABEL maintainer="team@appwrite.io"
 
 ENV INTERNAL_RUNTIME_ENTRYPOINT=main.py
@@ -12,8 +14,6 @@ RUN mkdir -p /usr/builds
 WORKDIR /usr/local/src
 
 COPY . .
-
-RUN apk --no-cache add musl-dev linux-headers g++
 
 RUN chmod +x /usr/local/src/start.sh
 RUN chmod +x /usr/local/src/build.sh

--- a/runtimes/python-3.10/Dockerfile
+++ b/runtimes/python-3.10/Dockerfile
@@ -13,6 +13,8 @@ WORKDIR /usr/local/src
 
 COPY . .
 
+RUN apk --no-cache add musl-dev linux-headers g++
+
 RUN chmod +x /usr/local/src/start.sh
 RUN chmod +x /usr/local/src/build.sh
 

--- a/runtimes/python-3.8/Dockerfile
+++ b/runtimes/python-3.8/Dockerfile
@@ -11,6 +11,8 @@ RUN mkdir -p /usr/builds
 
 WORKDIR /usr/local/src
 
+RUN apk --no-cache add musl-dev linux-headers g++
+
 COPY . .
 
 RUN chmod +x /usr/local/src/start.sh

--- a/runtimes/python-3.8/Dockerfile
+++ b/runtimes/python-3.8/Dockerfile
@@ -1,5 +1,7 @@
 FROM python:3.8-alpine3.15
 
+RUN apk --no-cache add musl-dev linux-headers g++
+
 LABEL maintainer="team@appwrite.io"
 
 ENV INTERNAL_RUNTIME_ENTRYPOINT=main.py
@@ -10,8 +12,6 @@ RUN mkdir -p /usr/workspace
 RUN mkdir -p /usr/builds
 
 WORKDIR /usr/local/src
-
-RUN apk --no-cache add musl-dev linux-headers g++
 
 COPY . .
 

--- a/runtimes/python-3.9/Dockerfile
+++ b/runtimes/python-3.9/Dockerfile
@@ -13,6 +13,8 @@ WORKDIR /usr/local/src
 
 COPY . .
 
+RUN apk --no-cache add musl-dev linux-headers g++
+
 RUN chmod +x /usr/local/src/start.sh
 RUN chmod +x /usr/local/src/build.sh
 

--- a/runtimes/python-3.9/Dockerfile
+++ b/runtimes/python-3.9/Dockerfile
@@ -1,5 +1,7 @@
 FROM python:3.9-alpine3.15
 
+RUN apk --no-cache add musl-dev linux-headers g++
+
 LABEL maintainer="team@appwrite.io"
 
 ENV INTERNAL_RUNTIME_ENTRYPOINT=main.py
@@ -12,8 +14,6 @@ RUN mkdir -p /usr/builds
 WORKDIR /usr/local/src
 
 COPY . .
-
-RUN apk --no-cache add musl-dev linux-headers g++
 
 RUN chmod +x /usr/local/src/start.sh
 RUN chmod +x /usr/local/src/build.sh


### PR DESCRIPTION
Pip could not install Numpy on the Alpine image because of missing build dependencies.
Added the needed dependencies to the Dockerfiles of all Python Runtimes.
