### PR TITLE
Feat: Add basic support for Kubernetes

### DIFF
--- a/runtimes/cpp-17/deployment.yaml
+++ b/runtimes/cpp-17/deployment.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: open-runtimes-cpp-17
+  labels:
+    app.kubernetes.io/name: open-runtimes-cpp-17
+    app.kubernetes.io/component: backend
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: open-runtimes-cpp-17
+      app.kubernetes.io/component: backend
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: open-runtimes-cpp-17
+        app.kubernetes.io/component: backend
+    spec:
+      containers:
+        - name: open-runtimes-cpp-17
+          image: open-runtimes-cpp:17
+          env:
+            - name: INTERNAL_RUNTIME_KEY
+              value: "secret-key"
+            - name: INTERNAL_RUNTIME_ENTRYPOINT
+              value: "index.cc"
+          command: ["/bin/sh"]
+          args: ["-c", "sh /usr/local/src/build.sh && cp /usr/code/code.tar.gz /tmp/code.tar.gz && sh /usr/local/src/start.sh"]
+          volumeMounts:
+            - mountPath: /usr/code
+              name: code
+          ports:
+            - containerPort: 3000
+      volumes:
+        - name: code
+          hostPath:
+            path: /example

--- a/runtimes/cpp-17/service.yaml
+++ b/runtimes/cpp-17/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: open-runtimes-cpp-17
+  labels:
+    app.kubernetes.io/name: open-runtimes-cpp-17
+    app.kubernetes.io/component: backend
+spec:
+  ports:
+    - port: 3000
+      targetPort: 3000
+  selector:
+    app.kubernetes.io/name: open-runtimes-cpp-17
+    app.kubernetes.io/component: backend

--- a/runtimes/dart-2.12/deployment.yaml
+++ b/runtimes/dart-2.12/deployment.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: open-runtimes-dart-2.12
+  labels:
+    app.kubernetes.io/name: open-runtimes-dart-2.12
+    app.kubernetes.io/component: backend
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: open-runtimes-dart-2.12
+      app.kubernetes.io/component: backend
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: open-runtimes-dart-2.12
+        app.kubernetes.io/component: backend
+    spec:
+      containers:
+        - name: open-runtimes-dart-2.12
+          image: open-runtimes-dart:2.12
+          env:
+            - name: INTERNAL_RUNTIME_KEY
+              value: "secret-key"
+            - name: INTERNAL_RUNTIME_ENTRYPOINT
+              value: "lib/main.dart"
+          command: ["/bin/sh"]
+          args: ["-c", "sh /usr/local/src/build.sh && cp /usr/code/code.tar.gz /tmp/code.tar.gz && sh /usr/local/src/start.sh"]
+          volumeMounts:
+            - mountPath: /usr/code
+              name: code
+          ports:
+            - containerPort: 3000
+      volumes:
+        - name: code
+          hostPath:
+            path: /example

--- a/runtimes/dart-2.12/service.yaml
+++ b/runtimes/dart-2.12/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: open-runtimes-dart-2.12
+  labels:
+    app.kubernetes.io/name: open-runtimes-dart-2.12
+    app.kubernetes.io/component: backend
+spec:
+  ports:
+    - port: 3000
+      targetPort: 3000
+  selector:
+    app.kubernetes.io/name: open-runtimes-dart-2.12
+    app.kubernetes.io/component: backend

--- a/runtimes/dart-2.13/deployment.yaml
+++ b/runtimes/dart-2.13/deployment.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: open-runtimes-dart-2.13
+  labels:
+    app.kubernetes.io/name: open-runtimes-dart-2.13
+    app.kubernetes.io/component: backend
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: open-runtimes-dart-2.13
+      app.kubernetes.io/component: backend
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: open-runtimes-dart-2.13
+        app.kubernetes.io/component: backend
+    spec:
+      containers:
+        - name: open-runtimes-dart-2.13
+          image: open-runtimes-dart:2.13
+          env:
+            - name: INTERNAL_RUNTIME_KEY
+              value: "secret-key"
+            - name: INTERNAL_RUNTIME_ENTRYPOINT
+              value: "lib/main.dart"
+          command: ["/bin/sh"]
+          args: ["-c", "sh /usr/local/src/build.sh && cp /usr/code/code.tar.gz /tmp/code.tar.gz && sh /usr/local/src/start.sh"]
+          volumeMounts:
+            - mountPath: /usr/code
+              name: code
+          ports:
+            - containerPort: 3000
+      volumes:
+        - name: code
+          hostPath:
+            path: /example

--- a/runtimes/dart-2.13/service.yaml
+++ b/runtimes/dart-2.13/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: open-runtimes-dart-2.13
+  labels:
+    app.kubernetes.io/name: open-runtimes-dart-2.13
+    app.kubernetes.io/component: backend
+spec:
+  ports:
+    - port: 3000
+      targetPort: 3000
+  selector:
+    app.kubernetes.io/name: open-runtimes-dart-2.13
+    app.kubernetes.io/component: backend

--- a/runtimes/dart-2.14/deployment.yaml
+++ b/runtimes/dart-2.14/deployment.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: open-runtimes-dart-2.14
+  labels:
+    app.kubernetes.io/name: open-runtimes-dart-2.14
+    app.kubernetes.io/component: backend
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: open-runtimes-dart-2.14
+      app.kubernetes.io/component: backend
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: open-runtimes-dart-2.14
+        app.kubernetes.io/component: backend
+    spec:
+      containers:
+        - name: open-runtimes-dart-2.14
+          image: open-runtimes-dart:2.14
+          env:
+            - name: INTERNAL_RUNTIME_KEY
+              value: "secret-key"
+            - name: INTERNAL_RUNTIME_ENTRYPOINT
+              value: "lib/main.dart"
+          command: ["/bin/sh"]
+          args: ["-c", "sh /usr/local/src/build.sh && cp /usr/code/code.tar.gz /tmp/code.tar.gz && sh /usr/local/src/start.sh"]
+          volumeMounts:
+            - mountPath: /usr/code
+              name: code
+          ports:
+            - containerPort: 3000
+      volumes:
+        - name: code
+          hostPath:
+            path: /example

--- a/runtimes/dart-2.14/service.yaml
+++ b/runtimes/dart-2.14/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: open-runtimes-dart-2.14
+  labels:
+    app.kubernetes.io/name: open-runtimes-dart-2.14
+    app.kubernetes.io/component: backend
+spec:
+  ports:
+    - port: 3000
+      targetPort: 3000
+  selector:
+    app.kubernetes.io/name: open-runtimes-dart-2.14
+    app.kubernetes.io/component: backend

--- a/runtimes/dart-2.15/deployment.yaml
+++ b/runtimes/dart-2.15/deployment.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: open-runtimes-dart-2.15
+  labels:
+    app.kubernetes.io/name: open-runtimes-dart-2.15
+    app.kubernetes.io/component: backend
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: open-runtimes-dart-2.15
+      app.kubernetes.io/component: backend
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: open-runtimes-dart-2.15
+        app.kubernetes.io/component: backend
+    spec:
+      containers:
+        - name: open-runtimes-dart-2.15
+          image: open-runtimes-dart:2.15
+          env:
+            - name: INTERNAL_RUNTIME_KEY
+              value: "secret-key"
+            - name: INTERNAL_RUNTIME_ENTRYPOINT
+              value: "lib/main.dart"
+          command: ["/bin/sh"]
+          args: ["-c", "sh /usr/local/src/build.sh && cp /usr/code/code.tar.gz /tmp/code.tar.gz && sh /usr/local/src/start.sh"]
+          volumeMounts:
+            - mountPath: /usr/code
+              name: code
+          ports:
+            - containerPort: 3000
+      volumes:
+        - name: code
+          hostPath:
+            path: /example

--- a/runtimes/dart-2.15/service.yaml
+++ b/runtimes/dart-2.15/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: open-runtimes-dart-2.15
+  labels:
+    app.kubernetes.io/name: open-runtimes-dart-2.15
+    app.kubernetes.io/component: backend
+spec:
+  ports:
+    - port: 3000
+      targetPort: 3000
+  selector:
+    app.kubernetes.io/name: open-runtimes-dart-2.15
+    app.kubernetes.io/component: backend

--- a/runtimes/dart-2.16/deployment.yaml
+++ b/runtimes/dart-2.16/deployment.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: open-runtimes-dart-2.16
+  labels:
+    app.kubernetes.io/name: open-runtimes-dart-2.16
+    app.kubernetes.io/component: backend
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: open-runtimes-dart-2.16
+      app.kubernetes.io/component: backend
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: open-runtimes-dart-2.16
+        app.kubernetes.io/component: backend
+    spec:
+      containers:
+        - name: open-runtimes-dart-2.16
+          image: open-runtimes-dart:2.16
+          env:
+            - name: INTERNAL_RUNTIME_KEY
+              value: "secret-key"
+            - name: INTERNAL_RUNTIME_ENTRYPOINT
+              value: "lib/main.dart"
+          command: ["/bin/sh"]
+          args: ["-c", "sh /usr/local/src/build.sh && cp /usr/code/code.tar.gz /tmp/code.tar.gz && sh /usr/local/src/start.sh"]
+          volumeMounts:
+            - mountPath: /usr/code
+              name: code
+          ports:
+            - containerPort: 3000
+      volumes:
+        - name: code
+          hostPath:
+            path: /example

--- a/runtimes/dart-2.16/service.yaml
+++ b/runtimes/dart-2.16/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: open-runtimes-dart-2.16
+  labels:
+    app.kubernetes.io/name: open-runtimes-dart-2.16
+    app.kubernetes.io/component: backend
+spec:
+  ports:
+    - port: 3000
+      targetPort: 3000
+  selector:
+    app.kubernetes.io/name: open-runtimes-dart-2.16
+    app.kubernetes.io/component: backend

--- a/runtimes/dart-2.17/deployment.yaml
+++ b/runtimes/dart-2.17/deployment.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: open-runtimes-dart-2.17
+  labels:
+    app.kubernetes.io/name: open-runtimes-dart-2.17
+    app.kubernetes.io/component: backend
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: open-runtimes-dart-2.17
+      app.kubernetes.io/component: backend
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: open-runtimes-dart-2.17
+        app.kubernetes.io/component: backend
+    spec:
+      containers:
+        - name: open-runtimes-dart-2.17
+          image: open-runtimes-dart:2.17
+          env:
+            - name: INTERNAL_RUNTIME_KEY
+              value: "secret-key"
+            - name: INTERNAL_RUNTIME_ENTRYPOINT
+              value: "lib/main.dart"
+          command: ["/bin/sh"]
+          args: ["-c", "sh /usr/local/src/build.sh && cp /usr/code/code.tar.gz /tmp/code.tar.gz && sh /usr/local/src/start.sh"]
+          volumeMounts:
+            - mountPath: /usr/code
+              name: code
+          ports:
+            - containerPort: 3000
+      volumes:
+        - name: code
+          hostPath:
+            path: /example

--- a/runtimes/dart-2.17/service.yaml
+++ b/runtimes/dart-2.17/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: open-runtimes-dart-2.17
+  labels:
+    app.kubernetes.io/name: open-runtimes-dart-2.17
+    app.kubernetes.io/component: backend
+spec:
+  ports:
+    - port: 3000
+      targetPort: 3000
+  selector:
+    app.kubernetes.io/name: open-runtimes-dart-2.17
+    app.kubernetes.io/component: backend

--- a/runtimes/deno-1.12/deployment.yaml
+++ b/runtimes/deno-1.12/deployment.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: open-runtimes-deno-1.12
+  labels:
+    app.kubernetes.io/name: open-runtimes-deno-1.12
+    app.kubernetes.io/component: backend
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: open-runtimes-deno-1.12
+      app.kubernetes.io/component: backend
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: open-runtimes-deno-1.12
+        app.kubernetes.io/component: backend
+    spec:
+      containers:
+        - name: open-runtimes-deno-1.12
+          image: open-runtimes-deno:1.12
+          env:
+            - name: INTERNAL_RUNTIME_KEY
+              value: "secret-key"
+            - name: INTERNAL_RUNTIME_ENTRYPOINT
+              value: "mod.ts"
+          command: ["/bin/sh"]
+          args: ["-c", "sh /usr/local/src/build.sh && cp /usr/code/code.tar.gz /tmp/code.tar.gz && sh /usr/local/src/start.sh"]
+          volumeMounts:
+            - mountPath: /usr/code
+              name: code
+          ports:
+            - containerPort: 3000
+      volumes:
+        - name: code
+          hostPath:
+            path: /example

--- a/runtimes/deno-1.12/service.yaml
+++ b/runtimes/deno-1.12/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: open-runtimes-deno-1.12
+  labels:
+    app.kubernetes.io/name: open-runtimes-deno-1.12
+    app.kubernetes.io/component: backend
+spec:
+  ports:
+    - port: 3000
+      targetPort: 3000
+  selector:
+    app.kubernetes.io/name: open-runtimes-deno-1.12
+    app.kubernetes.io/component: backend

--- a/runtimes/deno-1.13/deployment.yaml
+++ b/runtimes/deno-1.13/deployment.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: open-runtimes-deno-1.13
+  labels:
+    app.kubernetes.io/name: open-runtimes-deno-1.13
+    app.kubernetes.io/component: backend
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: open-runtimes-deno-1.13
+      app.kubernetes.io/component: backend
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: open-runtimes-deno-1.13
+        app.kubernetes.io/component: backend
+    spec:
+      containers:
+        - name: open-runtimes-deno-1.13
+          image: open-runtimes-deno:1.13
+          env:
+            - name: INTERNAL_RUNTIME_KEY
+              value: "secret-key"
+            - name: INTERNAL_RUNTIME_ENTRYPOINT
+              value: "mod.ts"
+          command: ["/bin/sh"]
+          args: ["-c", "sh /usr/local/src/build.sh && cp /usr/code/code.tar.gz /tmp/code.tar.gz && sh /usr/local/src/start.sh"]
+          volumeMounts:
+            - mountPath: /usr/code
+              name: code
+          ports:
+            - containerPort: 3000
+      volumes:
+        - name: code
+          hostPath:
+            path: /example

--- a/runtimes/deno-1.13/service.yaml
+++ b/runtimes/deno-1.13/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: open-runtimes-deno-1.13
+  labels:
+    app.kubernetes.io/name: open-runtimes-deno-1.13
+    app.kubernetes.io/component: backend
+spec:
+  ports:
+    - port: 3000
+      targetPort: 3000
+  selector:
+    app.kubernetes.io/name: open-runtimes-deno-1.13
+    app.kubernetes.io/component: backend

--- a/runtimes/deno-1.14/deployment.yaml
+++ b/runtimes/deno-1.14/deployment.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: open-runtimes-deno-1.14
+  labels:
+    app.kubernetes.io/name: open-runtimes-deno-1.14
+    app.kubernetes.io/component: backend
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: open-runtimes-deno-1.14
+      app.kubernetes.io/component: backend
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: open-runtimes-deno-1.14
+        app.kubernetes.io/component: backend
+    spec:
+      containers:
+        - name: open-runtimes-deno-1.14
+          image: open-runtimes-deno:1.14
+          env:
+            - name: INTERNAL_RUNTIME_KEY
+              value: "secret-key"
+            - name: INTERNAL_RUNTIME_ENTRYPOINT
+              value: "mod.ts"
+          command: ["/bin/sh"]
+          args: ["-c", "sh /usr/local/src/build.sh && cp /usr/code/code.tar.gz /tmp/code.tar.gz && sh /usr/local/src/start.sh"]
+          volumeMounts:
+            - mountPath: /usr/code
+              name: code
+          ports:
+            - containerPort: 3000
+      volumes:
+        - name: code
+          hostPath:
+            path: /example

--- a/runtimes/deno-1.14/service.yaml
+++ b/runtimes/deno-1.14/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: open-runtimes-deno-1.14
+  labels:
+    app.kubernetes.io/name: open-runtimes-deno-1.14
+    app.kubernetes.io/component: backend
+spec:
+  ports:
+    - port: 3000
+      targetPort: 3000
+  selector:
+    app.kubernetes.io/name: open-runtimes-deno-1.14
+    app.kubernetes.io/component: backend

--- a/runtimes/deno-1.21/deployment.yaml
+++ b/runtimes/deno-1.21/deployment.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: open-runtimes-deno-1.21
+  labels:
+    app.kubernetes.io/name: open-runtimes-deno-1.21
+    app.kubernetes.io/component: backend
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: open-runtimes-deno-1.21
+      app.kubernetes.io/component: backend
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: open-runtimes-deno-1.21
+        app.kubernetes.io/component: backend
+    spec:
+      containers:
+        - name: open-runtimes-deno-1.21
+          image: open-runtimes-deno:1.21
+          env:
+            - name: INTERNAL_RUNTIME_KEY
+              value: "secret-key"
+            - name: INTERNAL_RUNTIME_ENTRYPOINT
+              value: "mod.ts"
+          command: ["/bin/sh"]
+          args: ["-c", "sh /usr/local/src/build.sh && cp /usr/code/code.tar.gz /tmp/code.tar.gz && sh /usr/local/src/start.sh"]
+          volumeMounts:
+            - mountPath: /usr/code
+              name: code
+          ports:
+            - containerPort: 3000
+      volumes:
+        - name: code
+          hostPath:
+            path: /example

--- a/runtimes/deno-1.21/service.yaml
+++ b/runtimes/deno-1.21/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: open-runtimes-deno-1.21
+  labels:
+    app.kubernetes.io/name: open-runtimes-deno-1.21
+    app.kubernetes.io/component: backend
+spec:
+  ports:
+    - port: 3000
+      targetPort: 3000
+  selector:
+    app.kubernetes.io/name: open-runtimes-deno-1.21
+    app.kubernetes.io/component: backend

--- a/runtimes/dotnet-3.1/deployment.yaml
+++ b/runtimes/dotnet-3.1/deployment.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: open-runtimes-dotnet-3.1
+  labels:
+    app.kubernetes.io/name: open-runtimes-dotnet-3.1
+    app.kubernetes.io/component: backend
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: open-runtimes-dotnet-3.1
+      app.kubernetes.io/component: backend
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: open-runtimes-dotnet-3.1
+        app.kubernetes.io/component: backend
+    spec:
+      containers:
+        - name: open-runtimes-dotnet-3.1
+          image: open-runtimes-dotnet:3.1
+          env:
+            - name: INTERNAL_RUNTIME_KEY
+              value: "secret-key"
+            - name: INTERNAL_RUNTIME_ENTRYPOINT
+              value: "index.cs"
+          command: ["/bin/sh"]
+          args: ["-c", "sh /usr/local/src/build.sh && cp /usr/code/code.tar.gz /tmp/code.tar.gz && sh /usr/local/src/start.sh"]
+          volumeMounts:
+            - mountPath: /usr/code
+              name: code
+          ports:
+            - containerPort: 3000
+      volumes:
+        - name: code
+          hostPath:
+            path: /example

--- a/runtimes/dotnet-3.1/service.yaml
+++ b/runtimes/dotnet-3.1/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: open-runtimes-dotnet-3.1
+  labels:
+    app.kubernetes.io/name: open-runtimes-dotnet-3.1
+    app.kubernetes.io/component: backend
+spec:
+  ports:
+    - port: 3000
+      targetPort: 3000
+  selector:
+    app.kubernetes.io/name: open-runtimes-dotnet-3.1
+    app.kubernetes.io/component: backend

--- a/runtimes/dotnet-6.0/deployment.yaml
+++ b/runtimes/dotnet-6.0/deployment.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: open-runtimes-dotnet-6.0
+  labels:
+    app.kubernetes.io/name: open-runtimes-dotnet-6.0
+    app.kubernetes.io/component: backend
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: open-runtimes-dotnet-6.0
+      app.kubernetes.io/component: backend
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: open-runtimes-dotnet-6.0
+        app.kubernetes.io/component: backend
+    spec:
+      containers:
+        - name: open-runtimes-dotnet-6.0
+          image: open-runtimes-dotnet:6.0
+          env:
+            - name: INTERNAL_RUNTIME_KEY
+              value: "secret-key"
+            - name: INTERNAL_RUNTIME_ENTRYPOINT
+              value: "index.cs"
+          command: ["/bin/sh"]
+          args: ["-c", "sh /usr/local/src/build.sh && cp /usr/code/code.tar.gz /tmp/code.tar.gz && sh /usr/local/src/start.sh"]
+          volumeMounts:
+            - mountPath: /usr/code
+              name: code
+          ports:
+            - containerPort: 3000
+      volumes:
+        - name: code
+          hostPath:
+            path: /example

--- a/runtimes/dotnet-6.0/service.yaml
+++ b/runtimes/dotnet-6.0/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: open-runtimes-dotnet-6.0
+  labels:
+    app.kubernetes.io/name: open-runtimes-dotnet-6.0
+    app.kubernetes.io/component: backend
+spec:
+  ports:
+    - port: 3000
+      targetPort: 3000
+  selector:
+    app.kubernetes.io/name: open-runtimes-dotnet-6.0
+    app.kubernetes.io/component: backend

--- a/runtimes/java-11.0/deployment.yaml
+++ b/runtimes/java-11.0/deployment.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: open-runtimes-java-11
+  labels:
+    app.kubernetes.io/name: open-runtimes-java-11
+    app.kubernetes.io/component: backend
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: open-runtimes-java-11
+      app.kubernetes.io/component: backend
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: open-runtimes-java-11
+        app.kubernetes.io/component: backend
+    spec:
+      containers:
+        - name: open-runtimes-java-11
+          image: open-runtimes-java:11
+          env:
+            - name: INTERNAL_RUNTIME_KEY
+              value: "secret-key"
+            - name: INTERNAL_RUNTIME_ENTRYPOINT
+              value: "Index.java"
+          command: ["/bin/sh"]
+          args: ["-c", "sh /usr/local/src/build.sh && cp /usr/code/code.tar.gz /tmp/code.tar.gz && sh /usr/local/src/start.sh"]
+          volumeMounts:
+            - mountPath: /usr/code
+              name: code
+          ports:
+            - containerPort: 3000
+      volumes:
+        - name: code
+          hostPath:
+            path: /example

--- a/runtimes/java-11.0/service.yaml
+++ b/runtimes/java-11.0/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: open-runtimes-java-11
+  labels:
+    app.kubernetes.io/name: open-runtimes-java-11
+    app.kubernetes.io/component: backend
+spec:
+  ports:
+    - port: 3000
+      targetPort: 3000
+  selector:
+    app.kubernetes.io/name: open-runtimes-java-11
+    app.kubernetes.io/component: backend

--- a/runtimes/java-17.0/deployment.yaml
+++ b/runtimes/java-17.0/deployment.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: open-runtimes-java-17
+  labels:
+    app.kubernetes.io/name: open-runtimes-java-17
+    app.kubernetes.io/component: backend
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: open-runtimes-java-17
+      app.kubernetes.io/component: backend
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: open-runtimes-java-17
+        app.kubernetes.io/component: backend
+    spec:
+      containers:
+        - name: open-runtimes-java-17
+          image: open-runtimes-java:17
+          env:
+            - name: INTERNAL_RUNTIME_KEY
+              value: "secret-key"
+            - name: INTERNAL_RUNTIME_ENTRYPOINT
+              value: "Index.java"
+          command: ["/bin/sh"]
+          args: ["-c", "sh /usr/local/src/build.sh && cp /usr/code/code.tar.gz /tmp/code.tar.gz && sh /usr/local/src/start.sh"]
+          volumeMounts:
+            - mountPath: /usr/code
+              name: code
+          ports:
+            - containerPort: 3000
+      volumes:
+        - name: code
+          hostPath:
+            path: /example

--- a/runtimes/java-17.0/service.yaml
+++ b/runtimes/java-17.0/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: open-runtimes-java-17
+  labels:
+    app.kubernetes.io/name: open-runtimes-java-17
+    app.kubernetes.io/component: backend
+spec:
+  ports:
+    - port: 3000
+      targetPort: 3000
+  selector:
+    app.kubernetes.io/name: open-runtimes-java-17
+    app.kubernetes.io/component: backend

--- a/runtimes/java-18.0/deployment.yaml
+++ b/runtimes/java-18.0/deployment.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: open-runtimes-java-18
+  labels:
+    app.kubernetes.io/name: open-runtimes-java-18
+    app.kubernetes.io/component: backend
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: open-runtimes-java-18
+      app.kubernetes.io/component: backend
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: open-runtimes-java-18
+        app.kubernetes.io/component: backend
+    spec:
+      containers:
+        - name: open-runtimes-java-18
+          image: open-runtimes-java:18
+          env:
+            - name: INTERNAL_RUNTIME_KEY
+              value: "secret-key"
+            - name: INTERNAL_RUNTIME_ENTRYPOINT
+              value: "Index.java"
+          command: ["/bin/sh"]
+          args: ["-c", "sh /usr/local/src/build.sh && cp /usr/code/code.tar.gz /tmp/code.tar.gz && sh /usr/local/src/start.sh"]
+          volumeMounts:
+            - mountPath: /usr/code
+              name: code
+          ports:
+            - containerPort: 3000
+      volumes:
+        - name: code
+          hostPath:
+            path: /example

--- a/runtimes/java-18.0/service.yaml
+++ b/runtimes/java-18.0/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: open-runtimes-java-18
+  labels:
+    app.kubernetes.io/name: open-runtimes-java-18
+    app.kubernetes.io/component: backend
+spec:
+  ports:
+    - port: 3000
+      targetPort: 3000
+  selector:
+    app.kubernetes.io/name: open-runtimes-java-18
+    app.kubernetes.io/component: backend

--- a/runtimes/java-8.0/deployment.yaml
+++ b/runtimes/java-8.0/deployment.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: open-runtimes-java-8
+  labels:
+    app.kubernetes.io/name: open-runtimes-java-8
+    app.kubernetes.io/component: backend
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: open-runtimes-java-8
+      app.kubernetes.io/component: backend
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: open-runtimes-java-8
+        app.kubernetes.io/component: backend
+    spec:
+      containers:
+        - name: open-runtimes-java-8
+          image: open-runtimes-java:8
+          env:
+            - name: INTERNAL_RUNTIME_KEY
+              value: "secret-key"
+            - name: INTERNAL_RUNTIME_ENTRYPOINT
+              value: "Index.java"
+          command: ["/bin/sh"]
+          args: ["-c", "sh /usr/local/src/build.sh && cp /usr/code/code.tar.gz /tmp/code.tar.gz && sh /usr/local/src/start.sh"]
+          volumeMounts:
+            - mountPath: /usr/code
+              name: code
+          ports:
+            - containerPort: 3000
+      volumes:
+        - name: code
+          hostPath:
+            path: /example

--- a/runtimes/java-8.0/service.yaml
+++ b/runtimes/java-8.0/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: open-runtimes-java-8
+  labels:
+    app.kubernetes.io/name: open-runtimes-java-8
+    app.kubernetes.io/component: backend
+spec:
+  ports:
+    - port: 3000
+      targetPort: 3000
+  selector:
+    app.kubernetes.io/name: open-runtimes-java-8
+    app.kubernetes.io/component: backend

--- a/runtimes/kotlin-1.6/deployment.yaml
+++ b/runtimes/kotlin-1.6/deployment.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: open-runtimes-kotlin-1.6
+  labels:
+    app.kubernetes.io/name: open-runtimes-kotlin-1.6
+    app.kubernetes.io/component: backend
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: open-runtimes-kotlin-1.6
+      app.kubernetes.io/component: backend
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: open-runtimes-kotlin-1.6
+        app.kubernetes.io/component: backend
+    spec:
+      containers:
+        - name: open-runtimes-kotlin-1.6
+          image: open-runtimes-kotlin:1.6
+          env:
+            - name: INTERNAL_RUNTIME_KEY
+              value: "secret-key"
+            - name: INTERNAL_RUNTIME_ENTRYPOINT
+              value: "Index.kt"
+          command: ["/bin/sh"]
+          args: ["-c", "sh /usr/local/src/build.sh && cp /usr/code/code.tar.gz /tmp/code.tar.gz && sh /usr/local/src/start.sh"]
+          volumeMounts:
+            - mountPath: /usr/code
+              name: code
+          ports:
+            - containerPort: 3000
+      volumes:
+        - name: code
+          hostPath:
+            path: /example

--- a/runtimes/kotlin-1.6/service.yaml
+++ b/runtimes/kotlin-1.6/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: open-runtimes-kotlin-1.6
+  labels:
+    app.kubernetes.io/name: open-runtimes-kotlin-1.6
+    app.kubernetes.io/component: backend
+spec:
+  ports:
+    - port: 3000
+      targetPort: 3000
+  selector:
+    app.kubernetes.io/name: open-runtimes-kotlin-1.6
+    app.kubernetes.io/component: backend

--- a/runtimes/node-14.5/deployment.yaml
+++ b/runtimes/node-14.5/deployment.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: open-runtimes-node-14.5
+  labels:
+    app.kubernetes.io/name: open-runtimes-node-14.5
+    app.kubernetes.io/component: backend
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: open-runtimes-node-14.5
+      app.kubernetes.io/component: backend
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: open-runtimes-node-14.5
+        app.kubernetes.io/component: backend
+    spec:
+      containers:
+        - name: open-runtimes-node-14.5
+          image: open-runtimes-node:14.5
+          env:
+            - name: INTERNAL_RUNTIME_KEY
+              value: "secret-key"
+            - name: INTERNAL_RUNTIME_ENTRYPOINT
+              value: "index.js"
+          command: ["/bin/sh"]
+          args: ["-c", "sh /usr/local/src/build.sh && cp /usr/code/code.tar.gz /tmp/code.tar.gz && sh /usr/local/src/start.sh"]
+          volumeMounts:
+            - mountPath: /usr/code
+              name: code
+          ports:
+            - containerPort: 3000
+      volumes:
+        - name: code
+          hostPath:
+            path: /example

--- a/runtimes/node-14.5/service.yaml
+++ b/runtimes/node-14.5/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: open-runtimes-node-14.5
+  labels:
+    app.kubernetes.io/name: open-runtimes-node-14.5
+    app.kubernetes.io/component: backend
+spec:
+  ports:
+    - port: 3000
+      targetPort: 3000
+  selector:
+    app.kubernetes.io/name: open-runtimes-node-14.5
+    app.kubernetes.io/component: backend

--- a/runtimes/node-15.5/deployment.yaml
+++ b/runtimes/node-15.5/deployment.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: open-runtimes-node-15.5
+  labels:
+    app.kubernetes.io/name: open-runtimes-node-15.5
+    app.kubernetes.io/component: backend
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: open-runtimes-node-15.5
+      app.kubernetes.io/component: backend
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: open-runtimes-node-15.5
+        app.kubernetes.io/component: backend
+    spec:
+      containers:
+        - name: open-runtimes-node-15.5
+          image: open-runtimes-node:15.5
+          env:
+            - name: INTERNAL_RUNTIME_KEY
+              value: "secret-key"
+            - name: INTERNAL_RUNTIME_ENTRYPOINT
+              value: "index.js"
+          command: ["/bin/sh"]
+          args: ["-c", "sh /usr/local/src/build.sh && cp /usr/code/code.tar.gz /tmp/code.tar.gz && sh /usr/local/src/start.sh"]
+          volumeMounts:
+            - mountPath: /usr/code
+              name: code
+          ports:
+            - containerPort: 3000
+      volumes:
+        - name: code
+          hostPath:
+            path: /example

--- a/runtimes/node-15.5/service.yaml
+++ b/runtimes/node-15.5/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: open-runtimes-node-15.5
+  labels:
+    app.kubernetes.io/name: open-runtimes-node-15.5
+    app.kubernetes.io/component: backend
+spec:
+  ports:
+    - port: 3000
+      targetPort: 3000
+  selector:
+    app.kubernetes.io/name: open-runtimes-node-15.5
+    app.kubernetes.io/component: backend

--- a/runtimes/node-16.0/deployment.yaml
+++ b/runtimes/node-16.0/deployment.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: open-runtimes-node-16
+  labels:
+    app.kubernetes.io/name: open-runtimes-node-16
+    app.kubernetes.io/component: backend
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: open-runtimes-node-16
+      app.kubernetes.io/component: backend
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: open-runtimes-node-16
+        app.kubernetes.io/component: backend
+    spec:
+      containers:
+        - name: open-runtimes-node-16
+          image: open-runtimes-node:16
+          env:
+            - name: INTERNAL_RUNTIME_KEY
+              value: "secret-key"
+            - name: INTERNAL_RUNTIME_ENTRYPOINT
+              value: "index.js"
+          command: ["/bin/sh"]
+          args: ["-c", "sh /usr/local/src/build.sh && cp /usr/code/code.tar.gz /tmp/code.tar.gz && sh /usr/local/src/start.sh"]
+          volumeMounts:
+            - mountPath: /usr/code
+              name: code
+          ports:
+            - containerPort: 3000
+      volumes:
+        - name: code
+          hostPath:
+            path: /example

--- a/runtimes/node-16.0/service.yaml
+++ b/runtimes/node-16.0/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: open-runtimes-node-16
+  labels:
+    app.kubernetes.io/name: open-runtimes-node-16
+    app.kubernetes.io/component: backend
+spec:
+  ports:
+    - port: 3000
+      targetPort: 3000
+  selector:
+    app.kubernetes.io/name: open-runtimes-node-16
+    app.kubernetes.io/component: backend

--- a/runtimes/node-17.0/deployment.yaml
+++ b/runtimes/node-17.0/deployment.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: open-runtimes-node-17
+  labels:
+    app.kubernetes.io/name: open-runtimes-node-17
+    app.kubernetes.io/component: backend
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: open-runtimes-node-17
+      app.kubernetes.io/component: backend
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: open-runtimes-node-17
+        app.kubernetes.io/component: backend
+    spec:
+      containers:
+        - name: open-runtimes-node-17
+          image: open-runtimes-node:17
+          env:
+            - name: INTERNAL_RUNTIME_KEY
+              value: "secret-key"
+            - name: INTERNAL_RUNTIME_ENTRYPOINT
+              value: "index.js"
+          command: ["/bin/sh"]
+          args: ["-c", "sh /usr/local/src/build.sh && cp /usr/code/code.tar.gz /tmp/code.tar.gz && sh /usr/local/src/start.sh"]
+          volumeMounts:
+            - mountPath: /usr/code
+              name: code
+          ports:
+            - containerPort: 3000
+      volumes:
+        - name: code
+          hostPath:
+            path: /example

--- a/runtimes/node-17.0/service.yaml
+++ b/runtimes/node-17.0/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: open-runtimes-node-17
+  labels:
+    app.kubernetes.io/name: open-runtimes-node-17
+    app.kubernetes.io/component: backend
+spec:
+  ports:
+    - port: 3000
+      targetPort: 3000
+  selector:
+    app.kubernetes.io/name: open-runtimes-node-17
+    app.kubernetes.io/component: backend

--- a/runtimes/node-18.0/deployment.yaml
+++ b/runtimes/node-18.0/deployment.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: open-runtimes-node-18
+  labels:
+    app.kubernetes.io/name: open-runtimes-node-18
+    app.kubernetes.io/component: backend
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: open-runtimes-node-18
+      app.kubernetes.io/component: backend
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: open-runtimes-node-18
+        app.kubernetes.io/component: backend
+    spec:
+      containers:
+        - name: open-runtimes-node-18
+          image: open-runtimes-node:18
+          env:
+            - name: INTERNAL_RUNTIME_KEY
+              value: "secret-key"
+            - name: INTERNAL_RUNTIME_ENTRYPOINT
+              value: "index.js"
+          command: ["/bin/sh"]
+          args: ["-c", "sh /usr/local/src/build.sh && cp /usr/code/code.tar.gz /tmp/code.tar.gz && sh /usr/local/src/start.sh"]
+          volumeMounts:
+            - mountPath: /usr/code
+              name: code
+          ports:
+            - containerPort: 3000
+      volumes:
+        - name: code
+          hostPath:
+            path: /example

--- a/runtimes/node-18.0/service.yaml
+++ b/runtimes/node-18.0/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: open-runtimes-node-18
+  labels:
+    app.kubernetes.io/name: open-runtimes-node-18
+    app.kubernetes.io/component: backend
+spec:
+  ports:
+    - port: 3000
+      targetPort: 3000
+  selector:
+    app.kubernetes.io/name: open-runtimes-node-18
+    app.kubernetes.io/component: backend

--- a/runtimes/php-8.0/deployment.yaml
+++ b/runtimes/php-8.0/deployment.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: open-runtimes-php-8.0
+  labels:
+    app.kubernetes.io/name: open-runtimes-php-8.0
+    app.kubernetes.io/component: backend
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: open-runtimes-php-8.0
+      app.kubernetes.io/component: backend
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: open-runtimes-php-8.0
+        app.kubernetes.io/component: backend
+    spec:
+      containers:
+        - name: open-runtimes-php-8.0
+          image: open-runtimes-php:8.0
+          env:
+            - name: INTERNAL_RUNTIME_KEY
+              value: "secret-key"
+            - name: INTERNAL_RUNTIME_ENTRYPOINT
+              value: "index.php"
+          command: ["/bin/sh"]
+          args: ["-c", "sh /usr/local/src/build.sh && cp /usr/code/code.tar.gz /tmp/code.tar.gz && sh /usr/local/src/start.sh"]
+          volumeMounts:
+            - mountPath: /usr/code
+              name: code
+          ports:
+            - containerPort: 3000
+      volumes:
+        - name: code
+          hostPath:
+            path: /example

--- a/runtimes/php-8.0/service.yaml
+++ b/runtimes/php-8.0/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: open-runtimes-php-8.0
+  labels:
+    app.kubernetes.io/name: open-runtimes-php-8.0
+    app.kubernetes.io/component: backend
+spec:
+  ports:
+    - port: 3000
+      targetPort: 3000
+  selector:
+    app.kubernetes.io/name: open-runtimes-php-8.0
+    app.kubernetes.io/component: backend

--- a/runtimes/php-8.1/deployment.yaml
+++ b/runtimes/php-8.1/deployment.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: open-runtimes-php-8.1
+  labels:
+    app.kubernetes.io/name: open-runtimes-php-8.1
+    app.kubernetes.io/component: backend
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: open-runtimes-php-8.1
+      app.kubernetes.io/component: backend
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: open-runtimes-php-8.1
+        app.kubernetes.io/component: backend
+    spec:
+      containers:
+        - name: open-runtimes-php-8.1
+          image: open-runtimes-php:8.1
+          env:
+            - name: INTERNAL_RUNTIME_KEY
+              value: "secret-key"
+            - name: INTERNAL_RUNTIME_ENTRYPOINT
+              value: "index.php"
+          command: ["/bin/sh"]
+          args: ["-c", "sh /usr/local/src/build.sh && cp /usr/code/code.tar.gz /tmp/code.tar.gz && sh /usr/local/src/start.sh"]
+          volumeMounts:
+            - mountPath: /usr/code
+              name: code
+          ports:
+            - containerPort: 3000
+      volumes:
+        - name: code
+          hostPath:
+            path: /example

--- a/runtimes/php-8.1/service.yaml
+++ b/runtimes/php-8.1/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: open-runtimes-php-8.1
+  labels:
+    app.kubernetes.io/name: open-runtimes-php-8.1
+    app.kubernetes.io/component: backend
+spec:
+  ports:
+    - port: 3000
+      targetPort: 3000
+  selector:
+    app.kubernetes.io/name: open-runtimes-php-8.1
+    app.kubernetes.io/component: backend

--- a/runtimes/python-3.10/deployment.yaml
+++ b/runtimes/python-3.10/deployment.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: open-runtimes-python-3.10
+  labels:
+    app.kubernetes.io/name: open-runtimes-python-3.10
+    app.kubernetes.io/component: backend
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: open-runtimes-python-3.10
+      app.kubernetes.io/component: backend
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: open-runtimes-python-3.10
+        app.kubernetes.io/component: backend
+    spec:
+      containers:
+        - name: open-runtimes-python-3.10
+          image: open-runtimes-python:3.10
+          env:
+            - name: INTERNAL_RUNTIME_KEY
+              value: "secret-key"
+            - name: INTERNAL_RUNTIME_ENTRYPOINT
+              value: "main.py"
+          command: ["/bin/sh"]
+          args: ["-c", "sh /usr/local/src/build.sh && cp /usr/code/code.tar.gz /tmp/code.tar.gz && sh /usr/local/src/start.sh"]
+          volumeMounts:
+            - mountPath: /usr/code
+              name: code
+          ports:
+            - containerPort: 3000
+      volumes:
+        - name: code
+          hostPath:
+            path: /example

--- a/runtimes/python-3.10/service.yaml
+++ b/runtimes/python-3.10/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: open-runtimes-python-3.10
+  labels:
+    app.kubernetes.io/name: open-runtimes-python-3.10
+    app.kubernetes.io/component: backend
+spec:
+  ports:
+    - port: 3000
+      targetPort: 3000
+  selector:
+    app.kubernetes.io/name: open-runtimes-python-3.10
+    app.kubernetes.io/component: backend

--- a/runtimes/python-3.8/deployment.yaml
+++ b/runtimes/python-3.8/deployment.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: open-runtimes-python-3.8
+  labels:
+    app.kubernetes.io/name: open-runtimes-python-3.8
+    app.kubernetes.io/component: backend
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: open-runtimes-python-3.8
+      app.kubernetes.io/component: backend
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: open-runtimes-python-3.8
+        app.kubernetes.io/component: backend
+    spec:
+      containers:
+        - name: open-runtimes-python-3.8
+          image: open-runtimes-python:3.8
+          env:
+            - name: INTERNAL_RUNTIME_KEY
+              value: "secret-key"
+            - name: INTERNAL_RUNTIME_ENTRYPOINT
+              value: "main.py"
+          command: ["/bin/sh"]
+          args: ["-c", "sh /usr/local/src/build.sh && cp /usr/code/code.tar.gz /tmp/code.tar.gz && sh /usr/local/src/start.sh"]
+          volumeMounts:
+            - mountPath: /usr/code
+              name: code
+          ports:
+            - containerPort: 3000
+      volumes:
+        - name: code
+          hostPath:
+            path: /example

--- a/runtimes/python-3.8/service.yaml
+++ b/runtimes/python-3.8/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: open-runtimes-python-3.8
+  labels:
+    app.kubernetes.io/name: open-runtimes-python-3.8
+    app.kubernetes.io/component: backend
+spec:
+  ports:
+    - port: 3000
+      targetPort: 3000
+  selector:
+    app.kubernetes.io/name: open-runtimes-python-3.8
+    app.kubernetes.io/component: backend

--- a/runtimes/python-3.9/deployment.yaml
+++ b/runtimes/python-3.9/deployment.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: open-runtimes-python-3.9
+  labels:
+    app.kubernetes.io/name: open-runtimes-python-3.9
+    app.kubernetes.io/component: backend
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: open-runtimes-python-3.9
+      app.kubernetes.io/component: backend
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: open-runtimes-python-3.9
+        app.kubernetes.io/component: backend
+    spec:
+      containers:
+        - name: open-runtimes-python-3.9
+          image: open-runtimes-python:3.9
+          env:
+            - name: INTERNAL_RUNTIME_KEY
+              value: "secret-key"
+            - name: INTERNAL_RUNTIME_ENTRYPOINT
+              value: "main.py"
+          command: ["/bin/sh"]
+          args: ["-c", "sh /usr/local/src/build.sh && cp /usr/code/code.tar.gz /tmp/code.tar.gz && sh /usr/local/src/start.sh"]
+          volumeMounts:
+            - mountPath: /usr/code
+              name: code
+          ports:
+            - containerPort: 3000
+      volumes:
+        - name: code
+          hostPath:
+            path: /example

--- a/runtimes/python-3.9/service.yaml
+++ b/runtimes/python-3.9/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: open-runtimes-python-3.9
+  labels:
+    app.kubernetes.io/name: open-runtimes-python-3.9
+    app.kubernetes.io/component: backend
+spec:
+  ports:
+    - port: 3000
+      targetPort: 3000
+  selector:
+    app.kubernetes.io/name: open-runtimes-python-3.9
+    app.kubernetes.io/component: backend

--- a/runtimes/ruby-3.0/deployment.yaml
+++ b/runtimes/ruby-3.0/deployment.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: open-runtimes-ruby-3.0
+  labels:
+    app.kubernetes.io/name: open-runtimes-ruby-3.0
+    app.kubernetes.io/component: backend
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: open-runtimes-ruby-3.0
+      app.kubernetes.io/component: backend
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: open-runtimes-ruby-3.0
+        app.kubernetes.io/component: backend
+    spec:
+      containers:
+        - name: open-runtimes-ruby-3.0
+          image: open-runtimes-ruby:3.0
+          env:
+            - name: INTERNAL_RUNTIME_KEY
+              value: "secret-key"
+            - name: INTERNAL_RUNTIME_ENTRYPOINT
+              value: "index.rb"
+          command: ["/bin/sh"]
+          args: ["-c", "sh /usr/local/src/build.sh && cp /usr/code/code.tar.gz /tmp/code.tar.gz && sh /usr/local/src/start.sh"]
+          volumeMounts:
+            - mountPath: /usr/code
+              name: code
+          ports:
+            - containerPort: 3000
+      volumes:
+        - name: code
+          hostPath:
+            path: /example

--- a/runtimes/ruby-3.0/service.yaml
+++ b/runtimes/ruby-3.0/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: open-runtimes-ruby-3.0
+  labels:
+    app.kubernetes.io/name: open-runtimes-ruby-3.0
+    app.kubernetes.io/component: backend
+spec:
+  ports:
+    - port: 3000
+      targetPort: 3000
+  selector:
+    app.kubernetes.io/name: open-runtimes-ruby-3.0
+    app.kubernetes.io/component: backend

--- a/runtimes/ruby-3.1/deployment.yaml
+++ b/runtimes/ruby-3.1/deployment.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: open-runtimes-ruby-3.1
+  labels:
+    app.kubernetes.io/name: open-runtimes-ruby-3.1
+    app.kubernetes.io/component: backend
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: open-runtimes-ruby-3.1
+      app.kubernetes.io/component: backend
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: open-runtimes-ruby-3.1
+        app.kubernetes.io/component: backend
+    spec:
+      containers:
+        - name: open-runtimes-ruby-3.1
+          image: open-runtimes-ruby:3.1
+          env:
+            - name: INTERNAL_RUNTIME_KEY
+              value: "secret-key"
+            - name: INTERNAL_RUNTIME_ENTRYPOINT
+              value: "index.rb"
+          command: ["/bin/sh"]
+          args: ["-c", "sh /usr/local/src/build.sh && cp /usr/code/code.tar.gz /tmp/code.tar.gz && sh /usr/local/src/start.sh"]
+          volumeMounts:
+            - mountPath: /usr/code
+              name: code
+          ports:
+            - containerPort: 3000
+      volumes:
+        - name: code
+          hostPath:
+            path: /example

--- a/runtimes/ruby-3.1/service.yaml
+++ b/runtimes/ruby-3.1/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: open-runtimes-ruby-3.1
+  labels:
+    app.kubernetes.io/name: open-runtimes-ruby-3.1
+    app.kubernetes.io/component: backend
+spec:
+  ports:
+    - port: 3000
+      targetPort: 3000
+  selector:
+    app.kubernetes.io/name: open-runtimes-ruby-3.1
+    app.kubernetes.io/component: backend

--- a/runtimes/swift-5.5/deployment.yaml
+++ b/runtimes/swift-5.5/deployment.yaml
@@ -1,0 +1,36 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: open-runtimes-swift
+  labels:
+    app.kubernetes.io/name: open-runtimes-swift
+    app.kubernetes.io/component: backend
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: open-runtimes-swift
+      app.kubernetes.io/component: backend
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: open-runtimes-swift
+        app.kubernetes.io/component: backend
+    spec:
+      containers:
+        - name: open-runtimes-swift
+          image: open-runtimes-swift
+          env:
+            - name: INTERNAL_RUNTIME_KEY
+              value: "secret-key"
+          command: ["/bin/sh"]
+          args: ["-c", "sh /usr/local/src/build.sh && cp /usr/code/code.tar.gz /tmp/code.tar.gz && sh /usr/local/src/start.sh"]
+          volumeMounts:
+            - mountPath: /usr/code
+              name: code
+          ports:
+            - containerPort: 3000
+      volumes:
+        - name: code
+          hostPath:
+            path: /example

--- a/runtimes/swift-5.5/service.yaml
+++ b/runtimes/swift-5.5/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: open-runtimes-swift
+  labels:
+    app.kubernetes.io/name: open-runtimes-swift
+    app.kubernetes.io/component: backend
+spec:
+  ports:
+    - port: 3000
+      targetPort: 3000
+  selector:
+    app.kubernetes.io/name: open-runtimes-swift
+    app.kubernetes.io/component: backend


### PR DESCRIPTION
 - Each runtime has 2 new files added to its directory, a deployment and a service. These can be run using the kubectl -f deployment/service.yaml command to bring up the deployment and accompanying service. kubectl port-forward can then be used to map ports to the host machine.