### PR TITLE
FEAT: Allow Script execution in PHP runtime

### DIFF
--- a/runtimes/php-8.0/build.sh
+++ b/runtimes/php-8.0/build.sh
@@ -16,7 +16,7 @@ fi
 
 # Merge the vendor from the server into the user's vendor to be restored later.
 cd /usr/local/src/
-composer update --no-interaction --ignore-platform-reqs --optimize-autoloader --no-scripts --prefer-dist --no-dev
+composer update --no-interaction --ignore-platform-reqs --optimize-autoloader --prefer-dist --no-dev
 cp -r /usr/local/src/vendor /usr/builds/vendor
 
 # Finish build by preparing tar to use for starting the runtime

--- a/runtimes/php-8.1/build.sh
+++ b/runtimes/php-8.1/build.sh
@@ -16,7 +16,7 @@ fi
 
 # Merge the vendor from the server into the user's vendor to be restored later.
 cd /usr/local/src/
-composer update --no-interaction --ignore-platform-reqs --optimize-autoloader --no-scripts --prefer-dist --no-dev
+composer update --no-interaction --ignore-platform-reqs --optimize-autoloader --prefer-dist --no-dev
 cp -r /usr/local/src/vendor /usr/builds/vendor
 
 # Finish build by preparing tar to use for starting the runtime


### PR DESCRIPTION
This PR removes the --no-script parameter so custom extensions can be installed through the composer.json


e.g.

```sh
    "scripts": {
        "pre-package-install": "apk update && docker-php-ext-install pdo"
    }
```

Important in an environment where no custom dockerfiles can be used.