### PR TITLE
fix: Properly serialize native errors passed to ctx.error()

### DIFF
--- a/runtimes/node-20.0/src/server.js
+++ b/runtimes/node-20.0/src/server.js
@@ -96,7 +96,9 @@ const server = micro(async (req, res) => {
             }
         },
         error: function (message) {
-            if (message instanceof Object || Array.isArray(message)) {
+            if (err instanceof Error) {
+                errors.push(err.stack ?? err.message);
+            } else if (message instanceof Object || Array.isArray(message)) {
                 errors.push(JSON.stringify(message));
             } else {
                 errors.push(message + "");


### PR DESCRIPTION
When encountering an Error class passed to ctx.error(), this PR uses error.stack, falling back to error.message, to have a proper error message.
The issue with just calling JSON.stringify() is that the built-in JS Error class stringifies to `{}`.

This PR fixes #204.