### PR TITLE
[Node] - Adapting servers to pass the SIGINT to the child server.

### DIFF
--- a/runtimes/node-14.5/server.js
+++ b/runtimes/node-14.5/server.js
@@ -4,6 +4,8 @@ const { json, send } = require("micro");
 
 const USER_CODE_PATH = '/usr/code-start';
 
+let userFunction = require(USER_CODE_PATH + '/' + process.env.INTERNAL_RUNTIME_ENTRYPOINT);
+
 const server = micro(async (req, res) => {
     const body = await json(req);
 
@@ -56,7 +58,6 @@ const server = micro(async (req, res) => {
     };
 
     try {
-        let userFunction = require(USER_CODE_PATH + '/' + process.env.INTERNAL_RUNTIME_ENTRYPOINT);
 
         if (!(userFunction || userFunction.constructor || userFunction.call || userFunction.apply)) {
             throw new Error("User function is not valid.")

--- a/runtimes/node-14.5/start.sh
+++ b/runtimes/node-14.5/start.sh
@@ -1,8 +1,20 @@
 #!/bin/sh
-cp /tmp/code.tar.gz /usr/workspace/code.tar.gz 
+cp /tmp/code.tar.gz /usr/workspace/code.tar.gz
 cd /usr/workspace
 tar -zxf /usr/workspace/code.tar.gz -C /usr/code-start
 rm /usr/workspace/code.tar.gz
 cp -R /usr/code-start/node_modules/* /usr/local/src/node_modules
 cd /usr/local/src
-npm start
+
+close() {
+  kill -s SIGINT $(pgrep -f "node /usr/local/src/server.js")
+  sleep 3
+  kill -TERM "$child" 2>/dev/null
+}
+
+trap close SIGTERM
+
+npm start &
+
+child=$!
+wait "$child"

--- a/runtimes/node-16.0/server.js
+++ b/runtimes/node-16.0/server.js
@@ -4,6 +4,8 @@ const { json, send } = require("micro");
 
 const USER_CODE_PATH = '/usr/code-start';
 
+let userFunction = require(USER_CODE_PATH + '/' + process.env.INTERNAL_RUNTIME_ENTRYPOINT);
+
 const server = micro(async (req, res) => {
     const body = await json(req);
 
@@ -56,8 +58,6 @@ const server = micro(async (req, res) => {
     };
 
     try {
-        let userFunction = require(USER_CODE_PATH + '/' + process.env.INTERNAL_RUNTIME_ENTRYPOINT);
-
         if (!(userFunction || userFunction.constructor || userFunction.call || userFunction.apply)) {
             throw new Error("User function is not valid.")
         }

--- a/runtimes/node-16.0/start.sh
+++ b/runtimes/node-16.0/start.sh
@@ -5,4 +5,16 @@ tar -zxf /usr/workspace/code.tar.gz -C /usr/code-start
 rm /usr/workspace/code.tar.gz
 cp -R /usr/code-start/node_modules/* /usr/local/src/node_modules
 cd /usr/local/src
-npm start
+
+close() {
+  kill -s SIGINT $(pgrep -f "node /usr/local/src/server.js")
+  sleep 3
+  kill -TERM "$child" 2>/dev/null
+}
+
+trap close SIGTERM
+
+npm start &
+
+child=$!
+wait "$child"

--- a/runtimes/node-18.0/server.js
+++ b/runtimes/node-18.0/server.js
@@ -4,6 +4,8 @@ const { json, send } = require("micro");
 
 const USER_CODE_PATH = '/usr/code-start';
 
+let userFunction = require(USER_CODE_PATH + '/' + process.env.INTERNAL_RUNTIME_ENTRYPOINT);
+
 const server = micro(async (req, res) => {
     const body = await json(req);
 
@@ -56,8 +58,6 @@ const server = micro(async (req, res) => {
     };
 
     try {
-        let userFunction = require(USER_CODE_PATH + '/' + process.env.INTERNAL_RUNTIME_ENTRYPOINT);
-
         if (!(userFunction || userFunction.constructor || userFunction.call || userFunction.apply)) {
             throw new Error("User function is not valid.")
         }

--- a/runtimes/node-18.0/start.sh
+++ b/runtimes/node-18.0/start.sh
@@ -5,4 +5,16 @@ tar -zxf /usr/workspace/code.tar.gz -C /usr/code-start
 rm /usr/workspace/code.tar.gz
 cp -R /usr/code-start/node_modules/* /usr/local/src/node_modules
 cd /usr/local/src
-npm start
+
+close() {
+  kill -s SIGINT $(pgrep -f "node /usr/local/src/server.js")
+  sleep 3
+  kill -TERM "$child" 2>/dev/null
+}
+
+trap close SIGTERM
+
+npm start &
+
+child=$!
+wait "$child"

--- a/runtimes/node-19.0/server.js
+++ b/runtimes/node-19.0/server.js
@@ -4,6 +4,8 @@ const { json, send } = require("micro");
 
 const USER_CODE_PATH = '/usr/code-start';
 
+let userFunction = require(USER_CODE_PATH + '/' + process.env.INTERNAL_RUNTIME_ENTRYPOINT);
+
 const server = micro(async (req, res) => {
     const body = await json(req);
 
@@ -52,8 +54,6 @@ const server = micro(async (req, res) => {
         json: (json, status = 200) => send(res, status, {response: json, stdout: logs.join('\n'), stderr: errors.join('\n')}),
     };
     try {
-        let userFunction = require(USER_CODE_PATH + '/' + process.env.INTERNAL_RUNTIME_ENTRYPOINT);
-
         if (!(userFunction || userFunction.constructor || userFunction.call || userFunction.apply)) {
             throw new Error("User function is not valid.")
         }

--- a/runtimes/node-19.0/start.sh
+++ b/runtimes/node-19.0/start.sh
@@ -5,4 +5,16 @@ tar -zxf /usr/workspace/code.tar.gz -C /usr/code-start
 rm /usr/workspace/code.tar.gz
 cp -R /usr/code-start/node_modules/* /usr/local/src/node_modules
 cd /usr/local/src
-npm start
+
+close() {
+  kill -s SIGINT $(pgrep -f "node /usr/local/src/server.js")
+  sleep 3
+  kill -TERM "$child" 2>/dev/null
+}
+
+trap close SIGTERM
+
+npm start &
+
+child=$!
+wait "$child"


### PR DESCRIPTION
## Explanation of changes

### start.sh
Inside each of the `start.sh` files, I've added a [trap](https://www.geeksforgeeks.org/shell-scripting-bash-trap-command/) to catch `SIGTERM` requests, and it's needed to kill the `node /usr/local/src/server.js` command (that being handled by **pm2**) first, before continuing with the shutdown process.
```sh
...

close() {
  kill -s SIGINT $(pgrep -f "node /usr/local/src/server.js")
  sleep 3
  kill -TERM "$child" 2>/dev/null
}

trap close SIGTERM

npm start &

child=$!
wait "$child"
```

## server.js
It was needed to move the `require` part outside of the micro init function.
```js
const USER_CODE_PATH = '/usr/code-start';

let userFunction = require(USER_CODE_PATH + '/' + process.env.INTERNAL_RUNTIME_ENTRYPOINT);

const server = micro(async (req, res) => {
...
```
The reason for that is that the `process.on('SIGINT')` needed to be loaded the second the `pm2` is running the file. And, when the `require` function is **inside** the function the the `process.on` won't be able to listen to the `SIGINT` event. 

As of that, I've also removed the following line in all the micro functions.
```js
let userFunction = require(USER_CODE_PATH + '/' + process.env.INTERNAL_RUNTIME_ENTRYPOINT);
```

### Tests:

- [x] Checked the regular test of `x-internal-challenge`
- [x] Checked the SIGINT with the following code 👇.
I've added this line at the end of each of the `index.js` files inside the `example` folder.
```js
const https = require('https');

process.on('SIGINT', function () {
    https.get(`https://api.telegram.org/bot[TELEGRAM_BOT]/sendMessage?chat_id=[TELEGRAM_CHAT_ID]&text=end`);
})
```

The idea came thanks to Appwrite community member's contributions in [this](https://discord.com/channels/564160730845151244/1117792744178450442/1117792744178450442) Discord thread. 

Helps to (in the Node part): https://github.com/appwrite/appwrite/issues/5688