### PR TITLE
Add Swift 5.8 Runtime

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -141,6 +141,12 @@ env:
       SERVER_PROCESS="./Run serve"
       IMAGE=openruntimes/swift:${VERSION}-5.5
       ARCH=linux/amd64,linux/arm64
+    - RUNTIME=swift-5.8
+      PHP_CLASS=Swift58
+      ENTRYPOINT=Tests.swift
+      SERVER_PROCESS="./Run serve"
+      IMAGE=openruntimes/swift:${VERSION}-5.8
+      ARCH=linux/amd64,linux/arm64
 
     # Kotlin
     - RUNTIME=kotlin-1.6

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Runtime environments for serverless cloud computing for multiple coding language
 | Ruby | 3.0 | [openruntimes/ruby:v2-3.0](https://hub.docker.com/r/openruntimes/ruby) | [Examples](/runtimes/ruby-3.0/example) | [![Docker Pulls](https://img.shields.io/docker/pulls/openruntimes/ruby?color=f02e65&style=flat-square)](https://hub.docker.com/r/openruntimes/ruby) |
 | Ruby | 3.1 | [openruntimes/ruby:v2-3.1](https://hub.docker.com/r/openruntimes/ruby) | [Examples](/runtimes/ruby-3.1/example) | [![Docker Pulls](https://img.shields.io/docker/pulls/openruntimes/ruby?color=f02e65&style=flat-square)](https://hub.docker.com/r/openruntimes/ruby) |
 | Swift | 5.5 | [openruntimes/swift:v2-5.5](https://hub.docker.com/r/openruntimes/swift) | [Examples](/runtimes/swift-5.5/example) | [![Docker Pulls](https://img.shields.io/docker/pulls/openruntimes/swift?color=f02e65&style=flat-square)](https://hub.docker.com/r/openruntimes/swift) |
+| Swift | 5.8 | [openruntimes/swift:v2-5.8](https://hub.docker.com/r/openruntimes/swift) | [Examples](/runtimes/swift-5.8/example) | [![Docker Pulls](https://img.shields.io/docker/pulls/openruntimes/swift?color=f02e65&style=flat-square)](https://hub.docker.com/r/openruntimes/swift) |
 
 ## Architecture
 

--- a/build.sh
+++ b/build.sh
@@ -74,3 +74,6 @@ docker build -t openruntimes/ruby:v2-3.1 ./runtimes/ruby-3.1/
 
 echo 'Swift 5.5...'
 docker build -t openruntimes/swift:v2-5.5 ./runtimes/swift-5.5/
+
+echo 'Swift 5.8...'
+docker build -t openruntimes/swift:v2-5.8 ./runtimes/swift-5.8/

--- a/runtimes/swift-5.8/.env
+++ b/runtimes/swift-5.8/.env
@@ -1,0 +1,1 @@
+INTERNAL_RUNTIME_KEY=secret-key

--- a/runtimes/swift-5.8/.gitignore
+++ b/runtimes/swift-5.8/.gitignore
@@ -1,0 +1,96 @@
+# Open-runtime related
+example/code.tar.gz
+example/Run
+
+# Created by https://www.toptal.com/developers/gitignore/api/swift
+# Edit at https://www.toptal.com/developers/gitignore?templates=swift
+
+### Swift ###
+# Xcode
+#
+# gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
+
+## User settings
+xcuserdata/
+
+## compatibility with Xcode 8 and earlier (ignoring not required starting Xcode 9)
+*.xcscmblueprint
+*.xccheckout
+
+## compatibility with Xcode 3 and earlier (ignoring not required starting Xcode 4)
+build/
+DerivedData/
+*.moved-aside
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+
+## Obj-C/Swift specific
+*.hmap
+
+## App packaging
+*.ipa
+*.dSYM.zip
+*.dSYM
+
+## Playgrounds
+timeline.xctimeline
+playground.xcworkspace
+
+# Swift Package Manager
+# Add this line if you want to avoid checking in source code from Swift Package Manager dependencies.
+# Packages/
+# Package.pins
+# Package.resolved
+# *.xcodeproj
+# Xcode automatically generates this directory with a .xcworkspacedata file and xcuserdata
+# hence it is not needed unless you have added a package configuration file to your project
+# .swiftpm
+
+.build/
+
+# CocoaPods
+# We recommend against adding the Pods directory to your .gitignore. However
+# you should judge for yourself, the pros and cons are mentioned at:
+# https://guides.cocoapods.org/using/using-cocoapods.html#should-i-check-the-pods-directory-into-source-control
+# Pods/
+# Add this line if you want to avoid checking in source code from the Xcode workspace
+# *.xcworkspace
+
+# Carthage
+# Add this line if you want to avoid checking in source code from Carthage dependencies.
+# Carthage/Checkouts
+
+Carthage/Build/
+
+# Accio dependency management
+Dependencies/
+.accio/
+
+# fastlane
+# It is recommended to not store the screenshots in the git repo.
+# Instead, use fastlane to re-generate the screenshots whenever they are needed.
+# For more information about the recommended setup visit:
+# https://docs.fastlane.tools/best-practices/source-control/#source-control
+
+fastlane/report.xml
+fastlane/Preview.html
+fastlane/screenshots/**/*.png
+fastlane/test_output
+
+# Code Injection
+# After new code Injection tools there's a generated folder /iOSInjectionProject
+# https://github.com/johnno1962/injectionforxcode
+
+iOSInjectionProject/
+
+# End of https://www.toptal.com/developers/gitignore/api/swift
+
+# OS
+## Mac
+.DS_Store

--- a/runtimes/swift-5.8/Dockerfile
+++ b/runtimes/swift-5.8/Dockerfile
@@ -1,0 +1,17 @@
+FROM swiftarm/swift:5.5.2-focal-multi-arch
+
+LABEL maintainer="team@appwrite.io"
+
+RUN mkdir -p /usr/local/src/
+RUN mkdir -p /usr/code
+RUN mkdir -p /usr/workspace
+
+WORKDIR /usr/local/src
+COPY . .
+
+RUN chmod +x /usr/local/src/start.sh
+RUN chmod +x /usr/local/src/build.sh
+
+EXPOSE 3000
+
+CMD ["/usr/local/src/start.sh"]

--- a/runtimes/swift-5.8/Dockerfile
+++ b/runtimes/swift-5.8/Dockerfile
@@ -1,4 +1,4 @@
-FROM swiftarm/swift:5.5.2-focal-multi-arch
+FROM swift:5.8.1
 
 LABEL maintainer="team@appwrite.io"
 

--- a/runtimes/swift-5.8/Package.swift
+++ b/runtimes/swift-5.8/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.5
+// swift-tools-version:5.8
 import PackageDescription
 
 let package = Package(

--- a/runtimes/swift-5.8/Package.swift
+++ b/runtimes/swift-5.8/Package.swift
@@ -1,0 +1,31 @@
+// swift-tools-version:5.5
+import PackageDescription
+
+let package = Package(
+    name: "swift-runtime",
+    dependencies: [
+        // 💧 A server-side Swift web framework.
+        .package(url: "https://github.com/vapor/vapor.git", from: "4.0.0"),
+    ],
+    targets: [
+        .target(
+            name: "App",
+            dependencies: [
+                .product(name: "Vapor", package: "vapor")
+            ],
+            swiftSettings: [
+                // Enable better optimizations when building in Release configuration. Despite the use of
+                // the `.unsafeFlags` construct required by SwiftPM, this flag is recommended for Release
+                // builds. See <https://github.com/swift-server/guides/blob/main/docs/building.md#building-for-production> for details.
+                .unsafeFlags(["-cross-module-optimization"], .when(configuration: .release))
+            ]
+        ),
+        .executableTarget(name: "Run", dependencies: [
+            .target(name: "App")
+        ]),
+        .testTarget(name: "AppTests", dependencies: [
+            .target(name: "App"),
+            .product(name: "XCTVapor", package: "vapor"),
+        ])
+    ]
+)

--- a/runtimes/swift-5.8/README.md
+++ b/runtimes/swift-5.8/README.md
@@ -1,6 +1,6 @@
-# Swift Runtime 5.5
+# Swift Runtime 5.8
 
-This is the Open Runtime that builds and runs NodeJS code based on a `swiftarm/5.5.2-focal-multi-arch` base image. 
+This is the Open Runtime that builds and runs NodeJS code based on the official Swift runtime `swift:5.8.1` base image. 
 
 The runtime itself uses [Vapor](https://vapor.codes) as the Web Server to process the execution requests.
 
@@ -46,7 +46,7 @@ git clone https://github.com/open-runtimes/open-runtimes.git
 2. Enter the Swift runtime folder:
 
 ```bash
-cd open-runtimes/runtimes/swift-5.5
+cd open-runtimes/runtimes/swift-5.8
 ```
 
 3. Run the included example cloud function:

--- a/runtimes/swift-5.8/README.md
+++ b/runtimes/swift-5.8/README.md
@@ -1,0 +1,115 @@
+# Swift Runtime 5.5
+
+This is the Open Runtime that builds and runs NodeJS code based on a `swiftarm/5.5.2-focal-multi-arch` base image. 
+
+The runtime itself uses [Vapor](https://vapor.codes) as the Web Server to process the execution requests.
+
+To learn more about runtimes, visit [Runtimes introduction](https://github.com/open-runtimes/open-runtimes#runtimes-introduction) section of the main README.md.
+
+## Usage
+
+1. Create a folder and enter it. Add code into `index.swift` file:
+
+```bash
+mkdir swift-test && cd swift-test
+printf "func main(req: RequestValue, res: RequestResponse) -> RequestResponse {\n    return res.json(data: [\"n\": Double.random(in:0...1)])\n}" > index.swift
+```
+
+2. Build the code:
+
+```bash
+docker run --rm --interactive --tty --volume $PWD:/usr/code openruntimes/swift:v2-5.5 sh /usr/local/src/build.sh
+```
+
+3. Spin-up open-runtime:
+
+```bash
+docker run -p 3000:3000 -e INTERNAL_RUNTIME_KEY=secret-key --rm --interactive --tty --volume $PWD/code.tar.gz:/tmp/code.tar.gz:ro openruntimes/swift:v2-5.5 sh /usr/local/src/start.sh
+```
+
+4. In new terminal window, execute function:
+
+```
+curl -H "X-Internal-Challenge: secret-key" -H "Content-Type: application/json" -X POST http://localhost:3000/ -d '{"payload": "{}"}'
+```
+
+Output `{ "n": 0.7232589496628183 }` with a random float will be displayed after the execution.
+
+## Local development
+
+1. Clone the [open-runtimes](https://github.com/open-runtimes/open-runtimes) repository:
+
+```bash
+git clone https://github.com/open-runtimes/open-runtimes.git
+```
+
+2. Enter the Swift runtime folder:
+
+```bash
+cd open-runtimes/runtimes/swift-5.5
+```
+
+3. Run the included example cloud function:
+
+```bash
+docker-compose up -d
+```
+
+4. Execute the function:
+
+```bash
+curl -H "X-Internal-Challenge: secret-key" -H "Content-Type: application/json" -X POST http://localhost:3000/ -d '{"payload": "{}"}'
+```
+
+You can now send `POST` request to `http://localhost:3000`. Make sure you have header `x-internal-challenge: secret-key`. If your function expects any parameters, you can pass an optional JSON body like so: `{ "payload":{} }`.
+
+You can also make changes to the example code and apply the changes with the `docker-compose restart` command.
+
+## Notes
+
+- The `res` parameter has two methods:
+
+    - `send()`: Send a string response to the client.
+    - `json()`: Send a JSON response to the client.
+
+You can respond with `json()` by providing object:
+
+```swift
+func main(req: RequestValue, res: RequestResponse) -> RequestResponse {
+    res.json(data : [
+        "message": "Hello Open Runtimes 👋",
+        "variables": req.variables,
+        "payload": req.payload,
+        "headers": req.headers
+    ])
+}
+```
+
+- To handle dependencies, you need to have `Package.swift` file. Dependencies will be automatically cached and installed, so you don't need to include `.build` folder in your function.
+
+- The default entrypoint is `Sources/index.swift`. If your entrypoint differs, make sure to provide it in the JSON body of the request: `{ "file": "app.swift" }`.
+
+- Swift does not require `INTERNAL_RUNTIME_ENTRYPOINT` like other runtimes. In Swift, you only need to make sure a function called `main` is defined in any of your `.swift` files.
+
+- Swift runtime currently doesn't support ARM, because there are no official ARM images.
+
+## Authors
+
+**Eldad Fux**
+
++ [https://twitter.com/eldadfux](https://twitter.com/eldadfux)
++ [https://github.com/eldadfux](https://github.com/eldadfux)
+
+**Bradley Schofield**
+
++ [https://github.com/PineappleIOnic](https://github.com/PineappleIOnic)
+
+**Jake Barnby**
+
++ [https://github.com/abnegate](https://github.com/abnegate)
+
+## Contributing
+
+For security issues, please email security@appwrite.io instead of posting a public issue in GitHub.
+
+You can refer to the [Contributing Guide](https://github.com/open-runtimes/open-runtimes/blob/main/CONTRIBUTING.md) for more info.

--- a/runtimes/swift-5.8/Sources/App/configure.swift
+++ b/runtimes/swift-5.8/Sources/App/configure.swift
@@ -1,0 +1,5 @@
+import Vapor
+
+public func configure(_ app: Application) throws {
+    try routes(app)
+}

--- a/runtimes/swift-5.8/Sources/App/dependencies.swift
+++ b/runtimes/swift-5.8/Sources/App/dependencies.swift
@@ -1,0 +1,144 @@
+import Foundation
+
+let outpath = "/usr/local/src"
+let outfile = "Package.swift"
+let task = Process()
+let pipe = Pipe()
+
+task.standardOutput = pipe
+task.standardError = pipe
+task.arguments = ["-c", "swift package dump-package"]
+task.executableURL = URL(fileURLWithPath: "/bin/bash")
+try! task.run()
+
+let data = pipe.fileHandleForReading.readDataToEndOfFile()
+let json = try! JSONSerialization.jsonObject(with: data, options : .allowFragments) as! [String: Any]
+
+var packages = [String]()
+var products = [String]()
+
+var packageBlacklist = ["vapor"]
+var productBlacklist = ["Vapor"]
+
+func buildPackageStrings() {
+    if let dependencies = json["dependencies"] as? [[String: Any]] {
+        for dependency in dependencies {
+            if let scm = dependency["scm"] as? [[String: Any]] {
+                for data in scm {
+                    let identity = data["identity"] as? String
+                    let location = data["location"] as? String
+                    let lowerBound = ((data["requirement"] as? [String:Any])?["range"] as? [[String:Any]])?[0]["lowerBound"] as? String
+                    
+                    guard let identity = identity, let location = location, let lowerBound = lowerBound else {
+                        continue
+                    }
+                    if packageBlacklist.contains(identity) {
+                        continue
+                    }
+
+                    let output = ".package(url: \"\(location)\", from: \"\(lowerBound)\"),"
+
+                    packages.append(output)
+                }
+            }
+        }
+    }
+}
+
+func buildProductStrings() {
+    if let targets = json["targets"] as? [[String: Any]] {
+        for target in targets {
+            if let dependencies = target["dependencies"] as? [[String: Any]] {
+                for dependency in dependencies {
+                    let values = dependency["product"]! as! [Any]
+                    let identity = values[0] as? String
+                    let package = values[1] as? String
+                
+                    guard let identity = identity, let package = package else {
+                        continue
+                    }
+                    if productBlacklist.contains(identity) {
+                        continue
+                    }
+
+                    let output = ".product(name: \"\(identity)\", package: \"\(package)\"),"
+
+                    products.append(output)
+                }
+            }
+        }
+    }
+}
+
+func writePackageStrings() {
+    let path = "\(outpath)/\(outfile)"
+    var text = try! String(contentsOfFile: path)
+    let pattern = #"(.package\(.*)"#
+    let regex = try! NSRegularExpression(pattern: pattern, options: [])
+    let range = NSRange(text.startIndex..<text.endIndex, in: text)
+
+    regex.enumerateMatches(
+        in: text,
+        options: [],
+        range: range
+    ) { (match, _, stop) in
+        guard let match = match else { return }
+
+        let lastRange = Range(match.range(at: match.numberOfRanges - 1), in: text)
+        let lastMatch = String(text[lastRange!])
+        var last = lastMatch
+        if last.last != "," {
+            last += ","
+        }
+        let replacement = last + "\n\t\t" + packages.joined(separator: ",\n\t\t")
+        
+        text = text.replacingOccurrences(of: lastMatch, with: replacement)
+
+        // Set bool pointer to true to stop enumeration
+        stop.pointee = true
+    }
+    try! text.write(
+        to: URL(fileURLWithPath: path),
+        atomically: true,
+        encoding: .utf8
+    )
+}
+
+func writeProductStrings() {
+    let path = "\(outpath)/\(outfile)"
+    var text = try! String(contentsOfFile: path)
+    let pattern = #"(.product\(.*)"#
+    let regex = try! NSRegularExpression(pattern: pattern, options: [])
+    let range = NSRange(text.startIndex..<text.endIndex, in: text)
+
+    regex.enumerateMatches(
+        in: text,
+        options: [],
+        range: range
+    ) { (match, _, stop) in
+        guard let match = match else { return }
+        
+        let lastRange = Range(match.range(at: match.numberOfRanges - 1), in: text)
+        let lastMatch = String(text[lastRange!])
+        var last = lastMatch
+        if last.last != "," {
+            last += ","
+        }
+        let replacement = last + "\n\t\t\t\t" + products.joined(separator: ",\n\t\t\t\t")
+        
+        text = text.replacingOccurrences(of: lastMatch, with: replacement)
+        
+        // Set bool pointer to true to stop enumeration
+        stop.pointee = true
+    }
+    try! text.write(
+        to: URL(fileURLWithPath: path),
+        atomically: true,
+        encoding: .utf8
+    )
+}
+
+buildPackageStrings()
+buildProductStrings()
+writePackageStrings()
+writeProductStrings()

--- a/runtimes/swift-5.8/Sources/App/routes.swift
+++ b/runtimes/swift-5.8/Sources/App/routes.swift
@@ -1,0 +1,126 @@
+import Vapor
+import Foundation
+
+struct RequestValue {
+    var variables: [String: String] = [:]
+    var headers: [String: String] = [:]
+    var payload: String = ""
+
+    enum CodingKeys: String, CodingKey {
+        case variables
+        case headers
+        case payload
+    }
+}
+
+extension RequestValue : Decodable {
+    init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+
+        if let variables = try? values.decodeIfPresent([String: String].self, forKey: .variables) {
+            self.variables = variables
+        }
+        if let headers = try? values.decodeIfPresent([String: String].self, forKey: .headers) {
+            self.headers = headers
+        }
+        if let payload = try? values.decodeIfPresent(String.self, forKey: .payload) {
+            self.payload = payload
+        }
+    }
+}
+
+class RequestResponse {
+    var data: Any = ""
+    var statusCode: HTTPResponseStatus = HTTPResponseStatus.ok
+
+    init (data: String = "") {
+        self.data = data
+    }
+}
+
+extension RequestResponse {
+    func send(data: String) -> RequestResponse {
+        self.data = data
+        self.statusCode = HTTPResponseStatus.ok
+        return self
+    }
+    
+    func json(data: [String: Any?]) -> RequestResponse {
+        self.data = data
+        self.statusCode = HTTPResponseStatus.ok
+        return self
+    }
+    
+    fileprivate static func error(from data: Error) -> RequestResponse {
+        let response = RequestResponse()
+        response.data = data.localizedDescription
+        response.statusCode = HTTPResponseStatus.internalServerError
+        return response
+    }
+    
+    fileprivate static func unauthorized() -> RequestResponse {
+        let response = RequestResponse()
+        response.statusCode = HTTPResponseStatus.internalServerError
+        response.data = "Unauthorized"
+        return response
+    }
+}
+
+extension RequestResponse: AsyncResponseEncodable {
+    func encodeResponse(for request: Request) async throws -> Response {
+        var headers = HTTPHeaders()
+        headers.add(name: .contentType, value: "application/json")
+
+        if let JSONData = try? JSONSerialization.data(
+          withJSONObject: self.data,
+          options: .prettyPrinted
+        ), let JSONText = String(data: JSONData, encoding: String.Encoding.utf8) {
+            self.statusCode = HTTPResponseStatus.ok
+            self.data = JSONText
+        } else {
+            self.statusCode = HTTPResponseStatus.internalServerError
+            self.data = "Something went wrong encoding the Response JSON Object!"
+        }
+
+        return Response(
+            status: self.statusCode, 
+            headers: headers, 
+            body: .init(string: self.data as! String)
+        )
+    }
+}
+
+func routes(_ app: Application) throws {
+    app.on(.POST, "", body: .stream) { req async throws -> RequestResponse in
+        if (!req.headers.contains(name: "x-internal-challenge") || req.headers["x-internal-challenge"].isEmpty) {
+            return RequestResponse.unauthorized()
+        }
+
+        if (req.headers["x-internal-challenge"][0] != ProcessInfo.processInfo.environment["INTERNAL_RUNTIME_KEY"]) {
+            return RequestResponse.unauthorized()
+        }
+
+        do {
+            var request = RequestValue() 
+            let response = RequestResponse()
+
+            if let body = req.body.string,
+                !body.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines).isEmpty,
+                body != "\"\"" {
+                    request = try JSONDecoder().decode(RequestValue.self, from: body.data(using: .utf8)!)
+            }
+
+            let userResponse = try await main(req: request, res: response)
+
+            var output = [String:Any?]()
+            output["response"] = userResponse.data
+            output["stdout"] = ""
+            return userResponse.json(data: output)
+        } catch let error {
+            var output = [String:Any?]()
+            output["stdout"] = ""
+            output["stderr"] = error.localizedDescription
+            return RequestResponse().json(data: output)
+        }
+    }
+}

--- a/runtimes/swift-5.8/Sources/Run/main.swift
+++ b/runtimes/swift-5.8/Sources/Run/main.swift
@@ -1,0 +1,9 @@
+import App
+import Vapor
+
+var env = try Environment.detect()
+try LoggingSystem.bootstrap(from: &env)
+let app = Application(env)
+defer { app.shutdown() }
+try configure(app)
+try app.run()

--- a/runtimes/swift-5.8/Tests/AppTests/AppTests.swift
+++ b/runtimes/swift-5.8/Tests/AppTests/AppTests.swift
@@ -1,0 +1,15 @@
+@testable import App
+import XCTVapor
+
+final class AppTests: XCTestCase {
+    func testHelloWorld() throws {
+        let app = Application(.testing)
+        defer { app.shutdown() }
+        try configure(app)
+
+        try app.test(.GET, "hello", afterResponse: { res in
+            XCTAssertEqual(res.status, .ok)
+            XCTAssertEqual(res.body.string, "Hello, world!")
+        })
+    }
+}

--- a/runtimes/swift-5.8/build.sh
+++ b/runtimes/swift-5.8/build.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+# Fail build if any command fails
+set -e
+
+cp -a /usr/code/. /usr/local/src/Sources/App/Custom/
+cd /usr/local/src
+if [ -f "./Sources/App/Custom/Package.swift" ]; then
+    cd ./Sources/App/Custom
+    swift ../dependencies.swift
+    rm "Package.swift" 
+    cd /usr/local/src
+fi
+rm "Sources/App/dependencies.swift"
+swift package resolve
+swift build --configuration release
+cp "$(swift build --configuration release --show-bin-path)/Run" /usr/workspace/
+tar -zcf /usr/code/code.tar.gz -C /usr/workspace .

--- a/runtimes/swift-5.8/docker-compose.yml
+++ b/runtimes/swift-5.8/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '3'
+
+services:
+  open-runtimes-swift:
+    container_name: open-runtimes-swift
+    build:
+      context: .
+    ports: 
+      - 3000:3000
+    environment:
+      - INTERNAL_RUNTIME_KEY
+    volumes:
+      - ./example:/usr/code:rw
+    command: sh -c "sh /usr/local/src/build.sh && cp /usr/code/code.tar.gz /tmp/code.tar.gz && sh /usr/local/src/start.sh"

--- a/runtimes/swift-5.8/example/Package.swift
+++ b/runtimes/swift-5.8/example/Package.swift
@@ -1,8 +1,11 @@
-// swift-tools-version:5.5
+// swift-tools-version:5.8
 import PackageDescription
 
 let package = Package(
     name: "swift-runtime",
+	platforms: [
+	   .macOS(.v13)
+	],
     dependencies: [
         .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.0.0"),
     ],
@@ -11,7 +14,8 @@ let package = Package(
             name: "swift-function",
             dependencies: [
                 .product(name: "AsyncHTTPClient", package: "async-http-client")
-            ]
+            ],
+			path: "Sources/"
         )
     ]
 )

--- a/runtimes/swift-5.8/example/Package.swift
+++ b/runtimes/swift-5.8/example/Package.swift
@@ -1,0 +1,17 @@
+// swift-tools-version:5.5
+import PackageDescription
+
+let package = Package(
+    name: "swift-runtime",
+    dependencies: [
+        .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.0.0"),
+    ],
+    targets: [
+        .executableTarget(
+            name: "swift-function",
+            dependencies: [
+                .product(name: "AsyncHTTPClient", package: "async-http-client")
+            ]
+        )
+    ]
+)

--- a/runtimes/swift-5.8/example/Sources/index.swift
+++ b/runtimes/swift-5.8/example/Sources/index.swift
@@ -1,0 +1,42 @@
+//
+//  File.swift
+//  
+//
+//  Created by Bradley Schofield on 21/12/2021.
+//
+
+import Foundation
+import AsyncHTTPClient
+
+/*
+    'req' variable has:
+        'headers' - object with request headers
+        'payload' - object with request body data
+        'variables' - object with function variables
+    'res' variable has:
+        'send(text, status)' - function to return text response. Status code defaults to 200
+        'json(obj, status)' - function to return JSON response. Status code defaults to 200
+    
+    If an error is thrown, a response with code 500 will be returned.
+*/
+
+func main(req: RequestValue, res: RequestResponse) async throws -> RequestResponse {
+    var todoId: String = "1"
+
+    if !req.payload.isEmpty,
+        let data = req.payload.data(using: .utf8),
+        let payload = try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any] {
+            todoId = payload["id"] as? String ?? "1"
+    }
+
+    let httpClient = HTTPClient(eventLoopGroupProvider: .createNew)
+    let request = HTTPClientRequest(url: "https://jsonplaceholder.typicode.com/todos/\(todoId)")
+    let response = try await httpClient.execute(request, timeout: .seconds(30))
+    let data = try await response.body.collect(upTo: 1024 * 1024)
+    let todo = try JSONSerialization.jsonObject(with: data, options: []) as? [String: Any]
+
+    return res.json(data: [
+        "message": "Hello Open Runtimes 👋",
+        "todo": todo
+    ])
+}

--- a/runtimes/swift-5.8/start.sh
+++ b/runtimes/swift-5.8/start.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+cd /usr/code
+tar -zxf /tmp/code.tar.gz
+rm /tmp/code.tar.gz
+./Run serve --env production --hostname 0.0.0.0 --port 3000

--- a/tests/Swift58.php
+++ b/tests/Swift58.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Tests;
+
+// Runtime: swift-5.8
+// PHP class: Swift58
+// Entrypoint: Tests.swift
+
+class Swift58 extends Base
+{
+    public function testConsoleLogs(): void {
+        return; // Swift doesn't yet support console log.
+    }
+}

--- a/tests/swift-5.8/Package.resolved
+++ b/tests/swift-5.8/Package.resolved
@@ -1,0 +1,88 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "async-http-client",
+        "repositoryURL": "https://github.com/swift-server/async-http-client.git",
+        "state": {
+          "branch": null,
+          "revision": "78db67e5bf4a8543075787f228e8920097319281",
+          "version": "1.18.0"
+        }
+      },
+      {
+        "package": "swift-atomics",
+        "repositoryURL": "https://github.com/apple/swift-atomics.git",
+        "state": {
+          "branch": null,
+          "revision": "6c89474e62719ddcc1e9614989fff2f68208fe10",
+          "version": "1.1.0"
+        }
+      },
+      {
+        "package": "swift-collections",
+        "repositoryURL": "https://github.com/apple/swift-collections.git",
+        "state": {
+          "branch": null,
+          "revision": "937e904258d22af6e447a0b72c0bc67583ef64a2",
+          "version": "1.0.4"
+        }
+      },
+      {
+        "package": "swift-log",
+        "repositoryURL": "https://github.com/apple/swift-log.git",
+        "state": {
+          "branch": null,
+          "revision": "32e8d724467f8fe623624570367e3d50c5638e46",
+          "version": "1.5.2"
+        }
+      },
+      {
+        "package": "swift-nio",
+        "repositoryURL": "https://github.com/apple/swift-nio.git",
+        "state": {
+          "branch": null,
+          "revision": "6213ba7a06febe8fef60563a4a7d26a4085783cf",
+          "version": "2.54.0"
+        }
+      },
+      {
+        "package": "swift-nio-extras",
+        "repositoryURL": "https://github.com/apple/swift-nio-extras.git",
+        "state": {
+          "branch": null,
+          "revision": "0e0d0aab665ff1a0659ce75ac003081f2b1c8997",
+          "version": "1.19.0"
+        }
+      },
+      {
+        "package": "swift-nio-http2",
+        "repositoryURL": "https://github.com/apple/swift-nio-http2.git",
+        "state": {
+          "branch": null,
+          "revision": "a8ccf13fa62775277a5d56844878c828bbb3be1a",
+          "version": "1.27.0"
+        }
+      },
+      {
+        "package": "swift-nio-ssl",
+        "repositoryURL": "https://github.com/apple/swift-nio-ssl.git",
+        "state": {
+          "branch": null,
+          "revision": "e866a626e105042a6a72a870c88b4c531ba05f83",
+          "version": "2.24.0"
+        }
+      },
+      {
+        "package": "swift-nio-transport-services",
+        "repositoryURL": "https://github.com/apple/swift-nio-transport-services.git",
+        "state": {
+          "branch": null,
+          "revision": "41f4098903878418537020075a4d8a6e20a0b182",
+          "version": "1.17.0"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/tests/swift-5.8/Package.swift
+++ b/tests/swift-5.8/Package.swift
@@ -1,0 +1,18 @@
+// swift-tools-version:5.8
+import PackageDescription
+
+let package = Package(
+    name: "swift-runtime",
+    dependencies: [
+        .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.0.0"),
+    ],
+    targets: [
+        .executableTarget(
+            name: "swift-function",
+            dependencies: [
+                .product(name: "AsyncHTTPClient", package: "async-http-client")
+            ],
+			path: "Sources/"
+        )
+    ]
+)

--- a/tests/swift-5.8/Sources/Tests.swift
+++ b/tests/swift-5.8/Sources/Tests.swift
@@ -1,0 +1,55 @@
+import Foundation
+import AsyncHTTPClient
+
+//    'req' variable has:
+//        'headers' - object with request headers
+//        'payload' - object with request body data
+//        'variables' - object with function variables
+//    'res' variable has:
+//        'send(text, status)' - function to return text response. Status code defaults to 200
+//        'json(obj, status)' - function to return JSON response. Status code defaults to 200
+//    
+//    If an error is thrown, a response with code 500 will be returned.
+
+func main(req: RequestValue, res: RequestResponse) async throws -> RequestResponse {
+
+    let headerData = req.headers["x-test-header"]
+    let varData = req.variables["test-variable"]
+
+    var todoId: String = "1"
+
+    var reqPayload = req.payload as! String
+    if(reqPayload == "") {
+        reqPayload = "{}"
+    }
+
+    if !reqPayload.isEmpty,
+        let data = reqPayload.data(using: .utf8),
+        let payload = try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any] {
+            todoId = payload["id"] as? String ?? "1"
+    }
+
+    let httpClient = HTTPClient(eventLoopGroupProvider: .createNew)
+    let request = HTTPClientRequest(url: "https://jsonplaceholder.typicode.com/todos/\(todoId)")
+    let response = try await httpClient.execute(request, timeout: .seconds(30))
+    let data = try await response.body.collect(upTo: 1024 * 1024)
+    let todo = try JSONSerialization.jsonObject(with: data, options: []) as? [String: Any]
+
+    print("String1")
+    print(42)
+    print(4.2)
+    print(true)
+
+    print("String2")
+    print("String3")
+    print("String4")
+    print("String5")
+
+    return res.json(data: [
+        "isTest": true,
+        "message": "Hello Open Runtimes 👋",
+        "todo": todo,
+        "header": headerData,
+        "variable": varData
+    ])
+}


### PR DESCRIPTION
This adds a new runtime that supports the latest (as of now) version of Swift, 5.8.1.
## Tests
All tests pass.
## New in this runtime
1. Unlike the currently available runtime (Swift 5.5) this is based off of the official Swift docker image, which is suggested by this project.
2. Input code, in the form of Swift packages, can specify dependencies. The previous runtime supported version-based dependencies. This runtime also supports branch-based dependenceis.
In other words, 
You can specify a dependency like this, as you could with the previous runtime:
```swift
.package(url: "https://github.com/vapor/vapor.git", from: "4.0.0"),
```
And with this runtime you can specify it like this:
```swift
.package(url: "https://github.com/vapor/vapor.git", branch: "main"),
```
This can be useful for small, personal packages that get updated regularly. (This is what actually motivated this PR)

## New Swift features
Using this runtime over the 5.5 one you can leverage all the features that were introduced since Swift 5.5.
You can find notable features that were added since then on Paul Hudson's wonderful website for each release:
Swift [5.6](https://www.hackingwithswift.com/articles/247/whats-new-in-swift-5-6) 
Swift [5.7](https://www.hackingwithswift.com/articles/249/whats-new-in-swift-5-7) 
Swift [5.8](https://www.hackingwithswift.com/articles/256/whats-new-in-swift-5-8)
