### PR TITLE
Feat: .open-runtimes

### DIFF
--- a/runtimes/cpp-17/README.md
+++ b/runtimes/cpp-17/README.md
@@ -87,7 +87,7 @@ static RuntimeResponse &main(const RuntimeRequest &req, RuntimeResponse &res) {
 
 - To handle dependencies, you need to include a `CMakeLists.txt` file. Dependencies will be automatically cached and installed, so you don't need to include the `build` folder in your function.
 
-- The default entrypoint is `index.cc`. If your entrypoint differs, make sure to configure it using `INTERNAL_RUNTIME_ENTRYPOINT` environment variable, for instance, `INTERNAL_RUNTIME_ENTRYPOINT=src/app.cc`.
+- The default entrypoint is `index.cc`. If your entrypoint differs, make sure to configure it using `INTERNAL_RUNTIME_ENTRYPOINT` environment variable during build, for instance, `INTERNAL_RUNTIME_ENTRYPOINT=src/app.cc`.
 
 
 ## Authors

--- a/runtimes/cpp-17/build.sh
+++ b/runtimes/cpp-17/build.sh
@@ -46,5 +46,8 @@ cd /usr/local/src/build
 cmake -DCMAKE_BUILD_TYPE=Release ..
 make -j"$(nproc)"
 
+touch .open-runtimes
+echo "INTERNAL_RUNTIME_ENTRYPOINT=$INTERNAL_RUNTIME_ENTRYPOINT" > .open-runtimes
+
 # Finish build by preparing tar to use for starting the runtime
 tar --exclude code.tar.gz -zcf /usr/code/code.tar.gz .

--- a/runtimes/cpp-17/start.sh
+++ b/runtimes/cpp-17/start.sh
@@ -2,4 +2,9 @@
 
 cd /usr/code
 tar -zxf /tmp/code.tar.gz
+
+set -o allexport
+source ./.open-runtimes
+set +o allexport
+
 ./cpp_runtime

--- a/runtimes/dart-2.15/README.md
+++ b/runtimes/dart-2.15/README.md
@@ -99,7 +99,7 @@ Future<void> start(final req, final res) async {
 
 - To handle dependencies, you need to have `pubspec.yaml` file. Dependencies will be automatically cached and installed, so you don't need to include any dependencies folders in your function.
 
-- The default entrypoint is `lib/main.dart`. If your entrypoint differs, make sure to configure it using `INTERNAL_RUNTIME_ENTRYPOINT` environment variable, for instance, `INTERNAL_RUNTIME_ENTRYPOINT=lib/app.dart`.
+- The default entrypoint is `lib/main.dart`. If your entrypoint differs, make sure to configure it using `INTERNAL_RUNTIME_ENTRYPOINT` environment variable during build, for instance, `INTERNAL_RUNTIME_ENTRYPOINT=lib/app.dart`.
 
 - Dart function is a Dart library package, which means, your code has to be inside `lib` folder. You can learn more in [Dart documentation](https://dart.dev/guides/libraries/create-library-packages).
 

--- a/runtimes/dart-2.15/build.sh
+++ b/runtimes/dart-2.15/build.sh
@@ -36,5 +36,8 @@ cd /usr/local/src
 # Compile the Code
 dart compile exe server.dart -o runtime
 
+touch .open-runtimes
+echo "INTERNAL_RUNTIME_ENTRYPOINT=$INTERNAL_RUNTIME_ENTRYPOINT" > runtime/.open-runtimes
+
 # Finish build by preparing tar to use for starting the runtime
 tar --exclude code.tar.gz -zcf /usr/code/code.tar.gz runtime

--- a/runtimes/dart-2.15/build.sh
+++ b/runtimes/dart-2.15/build.sh
@@ -37,7 +37,7 @@ cd /usr/local/src
 dart compile exe server.dart -o runtime
 
 touch .open-runtimes
-echo "INTERNAL_RUNTIME_ENTRYPOINT=$INTERNAL_RUNTIME_ENTRYPOINT" > runtime/.open-runtimes
+echo "INTERNAL_RUNTIME_ENTRYPOINT=$INTERNAL_RUNTIME_ENTRYPOINT" > .open-runtimes
 
 # Finish build by preparing tar to use for starting the runtime
-tar --exclude code.tar.gz -zcf /usr/code/code.tar.gz runtime
+tar --exclude code.tar.gz -zcf /usr/code/code.tar.gz runtime .open-runtimes

--- a/runtimes/dart-2.15/start.sh
+++ b/runtimes/dart-2.15/start.sh
@@ -3,5 +3,10 @@ cp /tmp/code.tar.gz /usr/workspace/code.tar.gz
 cd /usr/workspace
 tar -zxf /usr/workspace/code.tar.gz -C /usr/code-start
 rm /usr/workspace/code.tar.gz
+
+set -o allexport
+source /usr/code-start/.open-runtimes
+set +o allexport
+
 cd /usr/code-start
 /usr/code-start/runtime

--- a/runtimes/dart-2.16/README.md
+++ b/runtimes/dart-2.16/README.md
@@ -99,7 +99,7 @@ Future<void> start(final req, final res) async {
 
 - To handle dependencies, you need to have `pubspec.yaml` file. Dependencies will be automatically cached and installed, so you don't need to include any dependencies folders in your function.
 
-- The default entrypoint is `lib/main.dart`. If your entrypoint differs, make sure to configure it using `INTERNAL_RUNTIME_ENTRYPOINT` environment variable, for instance, `INTERNAL_RUNTIME_ENTRYPOINT=lib/app.dart`.
+- The default entrypoint is `lib/main.dart`. If your entrypoint differs, make sure to configure it using `INTERNAL_RUNTIME_ENTRYPOINT` environment variable during build, for instance, `INTERNAL_RUNTIME_ENTRYPOINT=lib/app.dart`.
 
 - Dart function is a Dart library package, which means, your code has to be inside `lib` folder. You can learn more in [Dart documentation](https://dart.dev/guides/libraries/create-library-packages).
 

--- a/runtimes/dart-2.16/build.sh
+++ b/runtimes/dart-2.16/build.sh
@@ -36,5 +36,8 @@ cd /usr/local/src
 # Compile the Code
 dart compile exe server.dart -o runtime
 
+touch .open-runtimes
+echo "INTERNAL_RUNTIME_ENTRYPOINT=$INTERNAL_RUNTIME_ENTRYPOINT" > runtime/.open-runtimes
+
 # Finish build by preparing tar to use for starting the runtime
 tar --exclude code.tar.gz -zcf /usr/code/code.tar.gz runtime

--- a/runtimes/dart-2.16/build.sh
+++ b/runtimes/dart-2.16/build.sh
@@ -37,7 +37,7 @@ cd /usr/local/src
 dart compile exe server.dart -o runtime
 
 touch .open-runtimes
-echo "INTERNAL_RUNTIME_ENTRYPOINT=$INTERNAL_RUNTIME_ENTRYPOINT" > runtime/.open-runtimes
+echo "INTERNAL_RUNTIME_ENTRYPOINT=$INTERNAL_RUNTIME_ENTRYPOINT" > .open-runtimes
 
 # Finish build by preparing tar to use for starting the runtime
-tar --exclude code.tar.gz -zcf /usr/code/code.tar.gz runtime
+tar --exclude code.tar.gz -zcf /usr/code/code.tar.gz runtime .open-runtimes

--- a/runtimes/dart-2.16/start.sh
+++ b/runtimes/dart-2.16/start.sh
@@ -3,5 +3,10 @@ cp /tmp/code.tar.gz /usr/workspace/code.tar.gz
 cd /usr/workspace
 tar -zxf /usr/workspace/code.tar.gz -C /usr/code-start
 rm /usr/workspace/code.tar.gz
+
+set -o allexport
+source /usr/code-start/.open-runtimes
+set +o allexport
+
 cd /usr/code-start
 /usr/code-start/runtime

--- a/runtimes/dart-2.17/README.md
+++ b/runtimes/dart-2.17/README.md
@@ -99,7 +99,7 @@ Future<void> start(final req, final res) async {
 
 - To handle dependencies, you need to have `pubspec.yaml` file. Dependencies will be automatically cached and installed, so you don't need to include any dependencies folders in your function.
 
-- The default entrypoint is `lib/main.dart`. If your entrypoint differs, make sure to configure it using `INTERNAL_RUNTIME_ENTRYPOINT` environment variable, for instance, `INTERNAL_RUNTIME_ENTRYPOINT=lib/app.dart`.
+- The default entrypoint is `lib/main.dart`. If your entrypoint differs, make sure to configure it using `INTERNAL_RUNTIME_ENTRYPOINT` environment variable during build, for instance, `INTERNAL_RUNTIME_ENTRYPOINT=lib/app.dart`.
 
 - Dart function is a Dart library package, which means, your code has to be inside `lib` folder. You can learn more in [Dart documentation](https://dart.dev/guides/libraries/create-library-packages).
 

--- a/runtimes/dart-2.17/build.sh
+++ b/runtimes/dart-2.17/build.sh
@@ -36,5 +36,8 @@ cd /usr/local/src
 # Compile the Code
 dart compile exe server.dart -o runtime
 
+touch .open-runtimes
+echo "INTERNAL_RUNTIME_ENTRYPOINT=$INTERNAL_RUNTIME_ENTRYPOINT" > runtime/.open-runtimes
+
 # Finish build by preparing tar to use for starting the runtime
 tar --exclude code.tar.gz -zcf /usr/code/code.tar.gz runtime

--- a/runtimes/dart-2.17/build.sh
+++ b/runtimes/dart-2.17/build.sh
@@ -37,7 +37,7 @@ cd /usr/local/src
 dart compile exe server.dart -o runtime
 
 touch .open-runtimes
-echo "INTERNAL_RUNTIME_ENTRYPOINT=$INTERNAL_RUNTIME_ENTRYPOINT" > runtime/.open-runtimes
+echo "INTERNAL_RUNTIME_ENTRYPOINT=$INTERNAL_RUNTIME_ENTRYPOINT" > .open-runtimes
 
 # Finish build by preparing tar to use for starting the runtime
-tar --exclude code.tar.gz -zcf /usr/code/code.tar.gz runtime
+tar --exclude code.tar.gz -zcf /usr/code/code.tar.gz runtime .open-runtimes

--- a/runtimes/dart-2.17/start.sh
+++ b/runtimes/dart-2.17/start.sh
@@ -3,5 +3,10 @@ cp /tmp/code.tar.gz /usr/workspace/code.tar.gz
 cd /usr/workspace
 tar -zxf /usr/workspace/code.tar.gz -C /usr/code-start
 rm /usr/workspace/code.tar.gz
+
+set -o allexport
+source /usr/code-start/.open-runtimes
+set +o allexport
+
 cd /usr/code-start
 /usr/code-start/runtime

--- a/runtimes/dart-2.18/README.md
+++ b/runtimes/dart-2.18/README.md
@@ -99,7 +99,7 @@ Future<void> start(final req, final res) async {
 
 - To handle dependencies, you need to have `pubspec.yaml` file. Dependencies will be automatically cached and installed, so you don't need to include any dependencies folders in your function.
 
-- The default entrypoint is `lib/main.dart`. If your entrypoint differs, make sure to configure it using `INTERNAL_RUNTIME_ENTRYPOINT` environment variable, for instance, `INTERNAL_RUNTIME_ENTRYPOINT=lib/app.dart`.
+- The default entrypoint is `lib/main.dart`. If your entrypoint differs, make sure to configure it using `INTERNAL_RUNTIME_ENTRYPOINT` environment variable during build, for instance, `INTERNAL_RUNTIME_ENTRYPOINT=lib/app.dart`.
 
 - Dart function is a Dart library package, which means, your code has to be inside `lib` folder. You can learn more in [Dart documentation](https://dart.dev/guides/libraries/create-library-packages).
 

--- a/runtimes/dart-2.18/build.sh
+++ b/runtimes/dart-2.18/build.sh
@@ -36,5 +36,8 @@ cd /usr/local/src
 # Compile the Code
 dart compile exe server.dart -o runtime
 
+touch .open-runtimes
+echo "INTERNAL_RUNTIME_ENTRYPOINT=$INTERNAL_RUNTIME_ENTRYPOINT" > runtime/.open-runtimes
+
 # Finish build by preparing tar to use for starting the runtime
 tar --exclude code.tar.gz -zcf /usr/code/code.tar.gz runtime

--- a/runtimes/dart-2.18/build.sh
+++ b/runtimes/dart-2.18/build.sh
@@ -37,7 +37,7 @@ cd /usr/local/src
 dart compile exe server.dart -o runtime
 
 touch .open-runtimes
-echo "INTERNAL_RUNTIME_ENTRYPOINT=$INTERNAL_RUNTIME_ENTRYPOINT" > runtime/.open-runtimes
+echo "INTERNAL_RUNTIME_ENTRYPOINT=$INTERNAL_RUNTIME_ENTRYPOINT" > .open-runtimes
 
 # Finish build by preparing tar to use for starting the runtime
-tar --exclude code.tar.gz -zcf /usr/code/code.tar.gz runtime
+tar --exclude code.tar.gz -zcf /usr/code/code.tar.gz runtime .open-runtimes

--- a/runtimes/dart-2.18/start.sh
+++ b/runtimes/dart-2.18/start.sh
@@ -3,5 +3,10 @@ cp /tmp/code.tar.gz /usr/workspace/code.tar.gz
 cd /usr/workspace
 tar -zxf /usr/workspace/code.tar.gz -C /usr/code-start
 rm /usr/workspace/code.tar.gz
+
+set -o allexport
+source /usr/code-start/.open-runtimes
+set +o allexport
+
 cd /usr/code-start
 /usr/code-start/runtime

--- a/runtimes/deno-1.21/README.md
+++ b/runtimes/deno-1.21/README.md
@@ -24,7 +24,7 @@ docker run -e INTERNAL_RUNTIME_ENTRYPOINT=mod.ts --rm --interactive --tty --volu
 3. Spin-up open-runtime:
 
 ```bash
-docker run -p 3000:3000 -e INTERNAL_RUNTIME_KEY=secret-key -e INTERNAL_RUNTIME_ENTRYPOINT=mod.ts --rm --interactive --tty --volume $PWD/code.tar.gz:/tmp/code.tar.gz:ro openruntimes/deno:v2-1.21 sh /usr/local/src/start.sh
+docker run -p 3000:3000 -e INTERNAL_RUNTIME_KEY=secret-key --rm --interactive --tty --volume $PWD/code.tar.gz:/tmp/code.tar.gz:ro openruntimes/deno:v2-1.21 sh /usr/local/src/start.sh
 ```
 
 4. In new terminal window, execute function:
@@ -95,7 +95,7 @@ export default async function(req: any, res: any) {
 
 - Dependencies are handeled automatically. Open Runtimes automatically cache and install them during build process.
 
-- The default entrypoint is `mod.ts`. If your entrypoint differs, make sure to configure it using `INTERNAL_RUNTIME_ENTRYPOINT` environment variable, for instance, `INTERNAL_RUNTIME_ENTRYPOINT=src/app.ts`.
+- The default entrypoint is `mod.ts`. If your entrypoint differs, make sure to configure it using `INTERNAL_RUNTIME_ENTRYPOINT` environment variable during build, for instance, `INTERNAL_RUNTIME_ENTRYPOINT=src/app.ts`.
 
 - Deno runtime currently doesn't support ARM, because there are no official ARM images.
 

--- a/runtimes/deno-1.21/build.sh
+++ b/runtimes/deno-1.21/build.sh
@@ -20,5 +20,8 @@ deno cache server.ts
 cd /usr/builds
 deno cache $INTERNAL_RUNTIME_ENTRYPOINT
 
+touch .open-runtimes
+echo "INTERNAL_RUNTIME_ENTRYPOINT=$INTERNAL_RUNTIME_ENTRYPOINT" > .open-runtimes
+
 # Finish build by preparing tar to use for starting the runtime
 tar --exclude code.tar.gz -zcf /usr/code/code.tar.gz .

--- a/runtimes/deno-1.21/start.sh
+++ b/runtimes/deno-1.21/start.sh
@@ -3,6 +3,11 @@ cp /tmp/code.tar.gz /usr/workspace/code.tar.gz
 cd /usr/workspace 
 tar -zxf /usr/workspace/code.tar.gz -C /usr/code-start
 rm /usr/workspace/code.tar.gz
+
+set -o allexport
+source /usr/code-start/.open-runtimes
+set +o allexport
+
 export DENO_DIR="/usr/code-start/deno-cache"
 cd /usr/local/src/
 denon run --allow-net --allow-write --allow-read --allow-env server.ts

--- a/runtimes/deno-1.24/README.md
+++ b/runtimes/deno-1.24/README.md
@@ -24,7 +24,7 @@ docker run -e INTERNAL_RUNTIME_ENTRYPOINT=mod.ts --rm --interactive --tty --volu
 3. Spin-up open-runtime:
 
 ```bash
-docker run -p 3000:3000 -e INTERNAL_RUNTIME_KEY=secret-key -e INTERNAL_RUNTIME_ENTRYPOINT=mod.ts --rm --interactive --tty --volume $PWD/code.tar.gz:/tmp/code.tar.gz:ro openruntimes/deno:v2-1.24 sh /usr/local/src/start.sh
+docker run -p 3000:3000 -e INTERNAL_RUNTIME_KEY=secret-key --rm --interactive --tty --volume $PWD/code.tar.gz:/tmp/code.tar.gz:ro openruntimes/deno:v2-1.24 sh /usr/local/src/start.sh
 ```
 
 4. In new terminal window, execute function:
@@ -95,7 +95,7 @@ export default async function(req: any, res: any) {
 
 - Dependencies are handeled automatically. Open Runtimes automatically cache and install them during build process.
 
-- The default entrypoint is `mod.ts`. If your entrypoint differs, make sure to configure it using `INTERNAL_RUNTIME_ENTRYPOINT` environment variable, for instance, `INTERNAL_RUNTIME_ENTRYPOINT=src/app.ts`.
+- The default entrypoint is `mod.ts`. If your entrypoint differs, make sure to configure it using `INTERNAL_RUNTIME_ENTRYPOINT` environment variable during build, for instance, `INTERNAL_RUNTIME_ENTRYPOINT=src/app.ts`.
 
 - Deno runtime currently doesn't support ARM, because there are no official ARM images.
 

--- a/runtimes/deno-1.24/build.sh
+++ b/runtimes/deno-1.24/build.sh
@@ -20,5 +20,8 @@ deno cache server.ts
 cd /usr/builds
 deno cache $INTERNAL_RUNTIME_ENTRYPOINT
 
+touch .open-runtimes
+echo "INTERNAL_RUNTIME_ENTRYPOINT=$INTERNAL_RUNTIME_ENTRYPOINT" > .open-runtimes
+
 # Finish build by preparing tar to use for starting the runtime
 tar --exclude code.tar.gz -zcf /usr/code/code.tar.gz .

--- a/runtimes/deno-1.24/start.sh
+++ b/runtimes/deno-1.24/start.sh
@@ -3,6 +3,11 @@ cp /tmp/code.tar.gz /usr/workspace/code.tar.gz
 cd /usr/workspace 
 tar -zxf /usr/workspace/code.tar.gz -C /usr/code-start
 rm /usr/workspace/code.tar.gz
+
+set -o allexport
+source /usr/code-start/.open-runtimes
+set +o allexport
+
 export DENO_DIR="/usr/code-start/deno-cache"
 cd /usr/local/src/
 denon run --allow-net --allow-write --allow-read --allow-env server.ts

--- a/runtimes/dotnet-3.1/README.md
+++ b/runtimes/dotnet-3.1/README.md
@@ -24,7 +24,7 @@ docker run -e INTERNAL_RUNTIME_ENTRYPOINT=Index.cs --rm --interactive --tty --vo
 3. Spin-up open-runtime:
 
 ```bash
-docker run -p 3000:3000 -e INTERNAL_RUNTIME_KEY=secret-key -e INTERNAL_RUNTIME_ENTRYPOINT=Index.cs --rm --interactive --tty --volume $PWD/code.tar.gz:/tmp/code.tar.gz:ro openruntimes/dotnet:v2-3.1 sh /usr/local/src/start.sh
+docker run -p 3000:3000 -e INTERNAL_RUNTIME_KEY=secret-key --rm --interactive --tty --volume $PWD/code.tar.gz:/tmp/code.tar.gz:ro openruntimes/dotnet:v2-3.1 sh /usr/local/src/start.sh
 ```
 
 4. In new terminal window, execute function:
@@ -87,7 +87,7 @@ public async Task<RuntimeResponse> Main(RuntimeRequest req, RuntimeResponse res)
 
 - To handle dependencies, you need to have `csproj` file containing the `PackageReferences` you desire. Dependencies will be automatically cached and installed, so you don't need to include the `.nuget` folder in your function.
 
-- The default entrypoint is `Index.cs`. If your entrypoint differs, make sure to configure it using `INTERNAL_RUNTIME_ENTRYPOINT` environment variable, for instance, `INTERNAL_RUNTIME_ENTRYPOINT=src/App.cs`.
+- The default entrypoint is `Index.cs`. If your entrypoint differs, make sure to configure it using `INTERNAL_RUNTIME_ENTRYPOINT` environment variable during build, for instance, `INTERNAL_RUNTIME_ENTRYPOINT=src/App.cs`.
 
 ## Authors
 

--- a/runtimes/dotnet-3.1/build.sh
+++ b/runtimes/dotnet-3.1/build.sh
@@ -43,6 +43,10 @@ build() {
 
     # Tar the executable
     cd /usr/local/src/bin/Release/netcoreapp3.1/publish/
+
+    touch .open-runtimes
+    echo "INTERNAL_RUNTIME_ENTRYPOINT=$INTERNAL_RUNTIME_ENTRYPOINT" > .open-runtimes
+    
     tar -czf /usr/code/code.tar.gz .
 }
 

--- a/runtimes/dotnet-3.1/start.sh
+++ b/runtimes/dotnet-3.1/start.sh
@@ -3,4 +3,9 @@ cp /tmp/code.tar.gz /usr/code-start/code.tar.gz
 cd /usr/code-start
 tar -xzf /usr/code-start/code.tar.gz
 rm /usr/code-start/code.tar.gz
+
+set -o allexport
+source ./.open-runtimes
+set +o allexport
+
 dotnet DotNetRuntime.dll

--- a/runtimes/dotnet-6.0/README.md
+++ b/runtimes/dotnet-6.0/README.md
@@ -24,7 +24,7 @@ docker run -e INTERNAL_RUNTIME_ENTRYPOINT=Index.cs --rm --interactive --tty --vo
 3. Spin-up open-runtime:
 
 ```bash
-docker run -p 3000:3000 -e INTERNAL_RUNTIME_KEY=secret-key -e INTERNAL_RUNTIME_ENTRYPOINT=Index.cs --rm --interactive --tty --volume $PWD/code.tar.gz:/tmp/code.tar.gz:ro openruntimes/dotnet:v2-6.0 sh /usr/local/src/start.sh
+docker run -p 3000:3000 -e INTERNAL_RUNTIME_KEY=secret-key --rm --interactive --tty --volume $PWD/code.tar.gz:/tmp/code.tar.gz:ro openruntimes/dotnet:v2-6.0 sh /usr/local/src/start.sh
 ```
 
 4. In new terminal window, execute function:
@@ -87,7 +87,7 @@ public async Task<RuntimeResponse> Main(RuntimeRequest req, RuntimeResponse res)
 
 - To handle dependencies, you need to have `csproj` file containing the `PackageReferences` you desire. Dependencies will be automatically cached and installed, so you don't need to include the `.nuget` folder in your function.
 
-- The default entrypoint is `Index.cs`. If your entrypoint differs, make sure to configure it using `INTERNAL_RUNTIME_ENTRYPOINT` environment variable, for instance, `INTERNAL_RUNTIME_ENTRYPOINT=src/App.cs`.
+- The default entrypoint is `Index.cs`. If your entrypoint differs, make sure to configure it using `INTERNAL_RUNTIME_ENTRYPOINT` environment variable during build, for instance, `INTERNAL_RUNTIME_ENTRYPOINT=src/App.cs`.
 
 ## Authors
 

--- a/runtimes/dotnet-6.0/build.sh
+++ b/runtimes/dotnet-6.0/build.sh
@@ -44,6 +44,10 @@ build() {
 
     # Tar the executable
     cd /usr/local/src/bin/Release/net6.0/publish/
+
+    touch .open-runtimes
+    echo "INTERNAL_RUNTIME_ENTRYPOINT=$INTERNAL_RUNTIME_ENTRYPOINT" > .open-runtimes
+
     tar -czf /usr/code/code.tar.gz .
 }
 

--- a/runtimes/dotnet-6.0/start.sh
+++ b/runtimes/dotnet-6.0/start.sh
@@ -3,4 +3,9 @@ cp /tmp/code.tar.gz /usr/code-start/code.tar.gz
 cd /usr/code-start
 tar -xzf /usr/code-start/code.tar.gz
 rm /usr/code-start/code.tar.gz
+
+set -o allexport
+source ./.open-runtimes
+set +o allexport
+
 dotnet DotNetRuntime.dll

--- a/runtimes/java-11.0/README.md
+++ b/runtimes/java-11.0/README.md
@@ -90,7 +90,7 @@ public RuntimeResponse main(RuntimeRequest req, RuntimeResponse res) throws Exce
 
 - To handle dependencies, you need to have any `.gradle` file including a `dependencies` block. Dependencies will be automatically cached and installed, so you don't need to include the `build` folder in your function.
 
-- The default entrypoint is `Index.java`. If your entrypoint differs, make sure to configure it using `INTERNAL_RUNTIME_ENTRYPOINT` environment variable, for instance, `INTERNAL_RUNTIME_ENTRYPOINT=src/App.java`.
+- The default entrypoint is `Index.java`. If your entrypoint differs, make sure to configure it using `INTERNAL_RUNTIME_ENTRYPOINT` environment variable during build, for instance, `INTERNAL_RUNTIME_ENTRYPOINT=src/App.java`.
 
 ## Authors
 

--- a/runtimes/java-11.0/build.sh
+++ b/runtimes/java-11.0/build.sh
@@ -42,4 +42,8 @@ sh gradlew buildJar
 
 # Tar the jar
 cd /usr/local/src/build/libs/
+
+touch .open-runtimes
+echo "INTERNAL_RUNTIME_ENTRYPOINT=$INTERNAL_RUNTIME_ENTRYPOINT" > .open-runtimes
+
 tar -zcvf /usr/code/code.tar.gz .

--- a/runtimes/java-11.0/start.sh
+++ b/runtimes/java-11.0/start.sh
@@ -4,5 +4,10 @@ cp /tmp/code.tar.gz /usr/workspace/code.tar.gz
 cd /usr/workspace
 tar -zxf /usr/workspace/code.tar.gz -C /usr/code
 rm /usr/workspace/code.tar.gz
+
+set -o allexport
+source /usr/code-start/.open-runtimes
+set +o allexport
+
 cd /usr/code
 java -jar java-runtime-1.0.0.jar

--- a/runtimes/java-17.0/README.md
+++ b/runtimes/java-17.0/README.md
@@ -90,7 +90,7 @@ public RuntimeResponse main(RuntimeRequest req, RuntimeResponse res) throws Exce
 
 - To handle dependencies, you need to have any `.gradle` file including a `dependencies` block. Dependencies will be automatically cached and installed, so you don't need to include the `build` folder in your function.
 
-- The default entrypoint is `Index.java`. If your entrypoint differs, make sure to configure it using `INTERNAL_RUNTIME_ENTRYPOINT` environment variable, for instance, `INTERNAL_RUNTIME_ENTRYPOINT=src/App.java`.
+- The default entrypoint is `Index.java`. If your entrypoint differs, make sure to configure it using `INTERNAL_RUNTIME_ENTRYPOINT` environment variable during build, for instance, `INTERNAL_RUNTIME_ENTRYPOINT=src/App.java`.
 
 ## Authors
 

--- a/runtimes/java-17.0/build.sh
+++ b/runtimes/java-17.0/build.sh
@@ -42,4 +42,8 @@ sh gradlew buildJar
 
 # Tar the jar
 cd /usr/local/src/build/libs/
+
+touch .open-runtimes
+echo "INTERNAL_RUNTIME_ENTRYPOINT=$INTERNAL_RUNTIME_ENTRYPOINT" > .open-runtimes
+
 tar -zcvf /usr/code/code.tar.gz .

--- a/runtimes/java-17.0/start.sh
+++ b/runtimes/java-17.0/start.sh
@@ -4,5 +4,10 @@ cp /tmp/code.tar.gz /usr/workspace/code.tar.gz
 cd /usr/workspace
 tar -zxf /usr/workspace/code.tar.gz -C /usr/code
 rm /usr/workspace/code.tar.gz
+
+set -o allexport
+source /usr/code-start/.open-runtimes
+set +o allexport
+
 cd /usr/code
 java -jar java-runtime-1.0.0.jar

--- a/runtimes/java-18.0/README.md
+++ b/runtimes/java-18.0/README.md
@@ -90,7 +90,7 @@ public RuntimeResponse main(RuntimeRequest req, RuntimeResponse res) throws Exce
 
 - To handle dependencies, you need to have any `.gradle` file including a `dependencies` block. Dependencies will be automatically cached and installed, so you don't need to include the `build` folder in your function.
 
-- The default entrypoint is `Index.java`. If your entrypoint differs, make sure to configure it using `INTERNAL_RUNTIME_ENTRYPOINT` environment variable, for instance, `INTERNAL_RUNTIME_ENTRYPOINT=src/App.java`.
+- The default entrypoint is `Index.java`. If your entrypoint differs, make sure to configure it using `INTERNAL_RUNTIME_ENTRYPOINT` environment variable during build, for instance, `INTERNAL_RUNTIME_ENTRYPOINT=src/App.java`.
 
 ## Authors
 

--- a/runtimes/java-18.0/build.sh
+++ b/runtimes/java-18.0/build.sh
@@ -42,4 +42,8 @@ sh gradlew buildJar
 
 # Tar the jar
 cd /usr/local/src/build/libs/
+
+touch .open-runtimes
+echo "INTERNAL_RUNTIME_ENTRYPOINT=$INTERNAL_RUNTIME_ENTRYPOINT" > .open-runtimes
+
 tar -zcvf /usr/code/code.tar.gz .

--- a/runtimes/java-18.0/start.sh
+++ b/runtimes/java-18.0/start.sh
@@ -4,5 +4,10 @@ cp /tmp/code.tar.gz /usr/workspace/code.tar.gz
 cd /usr/workspace
 tar -zxf /usr/workspace/code.tar.gz -C /usr/code
 rm /usr/workspace/code.tar.gz
+
+set -o allexport
+source /usr/code-start/.open-runtimes
+set +o allexport
+
 cd /usr/code
 java -jar java-runtime-1.0.0.jar

--- a/runtimes/java-8.0/README.md
+++ b/runtimes/java-8.0/README.md
@@ -90,7 +90,7 @@ public RuntimeResponse main(RuntimeRequest req, RuntimeResponse res) throws Exce
 
 - To handle dependencies, you need to have any `.gradle` file including a `dependencies` block. Dependencies will be automatically cached and installed, so you don't need to include the `build` folder in your function.
 
-- The default entrypoint is `Index.java`. If your entrypoint differs, make sure to configure it using `INTERNAL_RUNTIME_ENTRYPOINT` environment variable, for instance, `INTERNAL_RUNTIME_ENTRYPOINT=src/App.java`.
+- The default entrypoint is `Index.java`. If your entrypoint differs, make sure to configure it using `INTERNAL_RUNTIME_ENTRYPOINT` environment variable during build, for instance, `INTERNAL_RUNTIME_ENTRYPOINT=src/App.java`.
 
 ## Authors
 

--- a/runtimes/java-8.0/build.sh
+++ b/runtimes/java-8.0/build.sh
@@ -42,4 +42,8 @@ sh gradlew buildJar
 
 # Tar the jar
 cd /usr/local/src/build/libs/
+
+touch .open-runtimes
+echo "INTERNAL_RUNTIME_ENTRYPOINT=$INTERNAL_RUNTIME_ENTRYPOINT" > .open-runtimes
+
 tar -zcvf /usr/code/code.tar.gz .

--- a/runtimes/java-8.0/start.sh
+++ b/runtimes/java-8.0/start.sh
@@ -4,5 +4,10 @@ cp /tmp/code.tar.gz /usr/workspace/code.tar.gz
 cd /usr/workspace
 tar -zxf /usr/workspace/code.tar.gz -C /usr/code
 rm /usr/workspace/code.tar.gz
+
+set -o allexport
+source /usr/code-start/.open-runtimes
+set +o allexport
+
 cd /usr/code
 java -jar java-runtime-1.0.0.jar

--- a/runtimes/kotlin-1.6/README.md
+++ b/runtimes/kotlin-1.6/README.md
@@ -86,7 +86,7 @@ fun main(req: RuntimeRequest, res: RuntimeResponse): RuntimeResponse = res.json(
 
 - To handle dependencies, you need to have any `.gradle` file including a `dependencies` block. Dependencies will be automatically cached and installed, so you don't need to include the `build` folder in your function.
 
-- The default entrypoint is `Index.kt`. If your entrypoint differs, make sure to configure it using `INTERNAL_RUNTIME_ENTRYPOINT` environment variable, for instance, `INTERNAL_RUNTIME_ENTRYPOINT=src/App.kt`.
+- The default entrypoint is `Index.kt`. If your entrypoint differs, make sure to configure it using `INTERNAL_RUNTIME_ENTRYPOINT` environment variable during build, for instance, `INTERNAL_RUNTIME_ENTRYPOINT=src/App.kt`.
 
 ## Authors
 

--- a/runtimes/kotlin-1.6/build.sh
+++ b/runtimes/kotlin-1.6/build.sh
@@ -42,4 +42,8 @@ sh gradlew buildJar
 
 # Tar the jar
 cd /usr/local/src/build/libs/
+
+touch .open-runtimes
+echo "INTERNAL_RUNTIME_ENTRYPOINT=$INTERNAL_RUNTIME_ENTRYPOINT" > .open-runtimes
+
 tar -zcvf /usr/code/code.tar.gz .

--- a/runtimes/kotlin-1.6/start.sh
+++ b/runtimes/kotlin-1.6/start.sh
@@ -4,5 +4,10 @@ cp /tmp/code.tar.gz /usr/workspace/code.tar.gz
 cd /usr/workspace
 tar -zxf /usr/workspace/code.tar.gz -C /usr/code
 rm /usr/workspace/code.tar.gz
+
+set -o allexport
+source /usr/code-start/.open-runtimes
+set +o allexport
+
 cd /usr/code
 java -jar kotlin-runtime-1.0.0.jar

--- a/runtimes/node-14.5/README.md
+++ b/runtimes/node-14.5/README.md
@@ -18,13 +18,13 @@ printf "module.exports = async (req, res) => {\n    res.json({ n: Math.random() 
 2. Build the code:
 
 ```bash
-docker run --rm --interactive --tty --volume $PWD:/usr/code openruntimes/node:v2-14.5 sh /usr/local/src/build.sh
+docker run -e INTERNAL_RUNTIME_ENTRYPOINT=index.js --rm --interactive --tty --volume $PWD:/usr/code openruntimes/node:v2-14.5 sh /usr/local/src/build.sh
 ```
 
 3. Spin-up open-runtime:
 
 ```bash
-docker run -p 3000:3000 -e INTERNAL_RUNTIME_KEY=secret-key -e INTERNAL_RUNTIME_ENTRYPOINT=index.js --rm --interactive --tty --volume $PWD/code.tar.gz:/tmp/code.tar.gz:ro openruntimes/node:v2-14.5 sh /usr/local/src/start.sh
+docker run -p 3000:3000 -e INTERNAL_RUNTIME_KEY=secret-key --rm --interactive --tty --volume $PWD/code.tar.gz:/tmp/code.tar.gz:ro openruntimes/node:v2-14.5 sh /usr/local/src/start.sh
 ```
 
 4. In new terminal window, execute function:
@@ -95,7 +95,7 @@ module.exports = (req, res) => {
 
 - To handle dependencies, you need to have `package.json` file. Dependencies will be automatically cached and installed, so you don't need to include `node_modules` folder in your function.
 
-- The default entrypoint is `index.js`. If your entrypoint differs, make sure to configure it using `INTERNAL_RUNTIME_ENTRYPOINT` environment variable, for instance, `INTERNAL_RUNTIME_ENTRYPOINT=src/app.js`.
+- The default entrypoint is `index.js`. If your entrypoint differs, make sure to configure it using `INTERNAL_RUNTIME_ENTRYPOINT` environment variable during build, for instance, `INTERNAL_RUNTIME_ENTRYPOINT=src/app.js`.
 
 
 ## Authors

--- a/runtimes/node-14.5/build.sh
+++ b/runtimes/node-14.5/build.sh
@@ -17,5 +17,8 @@ mkdir -p node_modules
 # Merge the node_modules from the server into the user's node_modules to be restored later.
 cp -R /usr/local/src/node_modules/* /usr/builds/node_modules
 
+touch .open-runtimes
+echo "INTERNAL_RUNTIME_ENTRYPOINT=$INTERNAL_RUNTIME_ENTRYPOINT" > .open-runtimes
+
 # Finish build by preparing tar to use for starting the runtime
 tar --exclude code.tar.gz -zcf /usr/code/code.tar.gz .

--- a/runtimes/node-14.5/start.sh
+++ b/runtimes/node-14.5/start.sh
@@ -3,6 +3,11 @@ cp /tmp/code.tar.gz /usr/workspace/code.tar.gz
 cd /usr/workspace
 tar -zxf /usr/workspace/code.tar.gz -C /usr/code-start
 rm /usr/workspace/code.tar.gz
+
+set -o allexport
+source /usr/code-start/.open-runtimes
+set +o allexport
+
 cp -R /usr/code-start/node_modules/* /usr/local/src/node_modules
 cd /usr/local/src
 npm start

--- a/runtimes/node-16.0/README.md
+++ b/runtimes/node-16.0/README.md
@@ -18,13 +18,13 @@ printf "module.exports = async (req, res) => {\n    res.json({ n: Math.random() 
 2. Build the code:
 
 ```bash
-docker run --rm --interactive --tty --volume $PWD:/usr/code openruntimes/node:v2-16.0 sh /usr/local/src/build.sh
+docker run -e INTERNAL_RUNTIME_ENTRYPOINT=index.js --rm --interactive --tty --volume $PWD:/usr/code openruntimes/node:v2-16.0 sh /usr/local/src/build.sh
 ```
 
 3. Spin-up open-runtime:
 
 ```bash
-docker run -p 3000:3000 -e INTERNAL_RUNTIME_KEY=secret-key -e INTERNAL_RUNTIME_ENTRYPOINT=index.js --rm --interactive --tty --volume $PWD/code.tar.gz:/tmp/code.tar.gz:ro openruntimes/node:v2-16.0 sh /usr/local/src/start.sh
+docker run -p 3000:3000 -e INTERNAL_RUNTIME_KEY=secret-key --rm --interactive --tty --volume $PWD/code.tar.gz:/tmp/code.tar.gz:ro openruntimes/node:v2-16.0 sh /usr/local/src/start.sh
 ```
 
 4. In new terminal window, execute function:
@@ -95,7 +95,7 @@ module.exports = (req, res) => {
 
 - To handle dependencies, you need to have `package.json` file. Dependencies will be automatically cached and installed, so you don't need to include `node_modules` folder in your function.
 
-- The default entrypoint is `index.js`. If your entrypoint differs, make sure to configure it using `INTERNAL_RUNTIME_ENTRYPOINT` environment variable, for instance, `INTERNAL_RUNTIME_ENTRYPOINT=src/app.js`.
+- The default entrypoint is `index.js`. If your entrypoint differs, make sure to configure it using `INTERNAL_RUNTIME_ENTRYPOINT` environment variable during build, for instance, `INTERNAL_RUNTIME_ENTRYPOINT=src/app.js`.
 
 
 ## Authors

--- a/runtimes/node-16.0/build.sh
+++ b/runtimes/node-16.0/build.sh
@@ -17,5 +17,8 @@ mkdir -p node_modules
 # Merge the node_modules from the server into the user's node_modules to be restored later.
 cp -R /usr/local/src/node_modules/* /usr/builds/node_modules
 
+touch .open-runtimes
+echo "INTERNAL_RUNTIME_ENTRYPOINT=$INTERNAL_RUNTIME_ENTRYPOINT" > .open-runtimes
+
 # Finish build by preparing tar to use for starting the runtime
 tar --exclude code.tar.gz -zcf /usr/code/code.tar.gz .

--- a/runtimes/node-16.0/start.sh
+++ b/runtimes/node-16.0/start.sh
@@ -3,6 +3,11 @@ cp /tmp/code.tar.gz /usr/workspace/code.tar.gz
 cd /usr/workspace
 tar -zxf /usr/workspace/code.tar.gz -C /usr/code-start
 rm /usr/workspace/code.tar.gz
+
+set -o allexport
+source /usr/code-start/.open-runtimes
+set +o allexport
+
 cp -R /usr/code-start/node_modules/* /usr/local/src/node_modules
 cd /usr/local/src
 npm start

--- a/runtimes/node-18.0/README.md
+++ b/runtimes/node-18.0/README.md
@@ -18,13 +18,13 @@ printf "module.exports = async (req, res) => {\n    res.json({ n: Math.random() 
 2. Build the code:
 
 ```bash
-docker run --rm --interactive --tty --volume $PWD:/usr/code openruntimes/node:v2-18.0 sh /usr/local/src/build.sh
+docker run -e INTERNAL_RUNTIME_ENTRYPOINT=index.js --rm --interactive --tty --volume $PWD:/usr/code openruntimes/node:v2-18.0 sh /usr/local/src/build.sh
 ```
 
 3. Spin-up open-runtime:
 
 ```bash
-docker run -p 3000:3000 -e INTERNAL_RUNTIME_KEY=secret-key -e INTERNAL_RUNTIME_ENTRYPOINT=index.js --rm --interactive --tty --volume $PWD/code.tar.gz:/tmp/code.tar.gz:ro openruntimes/node:v2-18.0 sh /usr/local/src/start.sh
+docker run -p 3000:3000 -e INTERNAL_RUNTIME_KEY=secret-key --rm --interactive --tty --volume $PWD/code.tar.gz:/tmp/code.tar.gz:ro openruntimes/node:v2-18.0 sh /usr/local/src/start.sh
 ```
 
 4. In new terminal window, execute function:
@@ -95,7 +95,7 @@ module.exports = (req, res) => {
 
 - To handle dependencies, you need to have `package.json` file. Dependencies will be automatically cached and installed, so you don't need to include `node_modules` folder in your function.
 
-- The default entrypoint is `index.js`. If your entrypoint differs, make sure to configure it using `INTERNAL_RUNTIME_ENTRYPOINT` environment variable, for instance, `INTERNAL_RUNTIME_ENTRYPOINT=src/app.js`.
+- The default entrypoint is `index.js`. If your entrypoint differs, make sure to configure it using `INTERNAL_RUNTIME_ENTRYPOINT` environment variable during build, for instance, `INTERNAL_RUNTIME_ENTRYPOINT=src/app.js`.
 
 
 ## Authors

--- a/runtimes/node-18.0/build.sh
+++ b/runtimes/node-18.0/build.sh
@@ -17,5 +17,8 @@ mkdir -p node_modules
 # Merge the node_modules from the server into the user's node_modules to be restored later.
 cp -R /usr/local/src/node_modules/* /usr/builds/node_modules
 
+touch .open-runtimes
+echo "$INTERNAL_RUNTIME_ENTRYPOINT" > .open-runtimes
+
 # Finish build by preparing tar to use for starting the runtime
 tar --exclude code.tar.gz -zcf /usr/code/code.tar.gz .

--- a/runtimes/node-18.0/build.sh
+++ b/runtimes/node-18.0/build.sh
@@ -18,7 +18,7 @@ mkdir -p node_modules
 cp -R /usr/local/src/node_modules/* /usr/builds/node_modules
 
 touch .open-runtimes
-echo "$INTERNAL_RUNTIME_ENTRYPOINT" > .open-runtimes
+echo "INTERNAL_RUNTIME_ENTRYPOINT=$INTERNAL_RUNTIME_ENTRYPOINT" > .open-runtimes
 
 # Finish build by preparing tar to use for starting the runtime
 tar --exclude code.tar.gz -zcf /usr/code/code.tar.gz .

--- a/runtimes/node-18.0/start.sh
+++ b/runtimes/node-18.0/start.sh
@@ -3,6 +3,7 @@ cp /tmp/code.tar.gz /usr/workspace/code.tar.gz
 cd /usr/workspace
 tar -zxf /usr/workspace/code.tar.gz -C /usr/code-start
 rm /usr/workspace/code.tar.gz
+env $(cat /usr/code-start/.open-runtimes | xargs)
 cp -R /usr/code-start/node_modules/* /usr/local/src/node_modules
 cd /usr/local/src
 npm start

--- a/runtimes/node-18.0/start.sh
+++ b/runtimes/node-18.0/start.sh
@@ -3,7 +3,11 @@ cp /tmp/code.tar.gz /usr/workspace/code.tar.gz
 cd /usr/workspace
 tar -zxf /usr/workspace/code.tar.gz -C /usr/code-start
 rm /usr/workspace/code.tar.gz
-env $(cat /usr/code-start/.open-runtimes | xargs)
+
+set -o allexport
+source /usr/code-start/.open-runtimes
+set +o allexport
+
 cp -R /usr/code-start/node_modules/* /usr/local/src/node_modules
 cd /usr/local/src
 npm start

--- a/runtimes/php-8.0/README.md
+++ b/runtimes/php-8.0/README.md
@@ -18,13 +18,13 @@ printf "<?\nreturn function(\$req, \$res) {\n    \$res->json([ 'n' => \mt_rand()
 2. Build the code:
 
 ```bash
-docker run --rm --interactive --tty --volume $PWD:/usr/code openruntimes/php:v2-8.0 sh /usr/local/src/build.sh
+docker run -e INTERNAL_RUNTIME_ENTRYPOINT=index.php --rm --interactive --tty --volume $PWD:/usr/code openruntimes/php:v2-8.0 sh /usr/local/src/build.sh
 ```
 
 3. Spin-up open-runtime:
 
 ```bash
-docker run -p 3000:3000 -e INTERNAL_RUNTIME_KEY=secret-key -e INTERNAL_RUNTIME_ENTRYPOINT=index.php --rm --interactive --tty --volume $PWD/code.tar.gz:/tmp/code.tar.gz:ro openruntimes/php:v2-8.0 sh /usr/local/src/start.sh
+docker run -p 3000:3000 -e INTERNAL_RUNTIME_KEY=secret-key --rm --interactive --tty --volume $PWD/code.tar.gz:/tmp/code.tar.gz:ro openruntimes/php:v2-8.0 sh /usr/local/src/start.sh
 ```
 
 4. In new terminal window, execute function:
@@ -103,7 +103,7 @@ return function($req, $res) {
 require 'vendor/autoload.php';
 ```
 
-- The default entrypoint is `index.php`. If your entrypoint differs, make sure to configure it using `INTERNAL_RUNTIME_ENTRYPOINT` environment variable, for instance, `INTERNAL_RUNTIME_ENTRYPOINT=src/app.php`.
+- The default entrypoint is `index.php`. If your entrypoint differs, make sure to configure it using `INTERNAL_RUNTIME_ENTRYPOINT` environment variable during build, for instance, `INTERNAL_RUNTIME_ENTRYPOINT=src/app.php`.
 
 ## Authors
 

--- a/runtimes/php-8.0/build.sh
+++ b/runtimes/php-8.0/build.sh
@@ -21,4 +21,8 @@ cp -r /usr/local/src/vendor /usr/builds/vendor
 
 # Finish build by preparing tar to use for starting the runtime
 cd /usr/builds
+
+touch .open-runtimes
+echo "INTERNAL_RUNTIME_ENTRYPOINT=$INTERNAL_RUNTIME_ENTRYPOINT" > .open-runtimes
+
 tar --exclude code.tar.gz -zcf /usr/code/code.tar.gz .

--- a/runtimes/php-8.0/start.sh
+++ b/runtimes/php-8.0/start.sh
@@ -3,6 +3,11 @@ cp /tmp/code.tar.gz /usr/workspace/code.tar.gz
 cd /usr/workspace/
 tar -zxf /usr/workspace/code.tar.gz -C /usr/code-start
 rm /usr/workspace/code.tar.gz
+
+set -o allexport
+source /usr/code-start/.open-runtimes
+set +o allexport
+
 cp -r /usr/code-start/vendor /usr/local/src/vendor
 cd /usr/local/src/
 php server.php

--- a/runtimes/php-8.1/README.md
+++ b/runtimes/php-8.1/README.md
@@ -18,13 +18,13 @@ printf "<?\nreturn function(\$req, \$res) {\n    \$res->json([ 'n' => \mt_rand()
 2. Build the code:
 
 ```bash
-docker run --rm --interactive --tty --volume $PWD:/usr/code openruntimes/php:v2-8.1 sh /usr/local/src/build.sh
+docker run -e INTERNAL_RUNTIME_ENTRYPOINT=index.php --rm --interactive --tty --volume $PWD:/usr/code openruntimes/php:v2-8.1 sh /usr/local/src/build.sh
 ```
 
 3. Spin-up open-runtime:
 
 ```bash
-docker run -p 3000:3000 -e INTERNAL_RUNTIME_KEY=secret-key -e INTERNAL_RUNTIME_ENTRYPOINT=index.php --rm --interactive --tty --volume $PWD/code.tar.gz:/tmp/code.tar.gz:ro openruntimes/php:v2-8.1 sh /usr/local/src/start.sh
+docker run -p 3000:3000 -e INTERNAL_RUNTIME_KEY=secret-key --rm --interactive --tty --volume $PWD/code.tar.gz:/tmp/code.tar.gz:ro openruntimes/php:v2-8.1 sh /usr/local/src/start.sh
 ```
 
 4. In new terminal window, execute function:
@@ -103,7 +103,7 @@ return function($req, $res) {
 require 'vendor/autoload.php';
 ```
 
-- The default entrypoint is `index.php`. If your entrypoint differs, make sure to configure it using `INTERNAL_RUNTIME_ENTRYPOINT` environment variable, for instance, `INTERNAL_RUNTIME_ENTRYPOINT=src/app.php`.
+- The default entrypoint is `index.php`. If your entrypoint differs, make sure to configure it using `INTERNAL_RUNTIME_ENTRYPOINT` environment variable during build, for instance, `INTERNAL_RUNTIME_ENTRYPOINT=src/app.php`.
 
 ## Authors
 

--- a/runtimes/php-8.1/build.sh
+++ b/runtimes/php-8.1/build.sh
@@ -21,4 +21,8 @@ cp -r /usr/local/src/vendor /usr/builds/vendor
 
 # Finish build by preparing tar to use for starting the runtime
 cd /usr/builds
+
+touch .open-runtimes
+echo "INTERNAL_RUNTIME_ENTRYPOINT=$INTERNAL_RUNTIME_ENTRYPOINT" > .open-runtimes
+
 tar --exclude code.tar.gz -zcf /usr/code/code.tar.gz .

--- a/runtimes/php-8.1/start.sh
+++ b/runtimes/php-8.1/start.sh
@@ -3,6 +3,11 @@ cp /tmp/code.tar.gz /usr/workspace/code.tar.gz
 cd /usr/workspace/
 tar -zxf /usr/workspace/code.tar.gz -C /usr/code-start
 rm /usr/workspace/code.tar.gz
+
+set -o allexport
+source /usr/code-start/.open-runtimes
+set +o allexport
+
 cp -r /usr/code-start/vendor /usr/local/src/vendor
 cd /usr/local/src/
 php server.php

--- a/runtimes/python-3.10/README.md
+++ b/runtimes/python-3.10/README.md
@@ -18,13 +18,13 @@ printf "import random\n\ndef main(req, res):\n    return res.json({'n': random.r
 2. Build the code:
 
 ```bash
-docker run --rm --interactive --tty --volume $PWD:/usr/code openruntimes/python:v2-3.10 sh /usr/local/src/build.sh
+docker run -e INTERNAL_RUNTIME_ENTRYPOINT=main.py --rm --interactive --tty --volume $PWD:/usr/code openruntimes/python:v2-3.10 sh /usr/local/src/build.sh
 ```
 
 3. Spin-up open-runtime:
 
 ```bash
-docker run -p 3000:3000 -e INTERNAL_RUNTIME_KEY=secret-key -e INTERNAL_RUNTIME_ENTRYPOINT=main.py --rm --interactive --tty --volume $PWD/code.tar.gz:/tmp/code.tar.gz:ro openruntimes/python:v2-3.10 sh /usr/local/src/start.sh
+docker run -p 3000:3000 -e INTERNAL_RUNTIME_KEY=secret-key --rm --interactive --tty --volume $PWD/code.tar.gz:/tmp/code.tar.gz:ro openruntimes/python:v2-3.10 sh /usr/local/src/start.sh
 ```
 
 4. In new terminal window, execute function:
@@ -93,7 +93,7 @@ def main(req, res):
 
 - To handle dependencies, you need to have `requirements.txt` file. Dependencies will be automatically cached and installed, so you don't need to include `__pycache__` folder in your function.
 
-- The default entrypoint is `main.py`. If your entrypoint differs, make sure to configure it using `INTERNAL_RUNTIME_ENTRYPOINT` environment variable, for instance, `INTERNAL_RUNTIME_ENTRYPOINT=src/app.py`.
+- The default entrypoint is `main.py`. If your entrypoint differs, make sure to configure it using `INTERNAL_RUNTIME_ENTRYPOINT` environment variable during build, for instance, `INTERNAL_RUNTIME_ENTRYPOINT=src/app.py`.
 
 ## Authors
 

--- a/runtimes/python-3.10/build.sh
+++ b/runtimes/python-3.10/build.sh
@@ -20,4 +20,8 @@ pip install --no-cache-dir -r requirements.txt
 
 # Finish build by preparing tar to use for starting the runtime
 cd /usr/builds
+
+touch .open-runtimes
+echo "INTERNAL_RUNTIME_ENTRYPOINT=$INTERNAL_RUNTIME_ENTRYPOINT" > .open-runtimes
+
 tar --exclude code.tar.gz -zcf /usr/code/code.tar.gz .

--- a/runtimes/python-3.10/start.sh
+++ b/runtimes/python-3.10/start.sh
@@ -5,6 +5,11 @@ mkdir -p userlib
 cd /usr/workspace
 tar -zxf /usr/workspace/code.tar.gz -C /usr/local/src/userlib
 rm /usr/workspace/code.tar.gz
+
+set -o allexport
+source /usr/local/src/userlib/.open-runtimes
+set +o allexport
+
 source /usr/local/src/userlib/runtime-env/bin/activate
 export VIRTUAL_ENV="/usr/local/src/userlib/runtime-env"
 export PATH="$VIRTUAL_ENV/bin:$PATH"

--- a/runtimes/python-3.8/README.md
+++ b/runtimes/python-3.8/README.md
@@ -18,13 +18,13 @@ printf "import random\n\ndef main(req, res):\n    return res.json({'n': random.r
 2. Build the code:
 
 ```bash
-docker run --rm --interactive --tty --volume $PWD:/usr/code openruntimes/python:v2-3.8 sh /usr/local/src/build.sh
+docker run -e INTERNAL_RUNTIME_ENTRYPOINT=main.py --rm --interactive --tty --volume $PWD:/usr/code openruntimes/python:v2-3.8 sh /usr/local/src/build.sh
 ```
 
 3. Spin-up open-runtime:
 
 ```bash
-docker run -p 3000:3000 -e INTERNAL_RUNTIME_KEY=secret-key -e INTERNAL_RUNTIME_ENTRYPOINT=main.py --rm --interactive --tty --volume $PWD/code.tar.gz:/tmp/code.tar.gz:ro openruntimes/python:v2-3.8 sh /usr/local/src/start.sh
+docker run -p 3000:3000 -e INTERNAL_RUNTIME_KEY=secret-key --rm --interactive --tty --volume $PWD/code.tar.gz:/tmp/code.tar.gz:ro openruntimes/python:v2-3.8 sh /usr/local/src/start.sh
 ```
 
 4. In new terminal window, execute function:
@@ -93,7 +93,7 @@ def main(req, res):
 
 - To handle dependencies, you need to have `requirements.txt` file. Dependencies will be automatically cached and installed, so you don't need to include `__pycache__` folder in your function.
 
-- The default entrypoint is `main.py`. If your entrypoint differs, make sure to configure it using `INTERNAL_RUNTIME_ENTRYPOINT` environment variable, for instance, `INTERNAL_RUNTIME_ENTRYPOINT=src/app.py`.
+- The default entrypoint is `main.py`. If your entrypoint differs, make sure to configure it using `INTERNAL_RUNTIME_ENTRYPOINT` environment variable during build, for instance, `INTERNAL_RUNTIME_ENTRYPOINT=src/app.py`.
 
 ## Authors
 

--- a/runtimes/python-3.8/build.sh
+++ b/runtimes/python-3.8/build.sh
@@ -20,4 +20,8 @@ pip install --no-cache-dir -r requirements.txt
 
 # Finish build by preparing tar to use for starting the runtime
 cd /usr/builds
+
+touch .open-runtimes
+echo "INTERNAL_RUNTIME_ENTRYPOINT=$INTERNAL_RUNTIME_ENTRYPOINT" > .open-runtimes
+
 tar --exclude code.tar.gz -zcf /usr/code/code.tar.gz .

--- a/runtimes/python-3.8/start.sh
+++ b/runtimes/python-3.8/start.sh
@@ -5,6 +5,11 @@ mkdir -p userlib
 cd /usr/workspace
 tar -zxf /usr/workspace/code.tar.gz -C /usr/local/src/userlib
 rm /usr/workspace/code.tar.gz
+
+set -o allexport
+source /usr/local/src/userlib/.open-runtimes
+set +o allexport
+
 source /usr/local/src/userlib/runtime-env/bin/activate
 export VIRTUAL_ENV="/usr/local/src/userlib/runtime-env"
 export PATH="$VIRTUAL_ENV/bin:$PATH"

--- a/runtimes/python-3.9/README.md
+++ b/runtimes/python-3.9/README.md
@@ -18,13 +18,13 @@ printf "import random\n\ndef main(req, res):\n    return res.json({'n': random.r
 2. Build the code:
 
 ```bash
-docker run --rm --interactive --tty --volume $PWD:/usr/code openruntimes/python:v2-3.9 sh /usr/local/src/build.sh
+docker run -e INTERNAL_RUNTIME_ENTRYPOINT=main.py --rm --interactive --tty --volume $PWD:/usr/code openruntimes/python:v2-3.9 sh /usr/local/src/build.sh
 ```
 
 3. Spin-up open-runtime:
 
 ```bash
-docker run -p 3000:3000 -e INTERNAL_RUNTIME_KEY=secret-key -e INTERNAL_RUNTIME_ENTRYPOINT=main.py --rm --interactive --tty --volume $PWD/code.tar.gz:/tmp/code.tar.gz:ro openruntimes/python:v2-3.9 sh /usr/local/src/start.sh
+docker run -p 3000:3000 -e INTERNAL_RUNTIME_KEY=secret-key --rm --interactive --tty --volume $PWD/code.tar.gz:/tmp/code.tar.gz:ro openruntimes/python:v2-3.9 sh /usr/local/src/start.sh
 ```
 
 4. In new terminal window, execute function:
@@ -93,7 +93,7 @@ def main(req, res):
 
 - To handle dependencies, you need to have `requirements.txt` file. Dependencies will be automatically cached and installed, so you don't need to include `__pycache__` folder in your function.
 
-- The default entrypoint is `main.py`. If your entrypoint differs, make sure to configure it using `INTERNAL_RUNTIME_ENTRYPOINT` environment variable, for instance, `INTERNAL_RUNTIME_ENTRYPOINT=src/app.py`.
+- The default entrypoint is `main.py`. If your entrypoint differs, make sure to configure it using `INTERNAL_RUNTIME_ENTRYPOINT` environment variable during build, for instance, `INTERNAL_RUNTIME_ENTRYPOINT=src/app.py`.
 
 ## Authors
 

--- a/runtimes/python-3.9/build.sh
+++ b/runtimes/python-3.9/build.sh
@@ -20,4 +20,8 @@ pip install --no-cache-dir -r requirements.txt
 
 # Finish build by preparing tar to use for starting the runtime
 cd /usr/builds
+
+touch .open-runtimes
+echo "INTERNAL_RUNTIME_ENTRYPOINT=$INTERNAL_RUNTIME_ENTRYPOINT" > .open-runtimes
+
 tar --exclude code.tar.gz -zcf /usr/code/code.tar.gz .

--- a/runtimes/python-3.9/start.sh
+++ b/runtimes/python-3.9/start.sh
@@ -5,6 +5,11 @@ mkdir -p userlib
 cd /usr/workspace
 tar -zxf /usr/workspace/code.tar.gz -C /usr/local/src/userlib
 rm /usr/workspace/code.tar.gz
+
+set -o allexport
+source /usr/local/src/userlib/.open-runtimes
+set +o allexport
+
 source /usr/local/src/userlib/runtime-env/bin/activate
 export VIRTUAL_ENV="/usr/local/src/userlib/runtime-env"
 export PATH="$VIRTUAL_ENV/bin:$PATH"

--- a/runtimes/ruby-3.0/README.md
+++ b/runtimes/ruby-3.0/README.md
@@ -18,13 +18,13 @@ printf "def main(request, response)\n    return response.json({:n => rand()})\ne
 2. Build the code:
 
 ```bash
-docker run --rm --interactive --tty --volume $PWD:/usr/code openruntimes/ruby:v2-3.0 sh /usr/local/src/build.sh
+docker run -e INTERNAL_RUNTIME_ENTRYPOINT=index.rb --rm --interactive --tty --volume $PWD:/usr/code openruntimes/ruby:v2-3.0 sh /usr/local/src/build.sh
 ```
 
 3. Spin-up open-runtime:
 
 ```bash
-docker run -p 3000:3000 -e INTERNAL_RUNTIME_KEY=secret-key -e INTERNAL_RUNTIME_ENTRYPOINT=index.rb --rm --interactive --tty --volume $PWD/code.tar.gz:/tmp/code.tar.gz:ro openruntimes/ruby:v2-3.0 sh /usr/local/src/start.sh
+docker run -p 3000:3000 -e INTERNAL_RUNTIME_KEY=secret-key --rm --interactive --tty --volume $PWD/code.tar.gz:/tmp/code.tar.gz:ro openruntimes/ruby:v2-3.0 sh /usr/local/src/start.sh
 ```
 
 4. In new terminal window, execute function:
@@ -95,7 +95,7 @@ end
 
 - To handle dependencies, you need to have `Gemfile` file. Dependencies will be automatically cached and installed, so you don't need to include any local denepdencies folder in your function.
 
-- The default entrypoint is `index.rb`. If your entrypoint differs, make sure to configure it using `INTERNAL_RUNTIME_ENTRYPOINT` environment variable, for instance, `INTERNAL_RUNTIME_ENTRYPOINT=src/app.rb`.
+- The default entrypoint is `index.rb`. If your entrypoint differs, make sure to configure it using `INTERNAL_RUNTIME_ENTRYPOINT` environment variable during build, for instance, `INTERNAL_RUNTIME_ENTRYPOINT=src/app.rb`.
 
 
 ## Authors

--- a/runtimes/ruby-3.0/build.sh
+++ b/runtimes/ruby-3.0/build.sh
@@ -25,4 +25,8 @@ fi
 # Finish build by preparing tar to use for starting the runtime
 cd /usr/builds
 cp -R /usr/local/src/vendor .
+
+touch .open-runtimes
+echo "INTERNAL_RUNTIME_ENTRYPOINT=$INTERNAL_RUNTIME_ENTRYPOINT" > .open-runtimes
+
 tar --exclude code.tar.gz -zcf /usr/code/code.tar.gz .

--- a/runtimes/ruby-3.0/start.sh
+++ b/runtimes/ruby-3.0/start.sh
@@ -3,6 +3,11 @@ cp /tmp/code.tar.gz /usr/workspace/code.tar.gz
 cd /usr/workspace
 tar -zxf /usr/workspace/code.tar.gz -C /usr/code-start
 rm /usr/workspace/code.tar.gz
+
+set -o allexport
+source /usr/code-start/.open-runtimes
+set +o allexport
+
 cd /usr/local/src
 cp -R /usr/code-start/vendor .
 

--- a/runtimes/ruby-3.1/README.md
+++ b/runtimes/ruby-3.1/README.md
@@ -18,13 +18,13 @@ printf "def main(request, response)\n    return response.json({:n => rand()})\ne
 2. Build the code:
 
 ```bash
-docker run --rm --interactive --tty --volume $PWD:/usr/code openruntimes/ruby:v2-3.1 sh /usr/local/src/build.sh
+docker run -e INTERNAL_RUNTIME_ENTRYPOINT=index.rb --rm --interactive --tty --volume $PWD:/usr/code openruntimes/ruby:v2-3.1 sh /usr/local/src/build.sh
 ```
 
 3. Spin-up open-runtime:
 
 ```bash
-docker run -p 3000:3000 -e INTERNAL_RUNTIME_KEY=secret-key -e INTERNAL_RUNTIME_ENTRYPOINT=index.rb --rm --interactive --tty --volume $PWD/code.tar.gz:/tmp/code.tar.gz:ro openruntimes/ruby:v2-3.1 sh /usr/local/src/start.sh
+docker run -p 3000:3000 -e INTERNAL_RUNTIME_KEY=secret-key --rm --interactive --tty --volume $PWD/code.tar.gz:/tmp/code.tar.gz:ro openruntimes/ruby:v2-3.1 sh /usr/local/src/start.sh
 ```
 
 4. In new terminal window, execute function:
@@ -95,7 +95,7 @@ end
 
 - To handle dependencies, you need to have `Gemfile` file. Dependencies will be automatically cached and installed, so you don't need to include any local denepdencies folder in your function.
 
-- The default entrypoint is `index.rb`. If your entrypoint differs, make sure to configure it using `INTERNAL_RUNTIME_ENTRYPOINT` environment variable, for instance, `INTERNAL_RUNTIME_ENTRYPOINT=src/app.rb`.
+- The default entrypoint is `index.rb`. If your entrypoint differs, make sure to configure it using `INTERNAL_RUNTIME_ENTRYPOINT` environment variable during build, for instance, `INTERNAL_RUNTIME_ENTRYPOINT=src/app.rb`.
 
 
 ## Authors

--- a/runtimes/ruby-3.1/build.sh
+++ b/runtimes/ruby-3.1/build.sh
@@ -25,4 +25,8 @@ fi
 # Finish build by preparing tar to use for starting the runtime
 cd /usr/builds
 cp -R /usr/local/src/vendor .
+
+touch .open-runtimes
+echo "INTERNAL_RUNTIME_ENTRYPOINT=$INTERNAL_RUNTIME_ENTRYPOINT" > .open-runtimes
+
 tar --exclude code.tar.gz -zcf /usr/code/code.tar.gz .

--- a/runtimes/ruby-3.1/start.sh
+++ b/runtimes/ruby-3.1/start.sh
@@ -3,6 +3,11 @@ cp /tmp/code.tar.gz /usr/workspace/code.tar.gz
 cd /usr/workspace
 tar -zxf /usr/workspace/code.tar.gz -C /usr/code-start
 rm /usr/workspace/code.tar.gz
+
+set -o allexport
+source /usr/code-start/.open-runtimes
+set +o allexport
+
 cd /usr/local/src
 cp -R /usr/code-start/vendor .
 

--- a/runtimes/swift-5.5/build.sh
+++ b/runtimes/swift-5.5/build.sh
@@ -15,4 +15,8 @@ rm "Sources/App/dependencies.swift"
 swift package resolve
 swift build --configuration release
 cp "$(swift build --configuration release --show-bin-path)/Run" /usr/workspace/
+
+touch .open-runtimes
+echo "INTERNAL_RUNTIME_ENTRYPOINT=$INTERNAL_RUNTIME_ENTRYPOINT" > .open-runtimes
+
 tar -zcf /usr/code/code.tar.gz -C /usr/workspace .

--- a/runtimes/swift-5.5/start.sh
+++ b/runtimes/swift-5.5/start.sh
@@ -2,4 +2,10 @@
 cd /usr/code
 tar -zxf /tmp/code.tar.gz
 rm /tmp/code.tar.gz
+
+set -o allexport
+source ./.open-runtimes
+set +o allexport
+
+
 ./Run serve --env production --hostname 0.0.0.0 --port 3000

--- a/tests.sh
+++ b/tests.sh
@@ -7,8 +7,8 @@ cd tests/${RUNTIME}
 echo "Building..."
 touch code.tar.gz
 tar --exclude code.tar.gz -czf code.tar.gz .
-docker run --rm --name open-runtimes-test-build -v $(pwd)/code.tar.gz:/usr/code/code.tar.gz:rw -e INTERNAL_RUNTIME_ENTRYPOINT=${ENTRYPOINT} -e INTERNAL_RUNTIME_KEY=test-secret-key open-runtimes/test-runtime sh -c "tar -xzf /usr/code/code.tar.gz -C /usr/code && sh /usr/local/src/build.sh"
-docker run --rm -d --name open-runtimes-test-serve -v $(pwd):/usr/code:rw -e INTERNAL_RUNTIME_ENTRYPOINT=${ENTRYPOINT} -e INTERNAL_RUNTIME_KEY=test-secret-key -p 3000:3000 open-runtimes/test-runtime sh -c "cp /usr/code/code.tar.gz /tmp/code.tar.gz && sh /usr/local/src/start.sh"
+docker run --rm --name open-runtimes-test-build -v $(pwd)/code.tar.gz:/usr/code/code.tar.gz:rw -e INTERNAL_RUNTIME_ENTRYPOINT=${ENTRYPOINT} open-runtimes/test-runtime sh -c "tar -xzf /usr/code/code.tar.gz -C /usr/code && sh /usr/local/src/build.sh"
+docker run --rm -d --name open-runtimes-test-serve -v $(pwd):/usr/code:rw -e INTERNAL_RUNTIME_KEY=test-secret-key -p 3000:3000 open-runtimes/test-runtime sh -c "cp /usr/code/code.tar.gz /tmp/code.tar.gz && sh /usr/local/src/start.sh"
 echo "Waiting for server..."
 max_wait=500
 wait_interval=10


### PR DESCRIPTION
Introduces .open-runtimes file that holds information from build-time that is nessessary during start-time, such as entrypoint in some runtimes.

This is introduced to bring consistency across all languages, as currently compiled languages require entrypoint during build, while transpired needs it during start.

- [x] Manual QA