### PR TITLE
Fix helper comment of dart res.send() and res.json()

### DIFF
--- a/runtimes/dart-2.15/example/lib/main.dart
+++ b/runtimes/dart-2.15/example/lib/main.dart
@@ -8,8 +8,8 @@ import 'package:dio/dio.dart' hide Response;
         'payload' - object with request body data
         'variables' - object with function variables
     'res' variable has:
-        'send(text, status)' - function to return text response. Status code defaults to 200
-        'json(obj, status)' - function to return JSON response. Status code defaults to 200
+        'send(text, status: status)' - function to return text response. Status code defaults to 200
+        'json(obj, status: status)' - function to return JSON response. Status code defaults to 200
     
     If an error is thrown, a response with code 500 will be returned.
 */

--- a/runtimes/dart-2.16/example/lib/main.dart
+++ b/runtimes/dart-2.16/example/lib/main.dart
@@ -8,8 +8,8 @@ import 'package:dio/dio.dart' hide Response;
         'payload' - object with request body data
         'variables' - object with function variables
     'res' variable has:
-        'send(text, status)' - function to return text response. Status code defaults to 200
-        'json(obj, status)' - function to return JSON response. Status code defaults to 200
+        'send(text, status: status)' - function to return text response. Status code defaults to 200
+        'json(obj, status: status)' - function to return JSON response. Status code defaults to 200
     
     If an error is thrown, a response with code 500 will be returned.
 */

--- a/runtimes/dart-2.17/example/lib/main.dart
+++ b/runtimes/dart-2.17/example/lib/main.dart
@@ -8,8 +8,8 @@ import 'package:dio/dio.dart' hide Response;
         'payload' - object with request body data
         'variables' - object with function variables
     'res' variable has:
-        'send(text, status)' - function to return text response. Status code defaults to 200
-        'json(obj, status)' - function to return JSON response. Status code defaults to 200
+        'send(text, status: status)' - function to return text response. Status code defaults to 200
+        'json(obj, status: status)' - function to return JSON response. Status code defaults to 200
     
     If an error is thrown, a response with code 500 will be returned.
 */

--- a/tests/dart-2.15/lib/tests.dart
+++ b/tests/dart-2.15/lib/tests.dart
@@ -8,8 +8,8 @@ import 'package:dio/dio.dart' hide Response;
         'payload' - object with request body data
         'variables' - object with function variables
     'res' variable has:
-        'send(text, status)' - function to return text response. Status code defaults to 200
-        'json(obj, status)' - function to return JSON response. Status code defaults to 200
+        'send(text, status: status)' - function to return text response. Status code defaults to 200
+        'json(obj, status: status)' - function to return JSON response. Status code defaults to 200
     
     If an error is thrown, a response with code 500 will be returned.
 */

--- a/tests/dart-2.16/lib/tests.dart
+++ b/tests/dart-2.16/lib/tests.dart
@@ -8,8 +8,8 @@ import 'package:dio/dio.dart' hide Response;
         'payload' - object with request body data
         'variables' - object with function variables
     'res' variable has:
-        'send(text, status)' - function to return text response. Status code defaults to 200
-        'json(obj, status)' - function to return JSON response. Status code defaults to 200
+        'send(text, status: status)' - function to return text response. Status code defaults to 200
+        'json(obj, status: status)' - function to return JSON response. Status code defaults to 200
     
     If an error is thrown, a response with code 500 will be returned.
 */

--- a/tests/dart-2.17/lib/tests.dart
+++ b/tests/dart-2.17/lib/tests.dart
@@ -8,8 +8,8 @@ import 'package:dio/dio.dart' hide Response;
         'payload' - object with request body data
         'variables' - object with function variables
     'res' variable has:
-        'send(text, status)' - function to return text response. Status code defaults to 200
-        'json(obj, status)' - function to return JSON response. Status code defaults to 200
+        'send(text, status: status)' - function to return text response. Status code defaults to 200
+        'json(obj, status: status)' - function to return JSON response. Status code defaults to 200
     
     If an error is thrown, a response with code 500 will be returned.
 */


### PR DESCRIPTION
## What does this PR do?

Because `status` is optional, the correct syntax for how to pass the status is like this:

```dart
res.json({"attr": "value"}, status: 200);
```

This change updates the comment to help make that clear, especially since there is no type on the res parameter.

## Test Plan

None

## Related PRs and Issues

* 

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes