### PR TITLE
Fix: Improve build speed

### DIFF
--- a/runtimes/bun-1.0/Dockerfile
+++ b/runtimes/bun-1.0/Dockerfile
@@ -16,7 +16,7 @@ COPY package* /usr/local/server/
 
 RUN bun install
 
-COPY . .
+COPY ./helpers ./helpers
 
 RUN chmod +x /usr/local/server/helpers/before-start.sh
 RUN chmod +x /usr/local/server/helpers/start.sh
@@ -24,5 +24,7 @@ RUN chmod +x /usr/local/server/helpers/start.sh
 RUN chmod +x /usr/local/server/helpers/before-build.sh
 RUN chmod +x /usr/local/server/helpers/build.sh
 RUN chmod +x /usr/local/server/helpers/after-build.sh
+
+COPY . .
 
 EXPOSE 3000

--- a/runtimes/cpp-17/Dockerfile
+++ b/runtimes/cpp-17/Dockerfile
@@ -38,7 +38,7 @@ RUN mkdir -p /usr/local/server/src/function
 
 WORKDIR /usr/local/server
 
-COPY . .
+COPY ./helpers ./helpers
 
 RUN chmod +x /usr/local/server/helpers/before-start.sh
 RUN chmod +x /usr/local/server/helpers/start.sh
@@ -46,5 +46,7 @@ RUN chmod +x /usr/local/server/helpers/start.sh
 RUN chmod +x /usr/local/server/helpers/before-build.sh
 RUN chmod +x /usr/local/server/helpers/build.sh
 RUN chmod +x /usr/local/server/helpers/after-build.sh
+
+COPY . .
 
 EXPOSE 3000

--- a/runtimes/cpp-20/Dockerfile
+++ b/runtimes/cpp-20/Dockerfile
@@ -38,7 +38,7 @@ RUN mkdir -p /usr/local/server/src/function
 
 WORKDIR /usr/local/server
 
-COPY . .
+COPY ./helpers ./helpers
 
 RUN chmod +x /usr/local/server/helpers/before-start.sh
 RUN chmod +x /usr/local/server/helpers/start.sh
@@ -46,5 +46,7 @@ RUN chmod +x /usr/local/server/helpers/start.sh
 RUN chmod +x /usr/local/server/helpers/before-build.sh
 RUN chmod +x /usr/local/server/helpers/build.sh
 RUN chmod +x /usr/local/server/helpers/after-build.sh
+
+COPY . .
 
 EXPOSE 3000

--- a/runtimes/dart-2.15/Dockerfile
+++ b/runtimes/dart-2.15/Dockerfile
@@ -12,7 +12,7 @@ RUN mkdir -p /usr/local/server/src/function
 
 WORKDIR /usr/local/server
 
-COPY . .
+COPY ./helpers ./helpers
 
 RUN chmod +x /usr/local/server/helpers/before-start.sh
 RUN chmod +x /usr/local/server/helpers/start.sh
@@ -20,6 +20,8 @@ RUN chmod +x /usr/local/server/helpers/start.sh
 RUN chmod +x /usr/local/server/helpers/before-build.sh
 RUN chmod +x /usr/local/server/helpers/build.sh
 RUN chmod +x /usr/local/server/helpers/after-build.sh
+
+COPY . .
 
 RUN dart --disable-analytics
 

--- a/runtimes/dart-2.16/Dockerfile
+++ b/runtimes/dart-2.16/Dockerfile
@@ -12,7 +12,7 @@ RUN mkdir -p /usr/local/server/src/function
 
 WORKDIR /usr/local/server
 
-COPY . .
+COPY ./helpers ./helpers
 
 RUN chmod +x /usr/local/server/helpers/before-start.sh
 RUN chmod +x /usr/local/server/helpers/start.sh
@@ -20,6 +20,8 @@ RUN chmod +x /usr/local/server/helpers/start.sh
 RUN chmod +x /usr/local/server/helpers/before-build.sh
 RUN chmod +x /usr/local/server/helpers/build.sh
 RUN chmod +x /usr/local/server/helpers/after-build.sh
+
+COPY . .
 
 RUN dart --disable-analytics
 

--- a/runtimes/dart-2.17/Dockerfile
+++ b/runtimes/dart-2.17/Dockerfile
@@ -12,7 +12,7 @@ RUN mkdir -p /usr/local/server/src/function
 
 WORKDIR /usr/local/server
 
-COPY . .
+COPY ./helpers ./helpers
 
 RUN chmod +x /usr/local/server/helpers/before-start.sh
 RUN chmod +x /usr/local/server/helpers/start.sh
@@ -20,6 +20,8 @@ RUN chmod +x /usr/local/server/helpers/start.sh
 RUN chmod +x /usr/local/server/helpers/before-build.sh
 RUN chmod +x /usr/local/server/helpers/build.sh
 RUN chmod +x /usr/local/server/helpers/after-build.sh
+
+COPY . .
 
 RUN dart --disable-analytics
 

--- a/runtimes/dart-2.18/Dockerfile
+++ b/runtimes/dart-2.18/Dockerfile
@@ -12,7 +12,7 @@ RUN mkdir -p /usr/local/server/src/function
 
 WORKDIR /usr/local/server
 
-COPY . .
+COPY ./helpers ./helpers
 
 RUN chmod +x /usr/local/server/helpers/before-start.sh
 RUN chmod +x /usr/local/server/helpers/start.sh
@@ -20,6 +20,8 @@ RUN chmod +x /usr/local/server/helpers/start.sh
 RUN chmod +x /usr/local/server/helpers/before-build.sh
 RUN chmod +x /usr/local/server/helpers/build.sh
 RUN chmod +x /usr/local/server/helpers/after-build.sh
+
+COPY . .
 
 RUN dart --disable-analytics
 

--- a/runtimes/dart-2.19/Dockerfile
+++ b/runtimes/dart-2.19/Dockerfile
@@ -12,7 +12,7 @@ RUN mkdir -p /usr/local/server/src/function
 
 WORKDIR /usr/local/server
 
-COPY . .
+COPY ./helpers ./helpers
 
 RUN chmod +x /usr/local/server/helpers/before-start.sh
 RUN chmod +x /usr/local/server/helpers/start.sh
@@ -20,6 +20,8 @@ RUN chmod +x /usr/local/server/helpers/start.sh
 RUN chmod +x /usr/local/server/helpers/before-build.sh
 RUN chmod +x /usr/local/server/helpers/build.sh
 RUN chmod +x /usr/local/server/helpers/after-build.sh
+
+COPY . .
 
 RUN dart --disable-analytics
 

--- a/runtimes/dart-3.0/Dockerfile
+++ b/runtimes/dart-3.0/Dockerfile
@@ -12,7 +12,7 @@ RUN mkdir -p /usr/local/server/src/function
 
 WORKDIR /usr/local/server
 
-COPY . .
+COPY ./helpers ./helpers
 
 RUN chmod +x /usr/local/server/helpers/before-start.sh
 RUN chmod +x /usr/local/server/helpers/start.sh
@@ -20,6 +20,8 @@ RUN chmod +x /usr/local/server/helpers/start.sh
 RUN chmod +x /usr/local/server/helpers/before-build.sh
 RUN chmod +x /usr/local/server/helpers/build.sh
 RUN chmod +x /usr/local/server/helpers/after-build.sh
+
+COPY . .
 
 RUN dart --disable-analytics
 

--- a/runtimes/dart-3.1/Dockerfile
+++ b/runtimes/dart-3.1/Dockerfile
@@ -12,7 +12,7 @@ RUN mkdir -p /usr/local/server/src/function
 
 WORKDIR /usr/local/server
 
-COPY . .
+COPY ./helpers ./helpers
 
 RUN chmod +x /usr/local/server/helpers/before-start.sh
 RUN chmod +x /usr/local/server/helpers/start.sh
@@ -20,6 +20,8 @@ RUN chmod +x /usr/local/server/helpers/start.sh
 RUN chmod +x /usr/local/server/helpers/before-build.sh
 RUN chmod +x /usr/local/server/helpers/build.sh
 RUN chmod +x /usr/local/server/helpers/after-build.sh
+
+COPY . .
 
 RUN dart --disable-analytics
 

--- a/runtimes/deno-1.21/Dockerfile
+++ b/runtimes/deno-1.21/Dockerfile
@@ -16,7 +16,7 @@ ENV DENO_DIR=/usr/builds/deno-cache
 
 RUN deno install -qAf --unstable https://deno.land/x/denon@2.5.0/denon.ts
 
-COPY . .
+COPY ./helpers ./helpers
 
 RUN chmod +x /usr/local/server/helpers/before-start.sh
 RUN chmod +x /usr/local/server/helpers/start.sh
@@ -24,5 +24,7 @@ RUN chmod +x /usr/local/server/helpers/start.sh
 RUN chmod +x /usr/local/server/helpers/before-build.sh
 RUN chmod +x /usr/local/server/helpers/build.sh
 RUN chmod +x /usr/local/server/helpers/after-build.sh
+
+COPY . .
 
 EXPOSE 3000

--- a/runtimes/deno-1.24/Dockerfile
+++ b/runtimes/deno-1.24/Dockerfile
@@ -16,7 +16,7 @@ ENV DENO_DIR=/usr/builds/deno-cache
 
 RUN deno install -qAf --unstable https://deno.land/x/denon@2.5.0/denon.ts
 
-COPY . .
+COPY ./helpers ./helpers
 
 RUN chmod +x /usr/local/server/helpers/before-start.sh
 RUN chmod +x /usr/local/server/helpers/start.sh
@@ -24,5 +24,7 @@ RUN chmod +x /usr/local/server/helpers/start.sh
 RUN chmod +x /usr/local/server/helpers/before-build.sh
 RUN chmod +x /usr/local/server/helpers/build.sh
 RUN chmod +x /usr/local/server/helpers/after-build.sh
+
+COPY . .
 
 EXPOSE 3000

--- a/runtimes/deno-1.35/Dockerfile
+++ b/runtimes/deno-1.35/Dockerfile
@@ -16,7 +16,7 @@ ENV DENO_DIR=/usr/builds/deno-cache
 
 RUN deno install -qAf --unstable https://deno.land/x/denon@2.5.0/denon.ts
 
-COPY . .
+COPY ./helpers ./helpers
 
 RUN chmod +x /usr/local/server/helpers/before-start.sh
 RUN chmod +x /usr/local/server/helpers/start.sh
@@ -24,5 +24,7 @@ RUN chmod +x /usr/local/server/helpers/start.sh
 RUN chmod +x /usr/local/server/helpers/before-build.sh
 RUN chmod +x /usr/local/server/helpers/build.sh
 RUN chmod +x /usr/local/server/helpers/after-build.sh
+
+COPY . .
 
 EXPOSE 3000

--- a/runtimes/dotnet-6.0/Dockerfile
+++ b/runtimes/dotnet-6.0/Dockerfile
@@ -10,7 +10,7 @@ RUN mkdir -p /usr/local/server/src/function
 
 WORKDIR /usr/local/server
 
-COPY . .
+COPY ./helpers ./helpers
 
 RUN chmod +x /usr/local/server/helpers/before-start.sh
 RUN chmod +x /usr/local/server/helpers/start.sh
@@ -18,5 +18,7 @@ RUN chmod +x /usr/local/server/helpers/start.sh
 RUN chmod +x /usr/local/server/helpers/before-build.sh
 RUN chmod +x /usr/local/server/helpers/build.sh
 RUN chmod +x /usr/local/server/helpers/after-build.sh
+
+COPY . .
 
 EXPOSE 3000

--- a/runtimes/dotnet-7.0/Dockerfile
+++ b/runtimes/dotnet-7.0/Dockerfile
@@ -10,7 +10,7 @@ RUN mkdir -p /usr/local/server/src/function
 
 WORKDIR /usr/local/server
 
-COPY . .
+COPY ./helpers ./helpers
 
 RUN chmod +x /usr/local/server/helpers/before-start.sh
 RUN chmod +x /usr/local/server/helpers/start.sh
@@ -18,5 +18,7 @@ RUN chmod +x /usr/local/server/helpers/start.sh
 RUN chmod +x /usr/local/server/helpers/before-build.sh
 RUN chmod +x /usr/local/server/helpers/build.sh
 RUN chmod +x /usr/local/server/helpers/after-build.sh
+
+COPY . .
 
 EXPOSE 3000

--- a/runtimes/dotnet-8.0/Dockerfile
+++ b/runtimes/dotnet-8.0/Dockerfile
@@ -10,7 +10,7 @@ RUN mkdir -p /usr/local/server/src/function
 
 WORKDIR /usr/local/server
 
-COPY . .
+COPY ./helpers ./helpers
 
 RUN chmod +x /usr/local/server/helpers/before-start.sh
 RUN chmod +x /usr/local/server/helpers/start.sh
@@ -18,5 +18,7 @@ RUN chmod +x /usr/local/server/helpers/start.sh
 RUN chmod +x /usr/local/server/helpers/before-build.sh
 RUN chmod +x /usr/local/server/helpers/build.sh
 RUN chmod +x /usr/local/server/helpers/after-build.sh
+
+COPY . .
 
 EXPOSE 3000

--- a/runtimes/java-11.0/Dockerfile
+++ b/runtimes/java-11.0/Dockerfile
@@ -10,7 +10,7 @@ RUN mkdir -p /usr/local/server/src/function
 
 WORKDIR /usr/local/server
 
-COPY . .
+COPY ./helpers ./helpers
 
 RUN chmod +x /usr/local/server/helpers/before-start.sh
 RUN chmod +x /usr/local/server/helpers/start.sh
@@ -18,5 +18,7 @@ RUN chmod +x /usr/local/server/helpers/start.sh
 RUN chmod +x /usr/local/server/helpers/before-build.sh
 RUN chmod +x /usr/local/server/helpers/build.sh
 RUN chmod +x /usr/local/server/helpers/after-build.sh
+
+COPY . .
 
 EXPOSE 3000

--- a/runtimes/java-17.0/Dockerfile
+++ b/runtimes/java-17.0/Dockerfile
@@ -10,7 +10,7 @@ RUN mkdir -p /usr/local/server/src/function
 
 WORKDIR /usr/local/server
 
-COPY . .
+COPY ./helpers ./helpers
 
 RUN chmod +x /usr/local/server/helpers/before-start.sh
 RUN chmod +x /usr/local/server/helpers/start.sh
@@ -18,5 +18,7 @@ RUN chmod +x /usr/local/server/helpers/start.sh
 RUN chmod +x /usr/local/server/helpers/before-build.sh
 RUN chmod +x /usr/local/server/helpers/build.sh
 RUN chmod +x /usr/local/server/helpers/after-build.sh
+
+COPY . .
 
 EXPOSE 3000

--- a/runtimes/java-18.0/Dockerfile
+++ b/runtimes/java-18.0/Dockerfile
@@ -10,7 +10,7 @@ RUN mkdir -p /usr/local/server/src/function
 
 WORKDIR /usr/local/server
 
-COPY . .
+COPY ./helpers ./helpers
 
 RUN chmod +x /usr/local/server/helpers/before-start.sh
 RUN chmod +x /usr/local/server/helpers/start.sh
@@ -18,5 +18,7 @@ RUN chmod +x /usr/local/server/helpers/start.sh
 RUN chmod +x /usr/local/server/helpers/before-build.sh
 RUN chmod +x /usr/local/server/helpers/build.sh
 RUN chmod +x /usr/local/server/helpers/after-build.sh
+
+COPY . .
 
 EXPOSE 3000

--- a/runtimes/java-8.0/Dockerfile
+++ b/runtimes/java-8.0/Dockerfile
@@ -10,7 +10,7 @@ RUN mkdir -p /usr/local/server/src/function
 
 WORKDIR /usr/local/server
 
-COPY . .
+COPY ./helpers ./helpers
 
 RUN chmod +x /usr/local/server/helpers/before-start.sh
 RUN chmod +x /usr/local/server/helpers/start.sh
@@ -18,5 +18,7 @@ RUN chmod +x /usr/local/server/helpers/start.sh
 RUN chmod +x /usr/local/server/helpers/before-build.sh
 RUN chmod +x /usr/local/server/helpers/build.sh
 RUN chmod +x /usr/local/server/helpers/after-build.sh
+
+COPY . .
 
 EXPOSE 3000

--- a/runtimes/kotlin-1.6/Dockerfile
+++ b/runtimes/kotlin-1.6/Dockerfile
@@ -10,7 +10,7 @@ RUN mkdir -p /usr/local/server/src/function
 
 WORKDIR /usr/local/server
 
-COPY . .
+COPY ./helpers ./helpers
 
 RUN chmod +x /usr/local/server/helpers/before-start.sh
 RUN chmod +x /usr/local/server/helpers/start.sh
@@ -18,5 +18,7 @@ RUN chmod +x /usr/local/server/helpers/start.sh
 RUN chmod +x /usr/local/server/helpers/before-build.sh
 RUN chmod +x /usr/local/server/helpers/build.sh
 RUN chmod +x /usr/local/server/helpers/after-build.sh
+
+COPY . .
 
 EXPOSE 3000

--- a/runtimes/kotlin-1.8/Dockerfile
+++ b/runtimes/kotlin-1.8/Dockerfile
@@ -10,7 +10,7 @@ RUN mkdir -p /usr/local/server/src/function
 
 WORKDIR /usr/local/server
 
-COPY . .
+COPY ./helpers ./helpers
 
 RUN chmod +x /usr/local/server/helpers/before-start.sh
 RUN chmod +x /usr/local/server/helpers/start.sh
@@ -18,5 +18,7 @@ RUN chmod +x /usr/local/server/helpers/start.sh
 RUN chmod +x /usr/local/server/helpers/before-build.sh
 RUN chmod +x /usr/local/server/helpers/build.sh
 RUN chmod +x /usr/local/server/helpers/after-build.sh
+
+COPY . .
 
 EXPOSE 3000

--- a/runtimes/node-14.5/Dockerfile
+++ b/runtimes/node-14.5/Dockerfile
@@ -18,7 +18,7 @@ RUN npm install pm2 -g
 
 RUN npm ci && npm cache clean --force
 
-COPY . .
+COPY ./helpers ./helpers
 
 RUN chmod +x /usr/local/server/helpers/before-start.sh
 RUN chmod +x /usr/local/server/helpers/start.sh
@@ -26,5 +26,7 @@ RUN chmod +x /usr/local/server/helpers/start.sh
 RUN chmod +x /usr/local/server/helpers/before-build.sh
 RUN chmod +x /usr/local/server/helpers/build.sh
 RUN chmod +x /usr/local/server/helpers/after-build.sh
+
+COPY . .
 
 EXPOSE 3000

--- a/runtimes/node-16.0/Dockerfile
+++ b/runtimes/node-16.0/Dockerfile
@@ -18,7 +18,7 @@ RUN npm install pm2 -g
 
 RUN npm ci && npm cache clean --force
 
-COPY . .
+COPY ./helpers ./helpers
 
 RUN chmod +x /usr/local/server/helpers/before-start.sh
 RUN chmod +x /usr/local/server/helpers/start.sh
@@ -26,5 +26,7 @@ RUN chmod +x /usr/local/server/helpers/start.sh
 RUN chmod +x /usr/local/server/helpers/before-build.sh
 RUN chmod +x /usr/local/server/helpers/build.sh
 RUN chmod +x /usr/local/server/helpers/after-build.sh
+
+COPY . .
 
 EXPOSE 3000

--- a/runtimes/node-18.0/Dockerfile
+++ b/runtimes/node-18.0/Dockerfile
@@ -18,7 +18,7 @@ RUN npm install pm2 -g
 
 RUN npm ci && npm cache clean --force
 
-COPY . .
+COPY ./helpers ./helpers
 
 RUN chmod +x /usr/local/server/helpers/before-start.sh
 RUN chmod +x /usr/local/server/helpers/start.sh
@@ -26,5 +26,7 @@ RUN chmod +x /usr/local/server/helpers/start.sh
 RUN chmod +x /usr/local/server/helpers/before-build.sh
 RUN chmod +x /usr/local/server/helpers/build.sh
 RUN chmod +x /usr/local/server/helpers/after-build.sh
+
+COPY . .
 
 EXPOSE 3000

--- a/runtimes/node-19.0/Dockerfile
+++ b/runtimes/node-19.0/Dockerfile
@@ -18,7 +18,7 @@ RUN npm install pm2 -g
 
 RUN npm ci && npm cache clean --force
 
-COPY . .
+COPY ./helpers ./helpers
 
 RUN chmod +x /usr/local/server/helpers/before-start.sh
 RUN chmod +x /usr/local/server/helpers/start.sh
@@ -26,5 +26,7 @@ RUN chmod +x /usr/local/server/helpers/start.sh
 RUN chmod +x /usr/local/server/helpers/before-build.sh
 RUN chmod +x /usr/local/server/helpers/build.sh
 RUN chmod +x /usr/local/server/helpers/after-build.sh
+
+COPY . .
 
 EXPOSE 3000

--- a/runtimes/node-20.0/Dockerfile
+++ b/runtimes/node-20.0/Dockerfile
@@ -18,7 +18,7 @@ RUN npm install pm2 -g
 
 RUN npm ci && npm cache clean --force
 
-COPY . .
+COPY ./helpers ./helpers
 
 RUN chmod +x /usr/local/server/helpers/before-start.sh
 RUN chmod +x /usr/local/server/helpers/start.sh
@@ -26,5 +26,7 @@ RUN chmod +x /usr/local/server/helpers/start.sh
 RUN chmod +x /usr/local/server/helpers/before-build.sh
 RUN chmod +x /usr/local/server/helpers/build.sh
 RUN chmod +x /usr/local/server/helpers/after-build.sh
+
+COPY . .
 
 EXPOSE 3000

--- a/runtimes/php-8.0/Dockerfile
+++ b/runtimes/php-8.0/Dockerfile
@@ -66,10 +66,7 @@ COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 COPY --from=step0 /usr/local/lib/php/extensions/no-debug-non-zts-20200930/swoole.so /usr/local/lib/php/extensions/no-debug-non-zts-20200930/yasd.so* /usr/local/lib/php/extensions/no-debug-non-zts-20200930/
 
 # Add Source Code
-COPY . .
-
-RUN composer update --no-interaction --ignore-platform-reqs --optimize-autoloader --prefer-dist --no-dev
-RUN mv vendor vendor-server
+COPY ./helpers ./helpers
 
 RUN chmod +x /usr/local/server/helpers/before-start.sh
 RUN chmod +x /usr/local/server/helpers/start.sh
@@ -77,6 +74,11 @@ RUN chmod +x /usr/local/server/helpers/start.sh
 RUN chmod +x /usr/local/server/helpers/before-build.sh
 RUN chmod +x /usr/local/server/helpers/build.sh
 RUN chmod +x /usr/local/server/helpers/after-build.sh
+
+COPY . .
+
+RUN composer update --no-interaction --ignore-platform-reqs --optimize-autoloader --prefer-dist --no-dev
+RUN mv vendor vendor-server
 
 # Enable Extensions
 RUN echo extension=swoole.so >> /usr/local/etc/php/conf.d/swoole.ini

--- a/runtimes/php-8.1/Dockerfile
+++ b/runtimes/php-8.1/Dockerfile
@@ -66,10 +66,7 @@ COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 COPY --from=step0 /usr/local/lib/php/extensions/no-debug-non-zts-20210902/swoole.so /usr/local/lib/php/extensions/no-debug-non-zts-20210902/yasd.so* /usr/local/lib/php/extensions/no-debug-non-zts-20210902/
 
 # Add Source Code
-COPY . .
-
-RUN composer update --no-interaction --ignore-platform-reqs --optimize-autoloader --prefer-dist --no-dev
-RUN mv vendor vendor-server
+COPY ./helpers ./helpers
 
 RUN chmod +x /usr/local/server/helpers/before-start.sh
 RUN chmod +x /usr/local/server/helpers/start.sh
@@ -77,6 +74,11 @@ RUN chmod +x /usr/local/server/helpers/start.sh
 RUN chmod +x /usr/local/server/helpers/before-build.sh
 RUN chmod +x /usr/local/server/helpers/build.sh
 RUN chmod +x /usr/local/server/helpers/after-build.sh
+
+COPY . .
+
+RUN composer update --no-interaction --ignore-platform-reqs --optimize-autoloader --prefer-dist --no-dev
+RUN mv vendor vendor-server
 
 # Enable Extensions
 RUN echo extension=swoole.so >> /usr/local/etc/php/conf.d/swoole.ini

--- a/runtimes/php-8.2/Dockerfile
+++ b/runtimes/php-8.2/Dockerfile
@@ -67,10 +67,7 @@ COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 COPY --from=step0 /usr/local/lib/php/extensions/no-debug-non-zts-20220829/swoole.so /usr/local/lib/php/extensions/no-debug-non-zts-20220829/yasd.so* /usr/local/lib/php/extensions/no-debug-non-zts-20220829/
 
 # Add Source Code
-COPY . .
-
-RUN composer update --no-interaction --ignore-platform-reqs --optimize-autoloader --prefer-dist --no-dev
-RUN mv vendor vendor-server
+COPY ./helpers ./helpers
 
 RUN chmod +x /usr/local/server/helpers/before-start.sh
 RUN chmod +x /usr/local/server/helpers/start.sh
@@ -78,6 +75,11 @@ RUN chmod +x /usr/local/server/helpers/start.sh
 RUN chmod +x /usr/local/server/helpers/before-build.sh
 RUN chmod +x /usr/local/server/helpers/build.sh
 RUN chmod +x /usr/local/server/helpers/after-build.sh
+
+COPY . .
+
+RUN composer update --no-interaction --ignore-platform-reqs --optimize-autoloader --prefer-dist --no-dev
+RUN mv vendor vendor-server
 
 # Enable Extensions
 RUN echo extension=swoole.so >> /usr/local/etc/php/conf.d/swoole.ini

--- a/runtimes/python-3.10/Dockerfile
+++ b/runtimes/python-3.10/Dockerfile
@@ -16,7 +16,7 @@ COPY requirements.txt .
 
 RUN pip install --no-cache-dir -r requirements.txt
 
-COPY . .
+COPY ./helpers ./helpers
 
 RUN chmod +x /usr/local/server/helpers/before-start.sh
 RUN chmod +x /usr/local/server/helpers/start.sh
@@ -24,6 +24,8 @@ RUN chmod +x /usr/local/server/helpers/start.sh
 RUN chmod +x /usr/local/server/helpers/before-build.sh
 RUN chmod +x /usr/local/server/helpers/build.sh
 RUN chmod +x /usr/local/server/helpers/after-build.sh
+
+COPY . .
 
 ENV FLASK_APP="/usr/local/server/src/server.py"
 

--- a/runtimes/python-3.11/Dockerfile
+++ b/runtimes/python-3.11/Dockerfile
@@ -16,7 +16,7 @@ COPY requirements.txt .
 
 RUN pip install --no-cache-dir -r requirements.txt
 
-COPY . .
+COPY ./helpers ./helpers
 
 RUN chmod +x /usr/local/server/helpers/before-start.sh
 RUN chmod +x /usr/local/server/helpers/start.sh
@@ -24,6 +24,8 @@ RUN chmod +x /usr/local/server/helpers/start.sh
 RUN chmod +x /usr/local/server/helpers/before-build.sh
 RUN chmod +x /usr/local/server/helpers/build.sh
 RUN chmod +x /usr/local/server/helpers/after-build.sh
+
+COPY . .
 
 ENV FLASK_APP="/usr/local/server/src/server.py"
 

--- a/runtimes/python-3.12/Dockerfile
+++ b/runtimes/python-3.12/Dockerfile
@@ -16,7 +16,7 @@ COPY requirements.txt .
 
 RUN pip install --no-cache-dir -r requirements.txt
 
-COPY . .
+COPY ./helpers ./helpers
 
 RUN chmod +x /usr/local/server/helpers/before-start.sh
 RUN chmod +x /usr/local/server/helpers/start.sh
@@ -24,6 +24,8 @@ RUN chmod +x /usr/local/server/helpers/start.sh
 RUN chmod +x /usr/local/server/helpers/before-build.sh
 RUN chmod +x /usr/local/server/helpers/build.sh
 RUN chmod +x /usr/local/server/helpers/after-build.sh
+
+COPY . .
 
 ENV FLASK_APP="/usr/local/server/src/server.py"
 

--- a/runtimes/python-3.8/Dockerfile
+++ b/runtimes/python-3.8/Dockerfile
@@ -16,7 +16,7 @@ COPY requirements.txt .
 
 RUN pip install --no-cache-dir -r requirements.txt
 
-COPY . .
+COPY ./helpers ./helpers
 
 RUN chmod +x /usr/local/server/helpers/before-start.sh
 RUN chmod +x /usr/local/server/helpers/start.sh
@@ -24,6 +24,8 @@ RUN chmod +x /usr/local/server/helpers/start.sh
 RUN chmod +x /usr/local/server/helpers/before-build.sh
 RUN chmod +x /usr/local/server/helpers/build.sh
 RUN chmod +x /usr/local/server/helpers/after-build.sh
+
+COPY . .
 
 ENV FLASK_APP="/usr/local/server/src/server.py"
 

--- a/runtimes/python-3.9/Dockerfile
+++ b/runtimes/python-3.9/Dockerfile
@@ -16,7 +16,7 @@ COPY requirements.txt .
 
 RUN pip install --no-cache-dir -r requirements.txt
 
-COPY . .
+COPY ./helpers ./helpers
 
 RUN chmod +x /usr/local/server/helpers/before-start.sh
 RUN chmod +x /usr/local/server/helpers/start.sh
@@ -24,6 +24,8 @@ RUN chmod +x /usr/local/server/helpers/start.sh
 RUN chmod +x /usr/local/server/helpers/before-build.sh
 RUN chmod +x /usr/local/server/helpers/build.sh
 RUN chmod +x /usr/local/server/helpers/after-build.sh
+
+COPY . .
 
 ENV FLASK_APP="/usr/local/server/src/server.py"
 

--- a/runtimes/ruby-3.0/Dockerfile
+++ b/runtimes/ruby-3.0/Dockerfile
@@ -16,7 +16,7 @@ RUN apk add --update alpine-sdk
 
 RUN gem install bundler
 
-COPY . .
+COPY ./helpers ./helpers
 
 RUN chmod +x /usr/local/server/helpers/before-start.sh
 RUN chmod +x /usr/local/server/helpers/start.sh
@@ -24,5 +24,7 @@ RUN chmod +x /usr/local/server/helpers/start.sh
 RUN chmod +x /usr/local/server/helpers/before-build.sh
 RUN chmod +x /usr/local/server/helpers/build.sh
 RUN chmod +x /usr/local/server/helpers/after-build.sh
+
+COPY . .
 
 EXPOSE 3000

--- a/runtimes/ruby-3.1/Dockerfile
+++ b/runtimes/ruby-3.1/Dockerfile
@@ -16,7 +16,7 @@ RUN apk add --update alpine-sdk
 
 RUN gem install bundler
 
-COPY . .
+COPY ./helpers ./helpers
 
 RUN chmod +x /usr/local/server/helpers/before-start.sh
 RUN chmod +x /usr/local/server/helpers/start.sh
@@ -24,5 +24,7 @@ RUN chmod +x /usr/local/server/helpers/start.sh
 RUN chmod +x /usr/local/server/helpers/before-build.sh
 RUN chmod +x /usr/local/server/helpers/build.sh
 RUN chmod +x /usr/local/server/helpers/after-build.sh
+
+COPY . .
 
 EXPOSE 3000

--- a/runtimes/ruby-3.2/Dockerfile
+++ b/runtimes/ruby-3.2/Dockerfile
@@ -16,7 +16,7 @@ RUN apk add --update alpine-sdk
 
 RUN gem install bundler
 
-COPY . .
+COPY ./helpers ./helpers
 
 RUN chmod +x /usr/local/server/helpers/before-start.sh
 RUN chmod +x /usr/local/server/helpers/start.sh
@@ -24,5 +24,7 @@ RUN chmod +x /usr/local/server/helpers/start.sh
 RUN chmod +x /usr/local/server/helpers/before-build.sh
 RUN chmod +x /usr/local/server/helpers/build.sh
 RUN chmod +x /usr/local/server/helpers/after-build.sh
+
+COPY . .
 
 EXPOSE 3000

--- a/runtimes/swift-5.5/Dockerfile
+++ b/runtimes/swift-5.5/Dockerfile
@@ -10,7 +10,7 @@ RUN mkdir -p /usr/local/server/src/function
 
 WORKDIR /usr/local/server
 
-COPY . .
+COPY ./helpers ./helpers
 
 RUN chmod +x /usr/local/server/helpers/before-start.sh
 RUN chmod +x /usr/local/server/helpers/start.sh
@@ -18,5 +18,7 @@ RUN chmod +x /usr/local/server/helpers/start.sh
 RUN chmod +x /usr/local/server/helpers/before-build.sh
 RUN chmod +x /usr/local/server/helpers/build.sh
 RUN chmod +x /usr/local/server/helpers/after-build.sh
+
+COPY . .
 
 EXPOSE 3000

--- a/runtimes/swift-5.8/Dockerfile
+++ b/runtimes/swift-5.8/Dockerfile
@@ -10,7 +10,7 @@ RUN mkdir -p /usr/local/server/src/function
 
 WORKDIR /usr/local/server
 
-COPY . .
+COPY ./helpers ./helpers
 
 RUN chmod +x /usr/local/server/helpers/before-start.sh
 RUN chmod +x /usr/local/server/helpers/start.sh
@@ -18,5 +18,7 @@ RUN chmod +x /usr/local/server/helpers/start.sh
 RUN chmod +x /usr/local/server/helpers/before-build.sh
 RUN chmod +x /usr/local/server/helpers/build.sh
 RUN chmod +x /usr/local/server/helpers/after-build.sh
+
+COPY . .
 
 EXPOSE 3000


### PR DESCRIPTION
If a code change is made, permissions on helpers is set each time. For some reason, this is slow and takes 3-5 seconds (on Gitpod workspace)

Doing this trick in Dockerfile ensures that helper setup is only made when there is a change to helper files.


Before:


https://github.com/open-runtimes/open-runtimes/assets/19310830/b659effb-c62b-4ce9-bbd8-0535c3e1a973



After:


https://github.com/open-runtimes/open-runtimes/assets/19310830/4d4fba3d-7978-4321-9cc6-4c05d21b4564

