### PR TITLE
Fix swift build for multiple dependencies

### DIFF
--- a/runtimes/swift-5.5/Sources/App/dependencies.swift
+++ b/runtimes/swift-5.5/Sources/App/dependencies.swift
@@ -90,7 +90,7 @@ func writePackageStrings() {
         if last.last != "," {
             last += ","
         }
-        let replacement = last + "\n\t\t" + packages.joined(separator: ",\n\t\t")
+        let replacement = last + "\n\t\t" + packages.joined(separator: "\n\t\t")
         
         text = text.replacingOccurrences(of: lastMatch, with: replacement)
 
@@ -124,7 +124,7 @@ func writeProductStrings() {
         if last.last != "," {
             last += ","
         }
-        let replacement = last + "\n\t\t\t\t" + products.joined(separator: ",\n\t\t\t\t")
+        let replacement = last + "\n\t\t\t\t" + products.joined(separator: "\n\t\t\t\t")
         
         text = text.replacingOccurrences(of: lastMatch, with: replacement)
         


### PR DESCRIPTION
When merging dependencies, we're adding an extra comma between dependencies which leads to a syntax error.

Fixes: https://github.com/appwrite/appwrite/issues/5863