### PR TITLE
Feat: Bun ARM support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -370,7 +370,7 @@ env:
       TEST_CLASS=Base
       ENTRYPOINT=tests.ts
       IMAGE=openruntimes/bun:${VERSION}-1.0
-      ARCH=linux/amd64
+      ARCH=linux/amd64,linux/arm64
       TEST_SCRIPT=tests.sh
       OPEN_RUNTIMES_BUILD_COMMAND="bun install"
       OPEN_RUNTIMES_START_COMMAND="bun src/server.ts"


### PR DESCRIPTION
Bun base image supports those archs:

<img width="202" alt="CleanShot 2023-09-13 at 08 43 01@2x" src="https://github.com/open-runtimes/open-runtimes/assets/19310830/dc82c838-65e1-4801-8951-0a7465837e16">

> https://hub.docker.com/r/oven/bun/tags


So I ensure we have same supported in Appwrite. It's also standard for us to support these 2 archs, as seen in in other rutimes.