### PR TITLE
Feat: Native ES modules support for Node runtimes

### DIFF
--- a/runtimes/node-14.5/package.json
+++ b/runtimes/node-14.5/package.json
@@ -2,6 +2,7 @@
   "name": "open-runtimes-node",
   "version": "1.0.0",
   "description": "",
+  "type": "module",
   "main": "server.js",
   "scripts": {
     "start": "pm2 start server.js --no-daemon",

--- a/runtimes/node-14.5/server.js
+++ b/runtimes/node-14.5/server.js
@@ -1,6 +1,8 @@
-const path = require("path");
-const micro = require("micro");
-const { json, send } = require("micro");
+import micro from 'micro';
+
+// Node 14.5 has no support for destructuring in imports,
+// results in a SyntaxError, so we're doing it here.
+const { send, json } = micro;
 
 const USER_CODE_PATH = '/usr/code-start';
 
@@ -22,8 +24,8 @@ const server = micro(async (req, res) => {
     console.stdinfo = console.info.bind(console);
     console.stddebug = console.debug.bind(console);
     console.stdwarn = console.warn.bind(console);
-    logs = [];
-    errors = [];
+    let logs = []
+    let errors = [];
     console.log = console.info = console.debug = function(){
         var args = [];
         Array.from(arguments).forEach(arg => {
@@ -52,7 +54,7 @@ const server = micro(async (req, res) => {
         json: (json, status = 200) => send(res, status, {response: json, stdout: logs.join('\n'), stderr: errors.join('\n')}),
     };
     try {
-        let userFunction = require(USER_CODE_PATH + '/' + process.env.INTERNAL_RUNTIME_ENTRYPOINT);
+        const userFunction = (await import(USER_CODE_PATH + '/' + process.env.INTERNAL_RUNTIME_ENTRYPOINT)).default;
 
         if (!(userFunction || userFunction.constructor || userFunction.call || userFunction.apply)) {
             throw new Error("User function is not valid.")

--- a/runtimes/node-14.5/server.js
+++ b/runtimes/node-14.5/server.js
@@ -70,7 +70,7 @@ const server = micro(async (req, res) => {
             await userFunction(request, response);
         }
     } catch (e) {
-        send(res, 500, {stdout: logs.join('\n'), stderr: errors.join('\n') + "\n" + e.code === 'MODULE_NOT_FOUND' ? "Code file not found." : e.stack || e});
+        send(res, 500, {stdout: logs.join('\n'), stderr: errors.join('\n') + "\n" + e.code === 'ERR_MODULE_NOT_FOUND' ? "Code file not found." : e.stack || e});
     }
     logs = [];
     errors = [];

--- a/runtimes/node-16.0/package.json
+++ b/runtimes/node-16.0/package.json
@@ -2,6 +2,7 @@
   "name": "open-runtimes-node",
   "version": "1.0.0",
   "description": "",
+  "type": "module",
   "main": "server.js",
   "scripts": {
     "start": "pm2 start server.js --no-daemon",

--- a/runtimes/node-16.0/server.js
+++ b/runtimes/node-16.0/server.js
@@ -66,7 +66,7 @@ const server = micro(async (req, res) => {
             await userFunction(request, response);
         }
     } catch (e) {
-        send(res, 500, {stdout: logs.join('\n'), stderr: errors.join('\n') + "\n" + e.code === 'MODULE_NOT_FOUND' ? "Code file not found." : e.stack || e});
+        send(res, 500, {stdout: logs.join('\n'), stderr: errors.join('\n') + "\n" + e.code === 'ERR_MODULE_NOT_FOUND' ? "Code file not found." : e.stack || e});
     }
     logs = [];
     errors = [];

--- a/runtimes/node-16.0/server.js
+++ b/runtimes/node-16.0/server.js
@@ -1,6 +1,4 @@
-const path = require("path");
-const micro = require("micro");
-const { json, send } = require("micro");
+import micro, { json, send } from 'micro';
 
 const USER_CODE_PATH = '/usr/code-start';
 
@@ -22,8 +20,8 @@ const server = micro(async (req, res) => {
     console.stdinfo = console.info.bind(console);
     console.stddebug = console.debug.bind(console);
     console.stdwarn = console.warn.bind(console);
-    logs = [];
-    errors = [];
+    let logs = []
+    let errors = [];
     console.log = console.info = console.debug = function(){
         var args = [];
         Array.from(arguments).forEach(arg => {
@@ -52,7 +50,7 @@ const server = micro(async (req, res) => {
         json: (json, status = 200) => send(res, status, {response: json, stdout: logs.join('\n'), stderr: errors.join('\n')}),
     };
     try {
-        let userFunction = require(USER_CODE_PATH + '/' + process.env.INTERNAL_RUNTIME_ENTRYPOINT);
+        const userFunction = (await import(USER_CODE_PATH + '/' + process.env.INTERNAL_RUNTIME_ENTRYPOINT)).default;
 
         if (!(userFunction || userFunction.constructor || userFunction.call || userFunction.apply)) {
             throw new Error("User function is not valid.")

--- a/runtimes/node-18.0/package.json
+++ b/runtimes/node-18.0/package.json
@@ -2,6 +2,7 @@
   "name": "open-runtimes-node",
   "version": "1.0.0",
   "description": "",
+  "type": "module",
   "main": "server.js",
   "scripts": {
     "start": "pm2 start server.js --no-daemon",

--- a/runtimes/node-18.0/server.js
+++ b/runtimes/node-18.0/server.js
@@ -66,7 +66,7 @@ const server = micro(async (req, res) => {
             await userFunction(request, response);
         }
     } catch (e) {
-        send(res, 500, {stdout: logs.join('\n'), stderr: errors.join('\n') + "\n" + e.code === 'MODULE_NOT_FOUND' ? "Code file not found." : e.stack || e});
+        send(res, 500, {stdout: logs.join('\n'), stderr: errors.join('\n') + "\n" + e.code === 'ERR_MODULE_NOT_FOUND' ? "Code file not found." : e.stack || e});
     }
     logs = [];
     errors = [];

--- a/runtimes/node-18.0/server.js
+++ b/runtimes/node-18.0/server.js
@@ -1,6 +1,4 @@
-const path = require("path");
-const micro = require("micro");
-const { json, send } = require("micro");
+import micro, { json, send } from 'micro';
 
 const USER_CODE_PATH = '/usr/code-start';
 
@@ -22,8 +20,8 @@ const server = micro(async (req, res) => {
     console.stdinfo = console.info.bind(console);
     console.stddebug = console.debug.bind(console);
     console.stdwarn = console.warn.bind(console);
-    logs = [];
-    errors = [];
+    let logs = []
+    let errors = [];
     console.log = console.info = console.debug = function(){
         var args = [];
         Array.from(arguments).forEach(arg => {
@@ -52,7 +50,7 @@ const server = micro(async (req, res) => {
         json: (json, status = 200) => send(res, status, {response: json, stdout: logs.join('\n'), stderr: errors.join('\n')}),
     };
     try {
-        let userFunction = require(USER_CODE_PATH + '/' + process.env.INTERNAL_RUNTIME_ENTRYPOINT);
+        const userFunction = (await import(USER_CODE_PATH + '/' + process.env.INTERNAL_RUNTIME_ENTRYPOINT)).default;
 
         if (!(userFunction || userFunction.constructor || userFunction.call || userFunction.apply)) {
             throw new Error("User function is not valid.")


### PR DESCRIPTION
This PR builds on https://github.com/open-runtimes/open-runtimes/pull/67 by adding support for running Nodes ES modules, instead of running compiled ES modules from TypeScript.

I am adding the image from the related issue as a reference as well as it running in a GitHub codespace.

<details><summary>Issue Image</summary>


![](https://user-images.githubusercontent.com/2221746/193495414-94ccb24a-e31d-4085-84c8-b03a1b14e8e8.png)

</details>

<details><summary>Codespace Image</summary>

![](https://user-images.githubusercontent.com/2221746/193591006-3955df59-1f37-4335-8f17-d1e9314985d6.png)

</details>

Closes #94 