### PR TITLE
Fix: Python Flask issues

### DIFF
--- a/runtimes/python-3.10/requirements.txt
+++ b/runtimes/python-3.10/requirements.txt
@@ -1,3 +1,4 @@
 Flask==2.0.1
 flask[async]
 Waitress==2.0.0
+Werkzeug==2.3.7

--- a/runtimes/python-3.11/requirements.txt
+++ b/runtimes/python-3.11/requirements.txt
@@ -1,3 +1,4 @@
 Flask==2.0.1
 flask[async]
 Waitress==2.0.0
+Werkzeug==2.3.7

--- a/runtimes/python-3.8/requirements.txt
+++ b/runtimes/python-3.8/requirements.txt
@@ -1,3 +1,4 @@
 Flask==2.0.1
 flask[async]
 Waitress==2.0.0
+Werkzeug==2.3.7

--- a/runtimes/python-3.9/requirements.txt
+++ b/runtimes/python-3.9/requirements.txt
@@ -1,3 +1,4 @@
 Flask==2.0.1
 flask[async]
 Waitress==2.0.0
+Werkzeug==2.3.7


### PR DESCRIPTION
Flask seems to fail to run:

```
Traceback (most recent call last):
  File "/usr/local/server/src/server.py", line 1, in <module>
    from flask import Flask, request, Response as FlaskResponse
  File "/usr/local/server/src/function/runtime-env/lib/python3.9/site-packages/flask/__init__.py", line 7, in <module>
    from .app import Flask as Flask
  File "/usr/local/server/src/function/runtime-env/lib/python3.9/site-packages/flask/app.py", line 28, in <module>
    from . import cli
  File "/usr/local/server/src/function/runtime-env/lib/python3.9/site-packages/flask/cli.py", line 18, in <module>
    from .helpers import get_debug_flag
  File "/usr/local/server/src/function/runtime-env/lib/python3.9/site-packages/flask/helpers.py", line 16, in <module>
    from werkzeug.urls import url_quote
ImportError: cannot import name 'url_quote' from 'werkzeug.urls' (/usr/local/server/src/function/runtime-env/lib/python3.9/site-packages/werkzeug/urls.py)
```

Because during build:

```
open-runtimes-python-3.9  | Collecting Werkzeug>=2.0
open-runtimes-python-3.9  |   Downloading werkzeug-3.0.0-py3-none-any.whl (226 kB)
```

When Werkzeug 3.0.0 was released [7 hours ago](https://pypi.org/project/Werkzeug/#history), matching time when appwrite tests started failing.

By locking the version of Werkzeug to 2.x, Python runtime now works again.