### PR TITLE
Fix: Dart error handling

### DIFF
--- a/runtimes/dart-2.15/server.dart
+++ b/runtimes/dart-2.15/server.dart
@@ -32,11 +32,10 @@ void main() async {
       );
 
       final response = Response();
-      await runZonedGuarded(
+      await runZoned(
         () async {
           await user_code.start(request, response);
         },
-        (e, stackTrace) => print('$e $stackTrace'),
         zoneSpecification: ZoneSpecification(
           print: (Zone self, ZoneDelegate parent, Zone zone, String line) {
             userLogs.add(line);

--- a/runtimes/dart-2.16/server.dart
+++ b/runtimes/dart-2.16/server.dart
@@ -32,11 +32,10 @@ void main() async {
       );
 
       final response = Response();
-      await runZonedGuarded(
+      await runZoned(
         () async {
           await user_code.start(request, response);
         },
-        (e, stackTrace) => print('$e $stackTrace'),
         zoneSpecification: ZoneSpecification(
           print: (Zone self, ZoneDelegate parent, Zone zone, String line) {
             userLogs.add(line);

--- a/runtimes/dart-2.17/server.dart
+++ b/runtimes/dart-2.17/server.dart
@@ -32,11 +32,10 @@ void main() async {
       );
 
       final response = Response();
-      await runZonedGuarded(
+      await runZoned(
         () async {
           await user_code.start(request, response);
         },
-        (e, stackTrace) => print('$e $stackTrace'),
         zoneSpecification: ZoneSpecification(
           print: (Zone self, ZoneDelegate parent, Zone zone, String line) {
             userLogs.add(line);

--- a/runtimes/dart-2.18/example/lib/main.dart
+++ b/runtimes/dart-2.18/example/lib/main.dart
@@ -15,8 +15,6 @@ import 'package:dio/dio.dart' hide Response;
 */
 
 Future<void> start(final req, final res) async {
-  String endpoint = req.variables['APPWRITE_ENDPOINT'];
-
   final payload = jsonDecode(req.payload == '' ? '{}' : req.payload);
 
   final id = payload['id'] ?? '1';

--- a/runtimes/dart-2.18/example/lib/main.dart
+++ b/runtimes/dart-2.18/example/lib/main.dart
@@ -15,6 +15,7 @@ import 'package:dio/dio.dart' hide Response;
 */
 
 Future<void> start(final req, final res) async {
+  String endpoint = req.variables['APPWRITE_ENDPOINT'];
 
   final payload = jsonDecode(req.payload == '' ? '{}' : req.payload);
 

--- a/runtimes/dart-2.18/server.dart
+++ b/runtimes/dart-2.18/server.dart
@@ -32,11 +32,10 @@ void main() async {
       );
 
       final response = Response();
-      await runZonedGuarded(
+      await runZoned(
         () async {
           await user_code.start(request, response);
         },
-        (e, stackTrace) => print('$e $stackTrace'),
         zoneSpecification: ZoneSpecification(
           print: (Zone self, ZoneDelegate parent, Zone zone, String line) {
             userLogs.add(line);


### PR DESCRIPTION
Runtime error in user code in Dart caused timeout error. This PR fixes this. It also fixes problem in Appwrite when logs werent visible after error in Dart (related to timeout issue)