### PR TITLE
Rename all 'env'to 'variables'

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,8 +139,8 @@ All requests should also have JSON body with the following structure:
 ```json5
 {
     // Following will be exposed to the function
-    "env": {
-        // Environment variables
+    "variables": {
+        // Function variables
     },
     "payload": "{}",
     "headers": {

--- a/docs/add-runtime.md
+++ b/docs/add-runtime.md
@@ -81,7 +81,7 @@ Initialize a web server that runs on port 3000 and binds to the 0.0.0.0 IP and o
 2. Decode the executor's JSON POST request. This normally looks like so:
 ```json
 {
- "env": {
+ "variables": {
     "USER_KEY":"abcd1234"
  },
  "headers": {
@@ -93,7 +93,7 @@ Initialize a web server that runs on port 3000 and binds to the 0.0.0.0 IP and o
 
 You must create two classes for users to use within their scripts.
 
-A `Request` Class and a `Response` class. The `Request` class must store `env`, `payload` and `headers` and pass them to the user's function. The Request always goes before the response in the user's function parameters.
+A `Request` Class and a `Response` class. The `Request` class must store `variables`, `payload` and `headers` and pass them to the user's function. The Request always goes before the response in the user's function parameters.
 
 The `Response` class must have two functions:
 
@@ -220,13 +220,13 @@ Within the folder you will need to create a function for your runtime that will 
     "isTest": true,
     "message": "Hello Open Runtimes 👋",
     "header": req.headers['x-test-header'],
-    "env": req.env['test-env'],
+    "variables": req.variables['test-variables'],
     "todo": {{body from your todo API http response}},
 ```
 
 ### 4.2 Adding your runtime to Travis
 
-Edit the `.travis.yml` file and add your runtime to the `env` section of it like so:
+Edit the `.travis.yml` file and add your runtime to the `variables` section of it like so:
 
 ```yaml
   # {{Language Name}}

--- a/runtimes/cpp-17/README.md
+++ b/runtimes/cpp-17/README.md
@@ -78,7 +78,7 @@ You can respond with `json()` by providing object:
 static RuntimeResponse *main(const RuntimeRequest& req, RuntimeResponse* res) { 
     Json::Value result; 
     result["message"] = "Hello Open Runtimes 👋";
-    result["env"] = req.env;
+    result["variables"] = req.variables;
     result["headers"] = req.headers;
     return res->json(result) 
 }

--- a/runtimes/cpp-17/example/index.cc
+++ b/runtimes/cpp-17/example/index.cc
@@ -11,7 +11,7 @@ static size_t WriteCallback(void *contents, size_t size, size_t nmemb, void *use
 static RuntimeResponse &main(const RuntimeRequest &req, RuntimeResponse &res)
 {
     std::string headerData = req.headers["x-test-header"];
-    std::string envData = req.env["test-env"];
+    std::string variableData = req.variables["test-variable"];
     std::string id;
 
     Json::CharReaderBuilder builder;
@@ -63,7 +63,7 @@ static RuntimeResponse &main(const RuntimeRequest &req, RuntimeResponse &res)
     response["message"] = "Hello Open Runtimes 👋";
     response["todo"] = todo;
     response["header"] = headerData;
-    response["env"] = envData;
+    response["variable"] = variableData;
 
     return res->json(response);
 }

--- a/runtimes/cpp-17/src/RuntimeRequest.h
+++ b/runtimes/cpp-17/src/RuntimeRequest.h
@@ -10,7 +10,7 @@ namespace runtime
     struct RuntimeRequest
     {
         std::string payload;
-        Json::Value env;
+        Json::Value variables;
         Json::Value headers;
     };
 }
@@ -25,7 +25,7 @@ namespace drogon
         if (json)
         {
             request.payload = (*json)["payload"].asString();
-            request.env = (*json)["env"];
+            request.variables = (*json)["variables"];
             request.headers = (*json)["headers"];
         }
         if (request.payload.empty())

--- a/runtimes/cpp-17/src/Wrapper.h
+++ b/runtimes/cpp-17/src/Wrapper.h
@@ -16,11 +16,11 @@ namespace runtime
         static RuntimeResponse &main(const RuntimeRequest &req, RuntimeResponse &resp)
         {
             std::string payload = req.payload;
-            Json::Value env = req.env;
+            Json::Value variables = req.variables;
             Json::Value headers = req.headers;
             Json::Value json;
             json["payload"] = payload;
-            json["env"] = env;
+            json["variables"] = variables;
             json["headers"] = headers;
             return resp.json(json);
         }

--- a/runtimes/dart-2.15/README.md
+++ b/runtimes/dart-2.15/README.md
@@ -90,7 +90,7 @@ import 'dart:async';
 Future<void> start(final req, final res) async {
   res.json({
     'message': "Hello Open Runtimes 👋",
-    'env': req.env,
+    'variables': req.variables,
     'payload': req.payload,
     'headers': req.headers
   });

--- a/runtimes/dart-2.15/example/lib/main.dart
+++ b/runtimes/dart-2.15/example/lib/main.dart
@@ -6,7 +6,7 @@ import 'package:dio/dio.dart' hide Response;
     'req' variable has:
         'headers' - object with request headers
         'payload' - object with request body data
-        'env' - object with environment variables
+        'variables' - object with function variables
     'res' variable has:
         'send(text, status)' - function to return text response. Status code defaults to 200
         'json(obj, status)' - function to return JSON response. Status code defaults to 200

--- a/runtimes/dart-2.15/function_types.dart
+++ b/runtimes/dart-2.15/function_types.dart
@@ -1,12 +1,12 @@
 import 'dart:convert';
 
 class Request {
-  final Map<String, dynamic> env;
+  final Map<String, dynamic> variables;
   final Map<String, dynamic> headers;
   final String payload;
 
   Request({
-    this.env = const {},
+    this.variables = const {},
     this.headers = const {},
     this.payload = '',
   });

--- a/runtimes/dart-2.15/server.dart
+++ b/runtimes/dart-2.15/server.dart
@@ -26,7 +26,7 @@ void main() async {
       final bodystring = await req.readAsString();
       final body = jsonDecode(bodystring);
       final request = Request(
-        env: body['env'] ?? {},
+        variables: body['variables'] ?? {},
         headers: body['headers'] ?? {},
         payload: body['payload'] ?? '',
       );

--- a/runtimes/dart-2.16/README.md
+++ b/runtimes/dart-2.16/README.md
@@ -90,7 +90,7 @@ import 'dart:async';
 Future<void> start(final req, final res) async {
   res.json({
     'message': "Hello Open Runtimes 👋",
-    'env': req.env,
+    'variables': req.variables,
     'payload': req.payload,
     'headers': req.headers
   });

--- a/runtimes/dart-2.16/example/lib/main.dart
+++ b/runtimes/dart-2.16/example/lib/main.dart
@@ -6,7 +6,7 @@ import 'package:dio/dio.dart' hide Response;
     'req' variable has:
         'headers' - object with request headers
         'payload' - object with request body data
-        'env' - object with environment variables
+        'variables' - object with function variables
     'res' variable has:
         'send(text, status)' - function to return text response. Status code defaults to 200
         'json(obj, status)' - function to return JSON response. Status code defaults to 200

--- a/runtimes/dart-2.16/function_types.dart
+++ b/runtimes/dart-2.16/function_types.dart
@@ -1,12 +1,12 @@
 import 'dart:convert';
 
 class Request {
-  final Map<String, dynamic> env;
+  final Map<String, dynamic> variables;
   final Map<String, dynamic> headers;
   final String payload;
 
   Request({
-    this.env = const {},
+    this.variables = const {},
     this.headers = const {},
     this.payload = '',
   });

--- a/runtimes/dart-2.16/server.dart
+++ b/runtimes/dart-2.16/server.dart
@@ -26,7 +26,7 @@ void main() async {
       final bodystring = await req.readAsString();
       final body = jsonDecode(bodystring);
       final request = Request(
-        env: body['env'] ?? {},
+        variables: body['variables'] ?? {},
         headers: body['headers'] ?? {},
         payload: body['payload'] ?? '',
       );

--- a/runtimes/dart-2.17/README.md
+++ b/runtimes/dart-2.17/README.md
@@ -90,7 +90,7 @@ import 'dart:async';
 Future<void> start(final req, final res) async {
   res.json({
     'message': "Hello Open Runtimes 👋",
-    'env': req.env,
+    'variables': req.variables,
     'payload': req.payload,
     'headers': req.headers
   });

--- a/runtimes/dart-2.17/example/lib/main.dart
+++ b/runtimes/dart-2.17/example/lib/main.dart
@@ -6,7 +6,7 @@ import 'package:dio/dio.dart' hide Response;
     'req' variable has:
         'headers' - object with request headers
         'payload' - object with request body data
-        'env' - object with environment variables
+        'variables' - object with function variables
     'res' variable has:
         'send(text, status)' - function to return text response. Status code defaults to 200
         'json(obj, status)' - function to return JSON response. Status code defaults to 200

--- a/runtimes/dart-2.17/function_types.dart
+++ b/runtimes/dart-2.17/function_types.dart
@@ -1,12 +1,12 @@
 import 'dart:convert';
 
 class Request {
-  final Map<String, dynamic> env;
+  final Map<String, dynamic> variables;
   final Map<String, dynamic> headers;
   final String payload;
 
   Request({
-    this.env = const {},
+    this.variables = const {},
     this.headers = const {},
     this.payload = '',
   });

--- a/runtimes/dart-2.17/server.dart
+++ b/runtimes/dart-2.17/server.dart
@@ -26,7 +26,7 @@ void main() async {
       final bodystring = await req.readAsString();
       final body = jsonDecode(bodystring);
       final request = Request(
-        env: body['env'] ?? {},
+        variables: body['variables'] ?? {},
         headers: body['headers'] ?? {},
         payload: body['payload'] ?? '',
       );

--- a/runtimes/deno-1.21/README.md
+++ b/runtimes/deno-1.21/README.md
@@ -86,7 +86,7 @@ You can respond with `json()` by providing object:
 export default async function(req: any, res: any) {
     res.json({
         'message': 'Hello Open Runtimes 👋',
-        'env': req.env,
+        'variables': req.variables,
         'payload': req.payload,
         'headers': req.headers
     });

--- a/runtimes/deno-1.21/example/mod.ts
+++ b/runtimes/deno-1.21/example/mod.ts
@@ -4,7 +4,7 @@ import axiod from "https://deno.land/x/axiod/mod.ts";
     'req' variable has:
         'headers' - object with request headers
         'payload' - object with request body data
-        'env' - object with environment variables
+        'variables' - object with function variables
     'res' variable has:
         'send(text, status)' - function to return text response. Status code defaults to 200
         'json(obj, status)' - function to return JSON response. Status code defaults to 200

--- a/runtimes/deno-1.21/server.ts
+++ b/runtimes/deno-1.21/server.ts
@@ -16,7 +16,7 @@ app.use(async (ctx) => {
   }
 
   const request = {
-    env: body.env ?? {},
+    variables: body.variables ?? {},
     headers: body.headers ?? {},
     payload: body.payload ?? ''
   };

--- a/runtimes/deno-1.24/README.md
+++ b/runtimes/deno-1.24/README.md
@@ -86,7 +86,7 @@ You can respond with `json()` by providing object:
 export default async function(req: any, res: any) {
     res.json({
         'message': 'Hello Open Runtimes 👋',
-        'env': req.env,
+        'variables': req.variables,
         'payload': req.payload,
         'headers': req.headers
     });

--- a/runtimes/deno-1.24/example/mod.ts
+++ b/runtimes/deno-1.24/example/mod.ts
@@ -4,7 +4,7 @@ import axiod from "https://deno.land/x/axiod/mod.ts";
     'req' variable has:
         'headers' - object with request headers
         'payload' - object with request body data
-        'env' - object with environment variables
+        'variables' - object with function variables
     'res' variable has:
         'send(text, status)' - function to return text response. Status code defaults to 200
         'json(obj, status)' - function to return JSON response. Status code defaults to 200

--- a/runtimes/deno-1.24/server.ts
+++ b/runtimes/deno-1.24/server.ts
@@ -16,7 +16,7 @@ app.use(async (ctx) => {
   }
 
   const request = {
-    env: body.env ?? {},
+    variables: body.variables ?? {},
     headers: body.headers ?? {},
     payload: body.payload ?? ''
   };

--- a/runtimes/dotnet-3.1/README.md
+++ b/runtimes/dotnet-3.1/README.md
@@ -78,7 +78,7 @@ You can respond with `json()` by providing object:
 public async Task<RuntimeResponse> Main(RuntimeRequest req, RuntimeResponse res) => 
     res.Json(new Dictionary<string, object>() {
         { "message" , "Hello Open Runtimes 👋" },
-        { "env", req.Env },
+        { "variables", req.variables },
         { "headers", req.Headers },
         { "payload", req.Payload }
     });

--- a/runtimes/dotnet-3.1/src/RuntimeRequest.cs
+++ b/runtimes/dotnet-3.1/src/RuntimeRequest.cs
@@ -6,7 +6,7 @@ namespace DotNetRuntime
 	{
 		public string Payload { get; set; } = "";
 
-		public Dictionary<string, string> Env { get; set; } =
+		public Dictionary<string, string> Variables { get; set; } =
 			new Dictionary<string, string>();
 
 		public Dictionary<string, string> Headers { get; set; } =

--- a/runtimes/dotnet-6.0/README.md
+++ b/runtimes/dotnet-6.0/README.md
@@ -78,7 +78,7 @@ You can respond with `json()` by providing object:
 public async Task<RuntimeResponse> Main(RuntimeRequest req, RuntimeResponse res) => 
     res.Json(new() {
         { "message" , "Hello Open Runtimes 👋" },
-        { "env", req.Env },
+        { "variables", req.Variables },
         { "headers", req.Headers },
         { "payload", req.Payload }
     });

--- a/runtimes/dotnet-6.0/src/RuntimeRequest.cs
+++ b/runtimes/dotnet-6.0/src/RuntimeRequest.cs
@@ -4,7 +4,7 @@ namespace DotNetRuntime
 	{
 		public string Payload { get; set; } = "";
 
-		public Dictionary<string, string> Env { get; set; } =
+		public Dictionary<string, string> Variables { get; set; } =
 			new Dictionary<string, string>();
 
 		public Dictionary<string, string> Headers { get; set; } =

--- a/runtimes/java-11.0/README.md
+++ b/runtimes/java-11.0/README.md
@@ -81,7 +81,7 @@ import java.util.HashMap;
 public RuntimeResponse main(RuntimeRequest req, RuntimeResponse res) throws Exception {
     Map<String, Object> result = new HashMap<>();
     result.put("message", "Hello Open Runtimes 👋");
-    result.put("env", req.getEnv());
+    result.put("variables", req.getVariables());
     result.put("headers", req.getHeaders());
     result.put("payload", req.getPayload());
     return res.json(result);

--- a/runtimes/java-11.0/src/main/java/io/openruntimes/java/RuntimeRequest.java
+++ b/runtimes/java-11.0/src/main/java/io/openruntimes/java/RuntimeRequest.java
@@ -7,16 +7,16 @@ import java.util.Map;
 public class RuntimeRequest {
     private String payload;
     private Map<String, String> headers;
-    private Map<String, String> env;
+    private Map<String, String> variables;
 
     public RuntimeRequest(
             String payload,
             Map<String, String> headers,
-            Map<String, String> env
+            Map<String, String> variables
     ) {
         this.payload = payload;
         this.headers = headers;
-        this.env = env;
+        this.variables = variables;
     }
 
     public RuntimeRequest(Req request) {
@@ -29,8 +29,8 @@ public class RuntimeRequest {
         if (data.containsKey("headers")) {
             this.headers = (Map<String, String>) data.get("headers");
         }
-        if (data.containsKey("env")) {
-            this.env = (Map<String, String>) data.get("env");
+        if (data.containsKey("variables")) {
+            this.variables = (Map<String, String>) data.get("variables");
         }
     }
 
@@ -38,7 +38,7 @@ public class RuntimeRequest {
     }
 
     public String getPayload() {
-        return payload;
+        return this.payload;
     }
 
     public void setPayload(String payload) {
@@ -46,19 +46,19 @@ public class RuntimeRequest {
     }
 
     public Map<String, String> getHeaders() {
-        return headers;
+        return this.headers;
     }
 
     public void setHeaders(Map<String, String> headers) {
         this.headers = headers;
     }
 
-    public Map<String, String> getEnv() {
-        return env;
+    public Map<String, String> getVariables() {
+        return this.variables;
     }
 
-    public void setEnv(Map<String, String> env) {
-        this.env = env;
+    public void setVariables(Map<String, String> variables) {
+        this.variables = variables;
     }
 }
 

--- a/runtimes/java-17.0/README.md
+++ b/runtimes/java-17.0/README.md
@@ -81,7 +81,7 @@ import java.util.HashMap;
 public RuntimeResponse main(RuntimeRequest req, RuntimeResponse res) throws Exception {
     Map<String, Object> result = new HashMap<>();
     result.put("message", "Hello Open Runtimes 👋");
-    result.put("env", req.getEnv());
+    result.put("variables", req.getVariables());
     result.put("headers", req.getHeaders());
     result.put("payload", req.getPayload());
     return res.json(result);

--- a/runtimes/java-17.0/src/main/java/io/openruntimes/java/RuntimeRequest.java
+++ b/runtimes/java-17.0/src/main/java/io/openruntimes/java/RuntimeRequest.java
@@ -7,16 +7,16 @@ import java.util.Map;
 public class RuntimeRequest {
     private String payload;
     private Map<String, String> headers;
-    private Map<String, String> env;
+    private Map<String, String> variables;
 
     public RuntimeRequest(
             String payload,
             Map<String, String> headers,
-            Map<String, String> env
+            Map<String, String> variables
     ) {
         this.payload = payload;
         this.headers = headers;
-        this.env = env;
+        this.variables = variables;
     }
 
     public RuntimeRequest(Req request) {
@@ -29,8 +29,8 @@ public class RuntimeRequest {
         if (data.containsKey("headers")) {
             this.headers = (Map<String, String>) data.get("headers");
         }
-        if (data.containsKey("env")) {
-            this.env = (Map<String, String>) data.get("env");
+        if (data.containsKey("variables")) {
+            this.variables = (Map<String, String>) data.get("variables");
         }
     }
 
@@ -38,7 +38,7 @@ public class RuntimeRequest {
     }
 
     public String getPayload() {
-        return payload;
+        return this.payload;
     }
 
     public void setPayload(String payload) {
@@ -46,19 +46,19 @@ public class RuntimeRequest {
     }
 
     public Map<String, String> getHeaders() {
-        return headers;
+        return this.headers;
     }
 
     public void setHeaders(Map<String, String> headers) {
         this.headers = headers;
     }
 
-    public Map<String, String> getEnv() {
-        return env;
+    public Map<String, String> getVariables() {
+        return this.variables;
     }
 
-    public void setEnv(Map<String, String> env) {
-        this.env = env;
+    public void setVariables(Map<String, String> variables) {
+        this.variables = variables;
     }
 }
 

--- a/runtimes/java-18.0/README.md
+++ b/runtimes/java-18.0/README.md
@@ -81,7 +81,7 @@ import java.util.HashMap;
 public RuntimeResponse main(RuntimeRequest req, RuntimeResponse res) throws Exception {
     Map<String, Object> result = new HashMap<>();
     result.put("message", "Hello Open Runtimes 👋");
-    result.put("env", req.getEnv());
+    result.put("variables", req.getVariables());
     result.put("headers", req.getHeaders());
     result.put("payload", req.getPayload());
     return res.json(result);

--- a/runtimes/java-18.0/src/main/java/io/openruntimes/java/RuntimeRequest.java
+++ b/runtimes/java-18.0/src/main/java/io/openruntimes/java/RuntimeRequest.java
@@ -7,16 +7,16 @@ import java.util.Map;
 public class RuntimeRequest {
     private String payload;
     private Map<String, String> headers;
-    private Map<String, String> env;
+    private Map<String, String> variables;
 
     public RuntimeRequest(
             String payload,
             Map<String, String> headers,
-            Map<String, String> env
+            Map<String, String> variables
     ) {
         this.payload = payload;
         this.headers = headers;
-        this.env = env;
+        this.variables = variables;
     }
 
     public RuntimeRequest(Req request) {
@@ -29,8 +29,8 @@ public class RuntimeRequest {
         if (data.containsKey("headers")) {
             this.headers = (Map<String, String>) data.get("headers");
         }
-        if (data.containsKey("env")) {
-            this.env = (Map<String, String>) data.get("env");
+        if (data.containsKey("variables")) {
+            this.variables = (Map<String, String>) data.get("variables");
         }
     }
 
@@ -38,7 +38,7 @@ public class RuntimeRequest {
     }
 
     public String getPayload() {
-        return payload;
+        return this.payload;
     }
 
     public void setPayload(String payload) {
@@ -46,19 +46,19 @@ public class RuntimeRequest {
     }
 
     public Map<String, String> getHeaders() {
-        return headers;
+        return this.headers;
     }
 
     public void setHeaders(Map<String, String> headers) {
         this.headers = headers;
     }
 
-    public Map<String, String> getEnv() {
-        return env;
+    public Map<String, String> getVariables() {
+        return this.variables;
     }
 
-    public void setEnv(Map<String, String> env) {
-        this.env = env;
+    public void setVariables(Map<String, String> variables) {
+        this.variables = variables;
     }
 }
 

--- a/runtimes/java-8.0/README.md
+++ b/runtimes/java-8.0/README.md
@@ -81,7 +81,7 @@ import java.util.HashMap;
 public RuntimeResponse main(RuntimeRequest req, RuntimeResponse res) throws Exception {
     Map<String, Object> result = new HashMap<>();
     result.put("message", "Hello Open Runtimes 👋");
-    result.put("env", req.getEnv());
+    result.put("variables", req.getVariables());
     result.put("headers", req.getHeaders());
     result.put("payload", req.getPayload());
     return res.json(result);

--- a/runtimes/java-8.0/src/main/java/io/openruntimes/java/RuntimeRequest.java
+++ b/runtimes/java-8.0/src/main/java/io/openruntimes/java/RuntimeRequest.java
@@ -7,16 +7,16 @@ import java.util.Map;
 public class RuntimeRequest {
     private String payload;
     private Map<String, String> headers;
-    private Map<String, String> env;
+    private Map<String, String> variables;
 
     public RuntimeRequest(
             String payload,
             Map<String, String> headers,
-            Map<String, String> env
+            Map<String, String> variables
     ) {
         this.payload = payload;
         this.headers = headers;
-        this.env = env;
+        this.variables = variables;
     }
 
     public RuntimeRequest(Req request) {
@@ -29,8 +29,8 @@ public class RuntimeRequest {
         if (data.containsKey("headers")) {
             this.headers = (Map<String, String>) data.get("headers");
         }
-        if (data.containsKey("env")) {
-            this.env = (Map<String, String>) data.get("env");
+        if (data.containsKey("variables")) {
+            this.variables = (Map<String, String>) data.get("variables");
         }
     }
 
@@ -38,7 +38,7 @@ public class RuntimeRequest {
     }
 
     public String getPayload() {
-        return payload;
+        return this.payload;
     }
 
     public void setPayload(String payload) {
@@ -46,19 +46,19 @@ public class RuntimeRequest {
     }
 
     public Map<String, String> getHeaders() {
-        return headers;
+        return this.headers;
     }
 
     public void setHeaders(Map<String, String> headers) {
         this.headers = headers;
     }
 
-    public Map<String, String> getEnv() {
-        return env;
+    public Map<String, String> getVariables() {
+        return this.variables;
     }
 
-    public void setEnv(Map<String, String> env) {
-        this.env = env;
+    public void setVariables(Map<String, String> variables) {
+        this.variables = variables;
     }
 }
 

--- a/runtimes/kotlin-1.6/README.md
+++ b/runtimes/kotlin-1.6/README.md
@@ -78,7 +78,7 @@ You can respond with `json()` by providing object:
 @Throws(Exception::class)
 fun main(req: RuntimeRequest, res: RuntimeResponse): RuntimeResponse = res.json(mapOf(
     "message" to "Hello Open Runtimes 👋",
-    "env" to req.env,
+    "variables" to req.variables,
     "headers" to req.headers,
     "payload" to req.payload
 ))

--- a/runtimes/kotlin-1.6/src/main/kotlin/io/openruntimes/kotlin/RuntimeRequest.kt
+++ b/runtimes/kotlin-1.6/src/main/kotlin/io/openruntimes/kotlin/RuntimeRequest.kt
@@ -5,12 +5,12 @@ import io.javalin.http.Context
 class RuntimeRequest(ctx: Context) {
     var payload = ""
     var headers = mutableMapOf<String, String>()
-    var env=  mutableMapOf<String, String>()
+    var variables = mutableMapOf<String, String>()
 
     init {
         val data = ctx.bodyAsClass<Map<String, Any>>()
         payload = data["payload"] as? String ?: ""
         headers = data["headers"] as? MutableMap<String, String> ?: mutableMapOf()
-        env = data["env"] as? MutableMap<String, String> ?: mutableMapOf()
+        variables = data["variables"] as? MutableMap<String, String> ?: mutableMapOf()
     }
 }

--- a/runtimes/node-14.5/README.md
+++ b/runtimes/node-14.5/README.md
@@ -86,7 +86,7 @@ You can respond with `json()` by providing object:
 module.exports = (req, res) => {
     res.json({
         'message': 'Hello Open Runtimes 👋',
-        'env': req.env,
+        'variables': req.variables,
         'payload': req.payload,
         'headers': req.headers
     });

--- a/runtimes/node-14.5/example/index.js
+++ b/runtimes/node-14.5/example/index.js
@@ -4,7 +4,7 @@ const fetch = require("node-fetch");
     'req' variable has:
         'headers' - object with request headers
         'payload' - object with request body data
-        'env' - object with environment variables
+        'variables' - object with function variables
     'res' variable has:
         'send(text, status)' - function to return text response. Status code defaults to 200
         'json(obj, status)' - function to return JSON response. Status code defaults to 200

--- a/runtimes/node-14.5/server.js
+++ b/runtimes/node-14.5/server.js
@@ -12,7 +12,7 @@ const server = micro(async (req, res) => {
     }
 
     const request = {
-        env: body.env ?? {},
+        variables: body.variables ?? {},
         headers: body.headers ?? {},
         payload: body.payload ?? '',
     };

--- a/runtimes/node-16.0/README.md
+++ b/runtimes/node-16.0/README.md
@@ -86,7 +86,7 @@ You can respond with `json()` by providing object:
 module.exports = (req, res) => {
     res.json({
         'message': 'Hello Open Runtimes 👋',
-        'env': req.env,
+        'variables': req.variables,
         'payload': req.payload,
         'headers': req.headers
     });

--- a/runtimes/node-16.0/example/index.js
+++ b/runtimes/node-16.0/example/index.js
@@ -4,7 +4,7 @@ const fetch = require("node-fetch");
     'req' variable has:
         'headers' - object with request headers
         'payload' - object with request body data
-        'env' - object with environment variables
+        'variables' - object with function variables
     'res' variable has:
         'send(text, status)' - function to return text response. Status code defaults to 200
         'json(obj, status)' - function to return JSON response. Status code defaults to 200

--- a/runtimes/node-16.0/server.js
+++ b/runtimes/node-16.0/server.js
@@ -12,7 +12,7 @@ const server = micro(async (req, res) => {
     }
 
     const request = {
-        env: body.env ?? {},
+        variables: body.variables ?? {},
         headers: body.headers ?? {},
         payload: body.payload ?? '',
     };

--- a/runtimes/node-18.0/README.md
+++ b/runtimes/node-18.0/README.md
@@ -86,7 +86,7 @@ You can respond with `json()` by providing object:
 module.exports = (req, res) => {
     res.json({
         'message': 'Hello Open Runtimes 👋',
-        'env': req.env,
+        'variables': req.variables,
         'payload': req.payload,
         'headers': req.headers
     });

--- a/runtimes/node-18.0/example/index.js
+++ b/runtimes/node-18.0/example/index.js
@@ -4,7 +4,7 @@ const fetch = require("node-fetch");
     'req' variable has:
         'headers' - object with request headers
         'payload' - object with request body data
-        'env' - object with environment variables
+        'variables' - object with function variables
     'res' variable has:
         'send(text, status)' - function to return text response. Status code defaults to 200
         'json(obj, status)' - function to return JSON response. Status code defaults to 200

--- a/runtimes/node-18.0/server.js
+++ b/runtimes/node-18.0/server.js
@@ -12,7 +12,7 @@ const server = micro(async (req, res) => {
     }
 
     const request = {
-        env: body.env ?? {},
+        variables: body.variables ?? {},
         headers: body.headers ?? {},
         payload: body.payload ?? '',
     };

--- a/runtimes/php-8.0/README.md
+++ b/runtimes/php-8.0/README.md
@@ -88,7 +88,7 @@ You can respond with `json()` by providing object:
 return function($req, $res) {
     $res->json([
         'message' => 'Hello Open Runtimes 👋',
-        'env' => $req['env'],
+        'variables' => $req['variables'],
         'payload' => $req['payload'],
         'headers' => $req['headers']
     ]);

--- a/runtimes/php-8.0/example/index.php
+++ b/runtimes/php-8.0/example/index.php
@@ -12,7 +12,7 @@ $client = new Client([
   '$req' variable has:
     'headers' - object with request headers
     'payload' - object with request body data
-    'env' - object with environment variables
+    'variables' - object with function variables
   '$res' variable has:
     'send(text, status)' - function to return text response. Status code defaults to 200
     'json(obj, status)' - function to return JSON response. Status code defaults to 200

--- a/runtimes/php-8.0/server.php
+++ b/runtimes/php-8.0/server.php
@@ -67,7 +67,7 @@ $server->on("Request", function($req, $res) use(&$userFunction) {
     }
 
     $request = [
-        'env' => $body['env'] ?? [],
+        'variables' => $body['variables'] ?? [],
         'headers' => $body['headers'] ?? [],
         'payload' => $body['payload'] ?? ''
     ];

--- a/runtimes/php-8.1/README.md
+++ b/runtimes/php-8.1/README.md
@@ -88,7 +88,7 @@ You can respond with `json()` by providing object:
 return function($req, $res) {
     $res->json([
         'message' => 'Hello Open Runtimes 👋',
-        'env' => $req['env'],
+        'variables' => $req['variables'],
         'payload' => $req['payload'],
         'headers' => $req['headers']
     ]);

--- a/runtimes/php-8.1/example/index.php
+++ b/runtimes/php-8.1/example/index.php
@@ -12,7 +12,7 @@ $client = new Client([
   '$req' variable has:
     'headers' - object with request headers
     'payload' - object with request body data
-    'env' - object with environment variables
+    'variables' - object with function variables
   '$res' variable has:
     'send(text, status)' - function to return text response. Status code defaults to 200
     'json(obj, status)' - function to return JSON response. Status code defaults to 200

--- a/runtimes/php-8.1/server.php
+++ b/runtimes/php-8.1/server.php
@@ -66,7 +66,7 @@ $server->on("Request", function($req, $res) use(&$userFunction) {
     }
 
     $request = [
-        'env' => $body['env'] ?? [],
+        'variables' => $body['variables'] ?? [],
         'headers' => $body['headers'] ?? [],
         'payload' => $body['payload'] ?? ''
     ];

--- a/runtimes/python-3.10/README.md
+++ b/runtimes/python-3.10/README.md
@@ -85,7 +85,7 @@ You can respond with `json()` by providing object:
 def main(req, res):
     return res.json({
         'message': 'Hello Open Runtimes 👋',
-        'env': req.env,
+        'variables': req.variables,
         'payload': req.payload,
         'headers': req.headers
     })

--- a/runtimes/python-3.10/example/main.py
+++ b/runtimes/python-3.10/example/main.py
@@ -3,7 +3,7 @@ import requests
 #    'req' variable has:
 #        'headers' - object with request headers
 #        'payload' - object with request body data
-#        'env' - object with environment variables
+#        'variables' - object with function variables
 #    'res' variable has:
 #        'send(text, status)' - function to return text response. Status code defaults to 200
 #        'json(obj, status)' - function to return JSON response. Status code defaults to 200

--- a/runtimes/python-3.10/server.py
+++ b/runtimes/python-3.10/server.py
@@ -29,10 +29,10 @@ class Request:
     def __init__(self, request):
         self.parsedRequest = request.get_json()
 
-        if 'env' in self.parsedRequest:
-            self.env = self.parsedRequest['env']
+        if 'variables' in self.parsedRequest:
+            self.variables = self.parsedRequest['variables']
         else:
-            self.env = {}
+            self.variables = {}
 
         if 'headers' in self.parsedRequest:
             self.headers = self.parsedRequest['headers']

--- a/runtimes/python-3.8/README.md
+++ b/runtimes/python-3.8/README.md
@@ -85,7 +85,7 @@ You can respond with `json()` by providing object:
 def main(req, res):
     return res.json({
         'message': 'Hello Open Runtimes 👋',
-        'env': req.env,
+        'variables': req.variables,
         'payload': req.payload,
         'headers': req.headers
     })

--- a/runtimes/python-3.8/example/main.py
+++ b/runtimes/python-3.8/example/main.py
@@ -3,7 +3,7 @@ import requests
 #    'req' variable has:
 #        'headers' - object with request headers
 #        'payload' - object with request body data
-#        'env' - object with environment variables
+#        'variables' - object with function variables
 #    'res' variable has:
 #        'send(text, status)' - function to return text response. Status code defaults to 200
 #        'json(obj, status)' - function to return JSON response. Status code defaults to 200

--- a/runtimes/python-3.8/server.py
+++ b/runtimes/python-3.8/server.py
@@ -29,10 +29,10 @@ class Request:
     def __init__(self, request):
         self.parsedRequest = request.get_json()
 
-        if 'env' in self.parsedRequest:
-            self.env = self.parsedRequest['env']
+        if 'variables' in self.parsedRequest:
+            self.variables = self.parsedRequest['variables']
         else:
-            self.env = {}
+            self.variables = {}
 
         if 'headers' in self.parsedRequest:
             self.headers = self.parsedRequest['headers']

--- a/runtimes/python-3.9/README.md
+++ b/runtimes/python-3.9/README.md
@@ -85,7 +85,7 @@ You can respond with `json()` by providing object:
 def main(req, res):
     return res.json({
         'message': 'Hello Open Runtimes 👋',
-        'env': req.env,
+        'variables': req.variables,
         'payload': req.payload,
         'headers': req.headers
     })

--- a/runtimes/python-3.9/example/main.py
+++ b/runtimes/python-3.9/example/main.py
@@ -3,7 +3,7 @@ import requests
 #    'req' variable has:
 #        'headers' - object with request headers
 #        'payload' - object with request body data
-#        'env' - object with environment variables
+#        'variables' - object with function variables
 #    'res' variable has:
 #        'send(text, status)' - function to return text response. Status code defaults to 200
 #        'json(obj, status)' - function to return JSON response. Status code defaults to 200

--- a/runtimes/python-3.9/server.py
+++ b/runtimes/python-3.9/server.py
@@ -29,10 +29,10 @@ class Request:
     def __init__(self, request):
         self.parsedRequest = request.get_json()
 
-        if 'env' in self.parsedRequest:
-            self.env = self.parsedRequest['env']
+        if 'variables' in self.parsedRequest:
+            self.variables = self.parsedRequest['variables']
         else:
-            self.env = {}
+            self.variables = {}
 
         if 'headers' in self.parsedRequest:
             self.headers = self.parsedRequest['headers']

--- a/runtimes/ruby-3.0/README.md
+++ b/runtimes/ruby-3.0/README.md
@@ -86,7 +86,7 @@ You can respond with `json()` by providing object:
 def main(req, res)
     return res.json({
         :message => 'Hello Open Runtimes 👋',
-        :env => req.env,
+        :variables => req.variables,
         :payload => req.payload,
         :headers => req.headers,
     })

--- a/runtimes/ruby-3.0/example/index.rb
+++ b/runtimes/ruby-3.0/example/index.rb
@@ -5,7 +5,7 @@ require 'json'
     'req' variable has:
         'headers' - object with request headers
         'payload' - object with request body data
-        'env' - object with environment variables
+        'variables' - object with function variables
     'res' variable has:
         'send(text, status)' - function to return text response. Status code defaults to 200
         'json(obj, status)' - function to return JSON response. Status code defaults to 200

--- a/runtimes/ruby-3.0/server.rb
+++ b/runtimes/ruby-3.0/server.rb
@@ -8,7 +8,7 @@ before do
 end
 
 class RuntimeRequest
-  def initialize(payload = '{}', env = {}, headers = {})
+  def initialize(payload = '{}', variables = {}, headers = {})
     if payload == nil
       payload = ''
     end
@@ -17,12 +17,12 @@ class RuntimeRequest
       headers = {}
     end
 
-    if env == nil
-      env = {}
+    if variables == nil
+      variables = {}
     end
 
     @payload = payload
-    @env = env
+    @variables = variables
     @headers = headers
   end
 
@@ -30,8 +30,8 @@ class RuntimeRequest
     @payload
   end
 
-  def env
-    @env
+  def variables
+    @variables
   end
 
   def headers
@@ -65,7 +65,7 @@ post '/' do
   request.body.rewind
   data = JSON.parse(request.body.read)
 
-  requestData = RuntimeRequest.new(data['payload'], data['env'], data['headers'])
+  requestData = RuntimeRequest.new(data['payload'], data['variables'], data['headers'])
   runtimeResponse = RuntimeResponse.new
 
   begin

--- a/runtimes/ruby-3.1/README.md
+++ b/runtimes/ruby-3.1/README.md
@@ -86,7 +86,7 @@ You can respond with `json()` by providing object:
 def main(req, res)
     return res.json({
         :message => 'Hello Open Runtimes 👋',
-        :env => req.env,
+        :variables => req.variables,
         :payload => req.payload,
         :headers => req.headers,
     })

--- a/runtimes/ruby-3.1/example/index.rb
+++ b/runtimes/ruby-3.1/example/index.rb
@@ -5,7 +5,7 @@ require 'json'
     'req' variable has:
         'headers' - object with request headers
         'payload' - object with request body data
-        'env' - object with environment variables
+        'variables' - object with function variables
     'res' variable has:
         'send(text, status)' - function to return text response. Status code defaults to 200
         'json(obj, status)' - function to return JSON response. Status code defaults to 200

--- a/runtimes/ruby-3.1/server.rb
+++ b/runtimes/ruby-3.1/server.rb
@@ -8,7 +8,7 @@ before do
 end
 
 class RuntimeRequest
-  def initialize(payload = '{}', env = {}, headers = {})
+  def initialize(payload = '{}', variables = {}, headers = {})
     if payload == nil
       payload = ''
     end
@@ -17,12 +17,12 @@ class RuntimeRequest
       headers = {}
     end
 
-    if env == nil
-      env = {}
+    if variables == nil
+      variables = {}
     end
 
     @payload = payload
-    @env = env
+    @variables = variables
     @headers = headers
   end
 
@@ -30,8 +30,8 @@ class RuntimeRequest
     @payload
   end
 
-  def env
-    @env
+  def variables
+    @variables
   end
 
   def headers
@@ -66,7 +66,7 @@ post '/' do
   request.body.rewind
   data = JSON.parse(request.body.read)
 
-  requestData = RuntimeRequest.new(data['payload'], data['env'], data['headers'])
+  requestData = RuntimeRequest.new(data['payload'], data['variables'], data['headers'])
   runtimeResponse = RuntimeResponse.new
 
   begin

--- a/runtimes/swift-5.5/README.md
+++ b/runtimes/swift-5.5/README.md
@@ -78,7 +78,7 @@ You can respond with `json()` by providing object:
 func main(req: RequestValue, res: RequestResponse) -> RequestResponse {
     res.json(data : [
         "message": "Hello Open Runtimes 👋",
-        "env": req.env,
+        "variables": req.variables,
         "payload": req.payload,
         "headers": req.headers
     ])

--- a/runtimes/swift-5.5/Sources/App/routes.swift
+++ b/runtimes/swift-5.5/Sources/App/routes.swift
@@ -2,12 +2,12 @@ import Vapor
 import Foundation
 
 struct RequestValue {
-    var env: [String: String] = [:]
+    var variables: [String: String] = [:]
     var headers: [String: String] = [:]
     var payload: String = ""
 
     enum CodingKeys: String, CodingKey {
-        case env
+        case variables
         case headers
         case payload
     }
@@ -17,8 +17,8 @@ extension RequestValue : Decodable {
     init(from decoder: Decoder) throws {
         let values = try decoder.container(keyedBy: CodingKeys.self)
 
-        if let env = try? values.decodeIfPresent([String: String].self, forKey: .env) {
-            self.env = env
+        if let variables = try? values.decodeIfPresent([String: String].self, forKey: .variables) {
+            self.variables = variables
         }
         if let headers = try? values.decodeIfPresent([String: String].self, forKey: .headers) {
             self.headers = headers

--- a/runtimes/swift-5.5/example/Sources/index.swift
+++ b/runtimes/swift-5.5/example/Sources/index.swift
@@ -12,7 +12,7 @@ import AsyncHTTPClient
     'req' variable has:
         'headers' - object with request headers
         'payload' - object with request body data
-        'env' - object with environment variables
+        'variables' - object with function variables
     'res' variable has:
         'send(text, status)' - function to return text response. Status code defaults to 200
         'json(obj, status)' - function to return JSON response. Status code defaults to 200

--- a/tests/Base.php
+++ b/tests/Base.php
@@ -98,14 +98,14 @@ abstract class Base extends TestCase
         self::assertEquals(false, $response['body']['todo']['completed']);
     }
 
-    public function testRuntimeHeadersAndEnv(): void 
+    public function testRuntimeHeadersAndVariables(): void 
     {
         $response = $this->call([
             'headers' => [
                 'x-test-header' => 'Header secret'
             ],
-            'env' => [
-                'test-env' => 'Environment secret'
+            'variables' => [
+                'test-variable' => 'Variable secret'
             ]
         ]);
 
@@ -114,18 +114,18 @@ abstract class Base extends TestCase
         self::assertEquals(200, $response['code']);
         self::assertEquals(true, $response['body']['isTest']);
         self::assertEquals('Header secret', $response['body']['header']);
-        self::assertEquals('Environment secret', $response['body']['env']);
+        self::assertEquals('Variable secret', $response['body']['variable']);
     }
 
-    public function testRuntimePayloadAndHeadersAndEnv(): void 
+    public function testRuntimePayloadAndHeadersAndVariables(): void 
     {
         $response = $this->call([
             'payload' => '{"id":"2"}',
             'headers' => [
                 'x-test-header' => 'Header secret'
             ],
-            'env' => [
-                'test-env' => 'Environment secret'
+            'variables' => [
+                'test-variable' => 'Variable secret'
             ]
         ]);
 
@@ -139,7 +139,7 @@ abstract class Base extends TestCase
         self::assertEquals('quis ut nam facilis et officia qui', $response['body']['todo']['title']);
         self::assertEquals(false, $response['body']['todo']['completed']);
         self::assertEquals('Header secret', $response['body']['header']);
-        self::assertEquals('Environment secret', $response['body']['env']);
+        self::assertEquals('Variable secret', $response['body']['variable']);
     }
 
     public function testRuntimeGarbageBody(): void

--- a/tests/cpp-17/tests.cc
+++ b/tests/cpp-17/tests.cc
@@ -10,7 +10,7 @@ static size_t WriteCallback(void *contents, size_t size, size_t nmemb, void *use
 
 static RuntimeResponse &main(const RuntimeRequest &req, RuntimeResponse &res) {
     std::string headerData = req.headers["x-test-header"].asString();
-    std::string envData = req.env["test-env"].asString();
+    std::string varData = req.variables["test-variable"].asString();
     std::string id;
 
     Json::CharReaderBuilder builder;
@@ -60,7 +60,7 @@ static RuntimeResponse &main(const RuntimeRequest &req, RuntimeResponse &res) {
     response["message"] = "Hello Open Runtimes 👋";
     response["todo"] = todo;
     response["header"] = headerData;
-    response["env"] = envData;
+    response["variable"] = varData;
 
     std::cout << "log1" << std::endl;
     std::cout << "{hello: world}" << std::endl;

--- a/tests/dart-2.15/lib/tests.dart
+++ b/tests/dart-2.15/lib/tests.dart
@@ -6,7 +6,7 @@ import 'package:dio/dio.dart' hide Response;
     'req' variable has:
         'headers' - object with request headers
         'payload' - object with request body data
-        'env' - object with environment variables
+        'variables' - object with function variables
     'res' variable has:
         'send(text, status)' - function to return text response. Status code defaults to 200
         'json(obj, status)' - function to return JSON response. Status code defaults to 200
@@ -27,7 +27,7 @@ Future<void> start(final req, final res) async {
     'isTest': true,
     'message': "Hello Open Runtimes 👋",
     'header': req.headers['x-test-header'],
-    'env': req.env['test-env'],
+    'variable': req.variables['test-variable'],
     'todo': todo.data,
   });
 }

--- a/tests/dart-2.16/lib/tests.dart
+++ b/tests/dart-2.16/lib/tests.dart
@@ -6,7 +6,7 @@ import 'package:dio/dio.dart' hide Response;
     'req' variable has:
         'headers' - object with request headers
         'payload' - object with request body data
-        'env' - object with environment variables
+        'variables' - object with function variables
     'res' variable has:
         'send(text, status)' - function to return text response. Status code defaults to 200
         'json(obj, status)' - function to return JSON response. Status code defaults to 200
@@ -27,7 +27,7 @@ Future<void> start(final req, final res) async {
     'isTest': true,
     'message': "Hello Open Runtimes 👋",
     'header': req.headers['x-test-header'],
-    'env': req.env['test-env'],
+    'variable': req.variables['test-variable'],
     'todo': todo.data,
   });
 }

--- a/tests/dart-2.17/lib/tests.dart
+++ b/tests/dart-2.17/lib/tests.dart
@@ -6,7 +6,7 @@ import 'package:dio/dio.dart' hide Response;
     'req' variable has:
         'headers' - object with request headers
         'payload' - object with request body data
-        'env' - object with environment variables
+        'variables' - object with function variables
     'res' variable has:
         'send(text, status)' - function to return text response. Status code defaults to 200
         'json(obj, status)' - function to return JSON response. Status code defaults to 200
@@ -27,7 +27,7 @@ Future<void> start(final req, final res) async {
     'isTest': true,
     'message': "Hello Open Runtimes 👋",
     'header': req.headers['x-test-header'],
-    'env': req.env['test-env'],
+    'variable': req.variables['test-variable'],
     'todo': todo.data,
   });
 }

--- a/tests/deno-1.21/tests.ts
+++ b/tests/deno-1.21/tests.ts
@@ -4,7 +4,7 @@ import axiod from "https://deno.land/x/axiod/mod.ts";
     'req' variable has:
         'headers' - object with request headers
         'payload' - object with request body data
-        'env' - object with environment variables
+        'variables' - object with function variables
     'res' variable has:
         'send(text, status)' - function to return text response. Status code defaults to 200
         'json(obj, status)' - function to return JSON response. Status code defaults to 200
@@ -28,7 +28,7 @@ export default async function(req: any, res: any) {
         isTest: true,
         message: 'Hello Open Runtimes 👋',
         header: req.headers['x-test-header'],
-        env: req.env['test-env'],
+        variable: req.variables['test-variable'],
         todo
     });
 }

--- a/tests/deno-1.24/tests.ts
+++ b/tests/deno-1.24/tests.ts
@@ -4,7 +4,7 @@ import axiod from "https://deno.land/x/axiod/mod.ts";
     'req' variable has:
         'headers' - object with request headers
         'payload' - object with request body data
-        'env' - object with environment variables
+        'variables' - object with function variables
     'res' variable has:
         'send(text, status)' - function to return text response. Status code defaults to 200
         'json(obj, status)' - function to return JSON response. Status code defaults to 200
@@ -28,7 +28,7 @@ export default async function(req: any, res: any) {
         isTest: true,
         message: 'Hello Open Runtimes 👋',
         header: req.headers['x-test-header'],
-        env: req.env['test-env'],
+        variable: req.variables['test-variable'],
         todo
     });
 }

--- a/tests/dotnet-3.1/Tests.cs
+++ b/tests/dotnet-3.1/Tests.cs
@@ -19,8 +19,8 @@ public async Task<RuntimeResponse> Main(RuntimeRequest req, RuntimeResponse res)
         ? req.Headers["x-test-header"]
         : "";
 
-    var env = req.Env.ContainsKey("test-env")
-        ? req.Env["test-env"]
+    var variableData = req.Variables.ContainsKey("test-variable")
+        ? req.Variables["test-variable"]
         : "";
 
     var response = await http.GetStringAsync($"https://jsonplaceholder.typicode.com/todos/{id.ToString()}");
@@ -35,7 +35,7 @@ public async Task<RuntimeResponse> Main(RuntimeRequest req, RuntimeResponse res)
         { "isTest", true },
         { "message", "Hello Open Runtimes 👋" },
         { "header", header },
-        { "env", env },
+        { "variable", variableData },
         { "todo", todo }
     });
 }

--- a/tests/dotnet-6.0/Tests.cs
+++ b/tests/dotnet-6.0/Tests.cs
@@ -19,7 +19,7 @@ public async Task<RuntimeResponse> Main(RuntimeRequest req, RuntimeResponse res)
         : "";
 
     var varData = req.Variables.ContainsKey("test-variable")
-        ? req.Vvariables["test-variable"]
+        ? req.Variables["test-variable"]
         : "";
 
     var response = await http.GetStringAsync($"https://jsonplaceholder.typicode.com/todos/{id}");

--- a/tests/dotnet-6.0/Tests.cs
+++ b/tests/dotnet-6.0/Tests.cs
@@ -18,8 +18,8 @@ public async Task<RuntimeResponse> Main(RuntimeRequest req, RuntimeResponse res)
         ? req.Headers["x-test-header"]
         : "";
 
-    var env = req.Env.ContainsKey("test-env")
-        ? req.Env["test-env"]
+    var varData = req.Variables.ContainsKey("test-variable")
+        ? req.Vvariables["test-variable"]
         : "";
 
     var response = await http.GetStringAsync($"https://jsonplaceholder.typicode.com/todos/{id}");
@@ -34,7 +34,7 @@ public async Task<RuntimeResponse> Main(RuntimeRequest req, RuntimeResponse res)
         { "isTest", true },
         { "message", "Hello Open Runtimes 👋" },
         { "header", header },
-        { "env", env },
+        { "variable", varData },
         { "todo", todo }
     });
 }

--- a/tests/java-11.0/Tests.java
+++ b/tests/java-11.0/Tests.java
@@ -21,10 +21,10 @@ public RuntimeResponse main(RuntimeRequest req, RuntimeResponse res) throws Exce
         header = headers.get("x-test-header");
     }
 
-    String env = "";
-    Map<String, String> envs = req.getEnv();
-    if (envs != null && envs.containsKey("test-env")) {
-        env = envs.get("test-env");
+    String varData = "";
+    Map<String, String> variables = req.getVariables();
+    if (variables != null && variables.containsKey("test-variable")) {
+        varData = variables.get("test-variable");
     }
 
     String id = "1";
@@ -52,7 +52,7 @@ public RuntimeResponse main(RuntimeRequest req, RuntimeResponse res) throws Exce
     data.put("isTest", true);
     data.put("message", "Hello Open Runtimes 👋");
     data.put("header", header);
-    data.put("env", env);
+    data.put("variable", varData);
     data.put("todo", todo);
 
     System.out.println("log1");

--- a/tests/java-17.0/Tests.java
+++ b/tests/java-17.0/Tests.java
@@ -21,10 +21,10 @@ public RuntimeResponse main(RuntimeRequest req, RuntimeResponse res) throws Exce
         header = headers.get("x-test-header");
     }
 
-    String env = "";
-    Map<String, String> envs = req.getEnv();
-    if (envs != null && envs.containsKey("test-env")) {
-        env = envs.get("test-env");
+    String varData = "";
+    Map<String, String> variables = req.getVariables();
+    if (variables != null && variables.containsKey("test-variable")) {
+        varData = variables.get("test-variable");
     }
 
     String id = "1";
@@ -52,7 +52,7 @@ public RuntimeResponse main(RuntimeRequest req, RuntimeResponse res) throws Exce
     data.put("isTest", true);
     data.put("message", "Hello Open Runtimes 👋");
     data.put("header", header);
-    data.put("env", env);
+    data.put("variable", varData);
     data.put("todo", todo);
 
 

--- a/tests/java-18.0/Tests.java
+++ b/tests/java-18.0/Tests.java
@@ -21,10 +21,10 @@ public RuntimeResponse main(RuntimeRequest req, RuntimeResponse res) throws Exce
         header = headers.get("x-test-header");
     }
 
-    String env = "";
-    Map<String, String> envs = req.getEnv();
-    if (envs != null && envs.containsKey("test-env")) {
-        env = envs.get("test-env");
+    String varData = "";
+    Map<String, String> variables = req.getVariables();
+    if (variables != null && variables.containsKey("test-variable")) {
+        varData = variables.get("test-variable");
     }
 
     String id = "1";
@@ -52,7 +52,7 @@ public RuntimeResponse main(RuntimeRequest req, RuntimeResponse res) throws Exce
     data.put("isTest", true);
     data.put("message", "Hello Open Runtimes 👋");
     data.put("header", header);
-    data.put("env", env);
+    data.put("variable", varData);
     data.put("todo", todo);
 
 

--- a/tests/java-8.0/Tests.java
+++ b/tests/java-8.0/Tests.java
@@ -21,10 +21,10 @@ public RuntimeResponse main(RuntimeRequest req, RuntimeResponse res) throws Exce
         header = headers.get("x-test-header");
     }
 
-    String env = "";
-    Map<String, String> envs = req.getEnv();
-    if (envs != null && envs.containsKey("test-env")) {
-        env = envs.get("test-env");
+    String varData = "";
+    Map<String, String> variables = req.getVariables();
+    if (variables != null && variables.containsKey("test-variable")) {
+        varData = variables.get("test-variable");
     }
 
     String id = "1";
@@ -52,7 +52,7 @@ public RuntimeResponse main(RuntimeRequest req, RuntimeResponse res) throws Exce
     data.put("isTest", true);
     data.put("message", "Hello Open Runtimes 👋");
     data.put("header", header);
-    data.put("env", env);
+    data.put("variable", varData);
     data.put("todo", todo);
 
     // Print to user function stdout

--- a/tests/kotlin-1.6/Tests.kt
+++ b/tests/kotlin-1.6/Tests.kt
@@ -15,7 +15,7 @@ fun main(req: RuntimeRequest, res: RuntimeResponse): RuntimeResponse {
     )
 
     val header = req.headers["x-test-header"] ?: ""
-    val env = req.env["test-env"] ?: ""
+    val varData = req.variables["test-variable"] ?: ""
     val id = payload["id"] ?: "1"
 
     val url = URL("https://jsonplaceholder.typicode.com/todos/$id")
@@ -46,7 +46,7 @@ fun main(req: RuntimeRequest, res: RuntimeResponse): RuntimeResponse {
         "isTest" to true,
         "message" to "Hello Open Runtimes 👋",
         "header" to header,
-        "env" to env,
+        "variable" to varData,
         "todo" to todo
     ))
 }

--- a/tests/node-14.5/tests.js
+++ b/tests/node-14.5/tests.js
@@ -4,7 +4,7 @@ const fetch = require("node-fetch");
     'req' variable has:
         'headers' - object with request headers
         'payload' - object with request body data
-        'env' - object with environment variables
+        'variables' - object with function variables
     'res' variable has:
         'send(text, status)' - function to return text response. Status code defaults to 200
         'json(obj, status)' - function to return JSON response. Status code defaults to 200
@@ -30,7 +30,7 @@ module.exports = async (req, res) => {
         isTest: true,
         message: 'Hello Open Runtimes 👋',
         header: req.headers['x-test-header'],
-        env: req.env['test-env'],
+        variable: req.variables['test-variable'],
         todo
     });
 }

--- a/tests/node-16.0/tests.js
+++ b/tests/node-16.0/tests.js
@@ -4,7 +4,7 @@ const fetch = require("node-fetch");
     'req' variable has:
         'headers' - object with request headers
         'payload' - object with request body data
-        'env' - object with environment variables
+        'variables' - object with function variables
     'res' variable has:
         'send(text, status)' - function to return text response. Status code defaults to 200
         'json(obj, status)' - function to return JSON response. Status code defaults to 200
@@ -30,7 +30,7 @@ module.exports = async (req, res) => {
         isTest: true,
         message: 'Hello Open Runtimes 👋',
         header: req.headers['x-test-header'],
-        env: req.env['test-env'],
+        variable: req.variables['test-variable'],
         todo
     });
 }

--- a/tests/node-18.0/tests.js
+++ b/tests/node-18.0/tests.js
@@ -4,7 +4,7 @@ const fetch = require("node-fetch");
     'req' variable has:
         'headers' - object with request headers
         'payload' - object with request body data
-        'env' - object with environment variables
+        'variables' - object with function variables
     'res' variable has:
         'send(text, status)' - function to return text response. Status code defaults to 200
         'json(obj, status)' - function to return JSON response. Status code defaults to 200
@@ -29,7 +29,7 @@ module.exports = async (req, res) => {
         isTest: true,
         message: 'Hello Open Runtimes 👋',
         header: req.headers['x-test-header'],
-        env: req.env['test-env'],
+        variable: req.variables['test-variable'],
         todo
     });
 }

--- a/tests/php-8.0/tests.php
+++ b/tests/php-8.0/tests.php
@@ -12,7 +12,7 @@ $client = new Client([
   '$req' variable has:
     'headers' - object with request headers
     'payload' - object with request body data
-    'env' - object with environment variables
+    'variables' - object with function variables
   '$res' variable has:
     'send(text, status)' - function to return text response. Status code defaults to 200
     'json(obj, status)' - function to return JSON response. Status code defaults to 200
@@ -33,7 +33,7 @@ return function($req, $res) use ($client) {
         'isTest' => true,
         'message' => 'Hello Open Runtimes 👋',
         'header' => $req['headers']['x-test-header'],
-        'env' => $req['env']['test-env'],
+        'variable' => $req['variables']['test-variable'],
         'todo' => $todo
     ]);
 };

--- a/tests/php-8.1/tests.php
+++ b/tests/php-8.1/tests.php
@@ -12,7 +12,7 @@ $client = new Client([
   '$req' variable has:
     'headers' - object with request headers
     'payload' - object with request body data
-    'env' - object with environment variables
+    'variables' - object with function variables
   '$res' variable has:
     'send(text, status)' - function to return text response. Status code defaults to 200
     'json(obj, status)' - function to return JSON response. Status code defaults to 200
@@ -33,7 +33,7 @@ return function($req, $res) use ($client) {
         'isTest' => true,
         'message' => 'Hello Open Runtimes 👋',
         'header' => $req['headers']['x-test-header'],
-        'env' => $req['env']['test-env'],
+        'variable' => $req['variables']['test-variable'],
         'todo' => $todo
     ]);
 };

--- a/tests/python-3.10/tests.py
+++ b/tests/python-3.10/tests.py
@@ -4,7 +4,7 @@ import requests
 #    'req' variable has:
 #        'headers' - object with request headers
 #        'payload' - object with request body data
-#        'env' - object with environment variables
+#        'variables' - object with function variables
 #    'res' variable has:
 #        'send(text, status)' - function to return text response. Status code defaults to 200
 #        'json(obj, status)' - function to return JSON response. Status code defaults to 200
@@ -16,7 +16,7 @@ def main(req, res):
     todo_id = payload.get('id', 1)
 
     header_data = req.headers.get('x-test-header', None)
-    env_data = req.env.get('test-env', None)
+    var_data = req.variables.get('test-variable', None)
 
     todo = (requests.get('https://jsonplaceholder.typicode.com/todos/' + str(todo_id))).json()
 
@@ -29,5 +29,5 @@ def main(req, res):
         'message': 'Hello Open Runtimes 👋',
         'todo': todo,
         'header': header_data,
-        'env': env_data
+        'variable': var_data
     })

--- a/tests/python-3.8/tests.py
+++ b/tests/python-3.8/tests.py
@@ -4,7 +4,7 @@ import requests
 #    'req' variable has:
 #        'headers' - object with request headers
 #        'payload' - object with request body data
-#        'env' - object with environment variables
+#        'variables' - object with function variables
 #    'res' variable has:
 #        'send(text, status)' - function to return text response. Status code defaults to 200
 #        'json(obj, status)' - function to return JSON response. Status code defaults to 200
@@ -16,7 +16,7 @@ def main(req, res):
     todo_id = payload.get('id', 1)
 
     header_data = req.headers.get('x-test-header', None)
-    env_data = req.env.get('test-env', None)
+    var_data = req.variables.get('test-variable', None)
 
     todo = (requests.get('https://jsonplaceholder.typicode.com/todos/' + str(todo_id))).json()
 
@@ -29,5 +29,5 @@ def main(req, res):
         'message': 'Hello Open Runtimes 👋',
         'todo': todo,
         'header': header_data,
-        'env': env_data
+        'variable': var_data
     })

--- a/tests/python-3.9/tests.py
+++ b/tests/python-3.9/tests.py
@@ -4,7 +4,7 @@ import requests
 #    'req' variable has:
 #        'headers' - object with request headers
 #        'payload' - object with request body data
-#        'env' - object with environment variables
+#        'variables' - object with function variables
 #    'res' variable has:
 #        'send(text, status)' - function to return text response. Status code defaults to 200
 #        'json(obj, status)' - function to return JSON response. Status code defaults to 200
@@ -16,7 +16,7 @@ def main(req, res):
     todo_id = payload.get('id', 1)
 
     header_data = req.headers.get('x-test-header', None)
-    env_data = req.env.get('test-env', None)
+    var_data = req.variables.get('test-variable', None)
 
     todo = (requests.get('https://jsonplaceholder.typicode.com/todos/' + str(todo_id))).json()
 
@@ -29,5 +29,5 @@ def main(req, res):
         'message': 'Hello Open Runtimes 👋',
         'todo': todo,
         'header': header_data,
-        'env': env_data
+        'variable': var_data
     })

--- a/tests/ruby-3.0/tests.rb
+++ b/tests/ruby-3.0/tests.rb
@@ -4,7 +4,7 @@ require 'json'
 #    'req' variable has:
 #        'headers' - object with request headers
 #        'payload' - object with request body data
-#        'env' - object with environment variables
+#        'variables' - object with function variables
 #    'res' variable has:
 #        'send(text, status)' - function to return text response. Status code defaults to 200
 #        'json(obj, status)' - function to return JSON response. Status code defaults to 200
@@ -25,6 +25,6 @@ def main(req, res)
         'message': 'Hello Open Runtimes 👋',
         'todo': todo,
         'header': req.headers['x-test-header'],
-        'env': req.env['test-env']
+        'variable': req.variables['test-variable']
     })
 end

--- a/tests/ruby-3.1/tests.rb
+++ b/tests/ruby-3.1/tests.rb
@@ -4,7 +4,7 @@ require 'json'
 #    'req' variable has:
 #        'headers' - object with request headers
 #        'payload' - object with request body data
-#        'env' - object with environment variables
+#        'variables' - object with function variables
 #    'res' variable has:
 #        'send(text, status)' - function to return text response. Status code defaults to 200
 #        'json(obj, status)' - function to return JSON response. Status code defaults to 200
@@ -25,6 +25,6 @@ def main(req, res)
         'message': 'Hello Open Runtimes 👋',
         'todo': todo,
         'header': req.headers['x-test-header'],
-        'env': req.env['test-env']
+        'variable': req.variables['test-variable']
     })
 end

--- a/tests/swift-5.5/Sources/Tests.swift
+++ b/tests/swift-5.5/Sources/Tests.swift
@@ -4,7 +4,7 @@ import AsyncHTTPClient
 //    'req' variable has:
 //        'headers' - object with request headers
 //        'payload' - object with request body data
-//        'env' - object with environment variables
+//        'variables' - object with function variables
 //    'res' variable has:
 //        'send(text, status)' - function to return text response. Status code defaults to 200
 //        'json(obj, status)' - function to return JSON response. Status code defaults to 200
@@ -14,7 +14,7 @@ import AsyncHTTPClient
 func main(req: RequestValue, res: RequestResponse) async throws -> RequestResponse {
 
     let headerData = req.headers["x-test-header"]
-    let envData = req.env["test-env"]
+    let varData = req.variables["test-variable"]
 
     var todoId: String = "1"
 
@@ -44,6 +44,6 @@ func main(req: RequestValue, res: RequestResponse) async throws -> RequestRespon
         "message": "Hello Open Runtimes 👋",
         "todo": todo,
         "header": headerData,
-        "env": envData
+        "variable": varData
     ])
 }


### PR DESCRIPTION
⚠️ This change requires OPR v3

Since OPR came into existance (Appwrite 0.13+), variables should be read from request object, NOT from environment variables.

This PR makes that obvious by renaming `req.env` to `req.variables` in all runtimes.

- [x] Tests updated