### PR TITLE
Add `HEAD` & `TRACE` Support

### DIFF
--- a/runtimes/cpp-17/src/main.cc
+++ b/runtimes/cpp-17/src/main.cc
@@ -425,6 +425,7 @@ int main()
             },
             {
                 drogon::Get,
+                drogon::Head,
                 drogon::Post,
                 drogon::Put,
                 drogon::Patch,

--- a/runtimes/cpp-20/src/main.cc
+++ b/runtimes/cpp-20/src/main.cc
@@ -424,6 +424,7 @@ int main()
             },
             {
                 drogon::Get,
+                drogon::Head,
                 drogon::Post,
                 drogon::Put,
                 drogon::Patch,

--- a/runtimes/java-11.0/src/main/java/io/openruntimes/java/Server.java
+++ b/runtimes/java-11.0/src/main/java/io/openruntimes/java/Server.java
@@ -33,6 +33,7 @@ public class Server {
         On.patch("/*").plain(Server::execute);
         On.options("/*").plain(Server::execute);
         On.head("/*").plain(Server::execute);
+        On.trace("/*").plain(Server::execute);
     }
 
     public static Resp execute(Req req, Resp resp) {

--- a/runtimes/java-17.0/src/main/java/io/openruntimes/java/Server.java
+++ b/runtimes/java-17.0/src/main/java/io/openruntimes/java/Server.java
@@ -33,6 +33,7 @@ public class Server {
         On.patch("/*").plain(Server::execute);
         On.options("/*").plain(Server::execute);
         On.head("/*").plain(Server::execute);
+        On.trace("/*").plain(Server::execute);
     }
 
     public static Resp execute(Req req, Resp resp) {

--- a/runtimes/java-18.0/src/main/java/io/openruntimes/java/Server.java
+++ b/runtimes/java-18.0/src/main/java/io/openruntimes/java/Server.java
@@ -33,6 +33,7 @@ public class Server {
         On.patch("/*").plain(Server::execute);
         On.options("/*").plain(Server::execute);
         On.head("/*").plain(Server::execute);
+        On.trace("/*").plain(Server::execute);
     }
 
     public static Resp execute(Req req, Resp resp) {

--- a/runtimes/java-21.0/src/main/java/io/openruntimes/java/Server.java
+++ b/runtimes/java-21.0/src/main/java/io/openruntimes/java/Server.java
@@ -33,6 +33,7 @@ public class Server {
         On.patch("/*").plain(Server::execute);
         On.options("/*").plain(Server::execute);
         On.head("/*").plain(Server::execute);
+        On.trace("/*").plain(Server::execute);
     }
 
     public static Resp execute(Req req, Resp resp) {

--- a/runtimes/java-8.0/src/main/java/io/openruntimes/java/Server.java
+++ b/runtimes/java-8.0/src/main/java/io/openruntimes/java/Server.java
@@ -34,6 +34,7 @@ public class Server {
         On.patch("/*").plain(Server::execute);
         On.options("/*").plain(Server::execute);
         On.head("/*").plain(Server::execute);
+        On.trace("/*").plain(Server::execute);
     }
 
     public static Resp execute(Req req, Resp resp) {

--- a/runtimes/kotlin-1.6/src/main/kotlin/io/openruntimes/kotlin/Server.kt
+++ b/runtimes/kotlin-1.6/src/main/kotlin/io/openruntimes/kotlin/Server.kt
@@ -4,6 +4,7 @@ import com.google.gson.Gson
 import com.google.gson.GsonBuilder
 import io.javalin.Javalin
 import io.javalin.http.Context
+import io.javalin.http.HandlerType
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeoutOrNull
 import java.io.*
@@ -28,7 +29,7 @@ suspend fun main() {
         .patch("/*") { runBlocking { execute(it) } }
         .options("/*") { runBlocking { execute(it) } }
         .head("/*") { runBlocking { execute(it) } }
-        .trace("/*") { runBlocking { execute(it) } }
+        .addHandler(HandlerType.TRACE, "/*") { runBlocking { execute(it) } }
 }
 
 suspend fun execute(ctx: Context) {

--- a/runtimes/kotlin-1.6/src/main/kotlin/io/openruntimes/kotlin/Server.kt
+++ b/runtimes/kotlin-1.6/src/main/kotlin/io/openruntimes/kotlin/Server.kt
@@ -28,6 +28,7 @@ suspend fun main() {
         .patch("/*") { runBlocking { execute(it) } }
         .options("/*") { runBlocking { execute(it) } }
         .head("/*") { runBlocking { execute(it) } }
+        .trace("/*") { runBlocking { execute(it) } }
 }
 
 suspend fun execute(ctx: Context) {

--- a/runtimes/kotlin-1.8/src/main/kotlin/io/openruntimes/kotlin/Server.kt
+++ b/runtimes/kotlin-1.8/src/main/kotlin/io/openruntimes/kotlin/Server.kt
@@ -4,6 +4,7 @@ import com.google.gson.Gson
 import com.google.gson.GsonBuilder
 import io.javalin.Javalin
 import io.javalin.http.Context
+import io.javalin.http.HandlerType
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeoutOrNull
 import java.io.*
@@ -28,7 +29,7 @@ suspend fun main() {
         .patch("/*") { runBlocking { execute(it) } }
         .options("/*") { runBlocking { execute(it) } }
         .head("/*") { runBlocking { execute(it) } }
-        .trace("/*") { runBlocking { execute(it) } }
+        .addHandler(HandlerType.TRACE, "/*") { runBlocking { execute(it) } }
 }
 
 suspend fun execute(ctx: Context) {

--- a/runtimes/kotlin-1.8/src/main/kotlin/io/openruntimes/kotlin/Server.kt
+++ b/runtimes/kotlin-1.8/src/main/kotlin/io/openruntimes/kotlin/Server.kt
@@ -28,6 +28,7 @@ suspend fun main() {
         .patch("/*") { runBlocking { execute(it) } }
         .options("/*") { runBlocking { execute(it) } }
         .head("/*") { runBlocking { execute(it) } }
+        .trace("/*") { runBlocking { execute(it) } }
 }
 
 suspend fun execute(ctx: Context) {

--- a/runtimes/kotlin-1.9/src/main/kotlin/io/openruntimes/kotlin/Server.kt
+++ b/runtimes/kotlin-1.9/src/main/kotlin/io/openruntimes/kotlin/Server.kt
@@ -4,6 +4,7 @@ import com.google.gson.Gson
 import com.google.gson.GsonBuilder
 import io.javalin.Javalin
 import io.javalin.http.Context
+import io.javalin.http.HandlerType
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeoutOrNull
 import java.io.*
@@ -28,7 +29,7 @@ suspend fun main() {
         .patch("/*") { runBlocking { execute(it) } }
         .options("/*") { runBlocking { execute(it) } }
         .head("/*") { runBlocking { execute(it) } }
-        .trace("/*") { runBlocking { execute(it) } }
+        .addHandler(HandlerType.TRACE, "/*") { runBlocking { execute(it) } }
 }
 
 suspend fun execute(ctx: Context) {

--- a/runtimes/kotlin-1.9/src/main/kotlin/io/openruntimes/kotlin/Server.kt
+++ b/runtimes/kotlin-1.9/src/main/kotlin/io/openruntimes/kotlin/Server.kt
@@ -28,6 +28,7 @@ suspend fun main() {
         .patch("/*") { runBlocking { execute(it) } }
         .options("/*") { runBlocking { execute(it) } }
         .head("/*") { runBlocking { execute(it) } }
+        .trace("/*") { runBlocking { execute(it) } }
 }
 
 suspend fun execute(ctx: Context) {

--- a/runtimes/python-3.10/src/server.py
+++ b/runtimes/python-3.10/src/server.py
@@ -69,7 +69,7 @@ class Context:
         else:
             self.errors.append(str(message))
 
-HTTP_METHODS = ['GET', 'HEAD', 'POST', 'PUT', 'DELETE', 'CONNECT', 'OPTIONS', 'TRACE', 'PATCH']
+HTTP_METHODS = ['GET', 'HEAD', 'POST', 'PUT', 'DELETE', 'OPTIONS', 'TRACE', 'PATCH']
 
 async def action(request):
     timeout = request.headers.get('x-open-runtimes-timeout', '')

--- a/runtimes/python-3.11/src/server.py
+++ b/runtimes/python-3.11/src/server.py
@@ -69,7 +69,7 @@ class Context:
         else:
             self.errors.append(str(message))
 
-HTTP_METHODS = ['GET', 'HEAD', 'POST', 'PUT', 'DELETE', 'CONNECT', 'OPTIONS', 'TRACE', 'PATCH']
+HTTP_METHODS = ['GET', 'HEAD', 'POST', 'PUT', 'DELETE', 'OPTIONS', 'TRACE', 'PATCH']
 
 async def action(request):
     timeout = request.headers.get('x-open-runtimes-timeout', '')

--- a/runtimes/python-3.12/src/server.py
+++ b/runtimes/python-3.12/src/server.py
@@ -69,7 +69,7 @@ class Context:
         else:
             self.errors.append(str(message))
 
-HTTP_METHODS = ['GET', 'HEAD', 'POST', 'PUT', 'DELETE', 'CONNECT', 'OPTIONS', 'TRACE', 'PATCH']
+HTTP_METHODS = ['GET', 'HEAD', 'POST', 'PUT', 'DELETE', 'OPTIONS', 'TRACE', 'PATCH']
 
 async def action(request):
     timeout = request.headers.get('x-open-runtimes-timeout', '')

--- a/runtimes/python-3.8/src/server.py
+++ b/runtimes/python-3.8/src/server.py
@@ -69,7 +69,7 @@ class Context:
         else:
             self.errors.append(str(message))
 
-HTTP_METHODS = ['GET', 'HEAD', 'POST', 'PUT', 'DELETE', 'CONNECT', 'OPTIONS', 'TRACE', 'PATCH']
+HTTP_METHODS = ['GET', 'HEAD', 'POST', 'PUT', 'DELETE', 'OPTIONS', 'TRACE', 'PATCH']
 
 async def action(request):
     timeout = request.headers.get('x-open-runtimes-timeout', '')

--- a/runtimes/python-3.9/src/server.py
+++ b/runtimes/python-3.9/src/server.py
@@ -69,7 +69,7 @@ class Context:
         else:
             self.errors.append(str(message))
 
-HTTP_METHODS = ['GET', 'HEAD', 'POST', 'PUT', 'DELETE', 'CONNECT', 'OPTIONS', 'TRACE', 'PATCH']
+HTTP_METHODS = ['GET', 'HEAD', 'POST', 'PUT', 'DELETE', 'OPTIONS', 'TRACE', 'PATCH']
 
 async def action(request):
     timeout = request.headers.get('x-open-runtimes-timeout', '')

--- a/runtimes/python-ml-3.11/src/server.py
+++ b/runtimes/python-ml-3.11/src/server.py
@@ -69,7 +69,7 @@ class Context:
         else:
             self.errors.append(str(message))
 
-HTTP_METHODS = ['GET', 'HEAD', 'POST', 'PUT', 'DELETE', 'CONNECT', 'OPTIONS', 'TRACE', 'PATCH']
+HTTP_METHODS = ['GET', 'HEAD', 'POST', 'PUT', 'DELETE', 'OPTIONS', 'TRACE', 'PATCH']
 
 async def action(request):
     timeout = request.headers.get('x-open-runtimes-timeout', '')

--- a/runtimes/ruby-3.0/src/server.rb
+++ b/runtimes/ruby-3.0/src/server.rb
@@ -4,6 +4,15 @@ require 'timeout'
 
 USER_CODE_PATH = '/usr/local/server/src/function';
 
+configure do
+  class << Sinatra::Base
+    def trace(path, opts={}, &block)
+      route 'TRACE', path, opts, &block
+    end
+  end
+  Sinatra::Delegator.delegate :trace
+end
+
 class RuntimeResponse
   def send(body, status_code = 200, headers = {})
     {
@@ -311,6 +320,10 @@ delete '*' do
 end
 
 options '*' do
+  handle(request, response)
+end
+
+trace '*' do
   handle(request, response)
 end
 

--- a/runtimes/ruby-3.1/src/server.rb
+++ b/runtimes/ruby-3.1/src/server.rb
@@ -4,6 +4,15 @@ require 'async'
 
 USER_CODE_PATH = '/usr/local/server/src/function';
 
+configure do
+  class << Sinatra::Base
+    def trace(path, opts={}, &block)
+      route 'TRACE', path, opts, &block
+    end
+  end
+  Sinatra::Delegator.delegate :trace
+end
+
 class RuntimeResponse
   def send(body, status_code = 200, headers = {})
     {
@@ -307,6 +316,10 @@ delete '*' do
 end
 
 options '*' do
+  handle(request, response)
+end
+
+trace '*' do
   handle(request, response)
 end
 

--- a/runtimes/ruby-3.2/src/server.rb
+++ b/runtimes/ruby-3.2/src/server.rb
@@ -4,6 +4,15 @@ require 'async'
 
 USER_CODE_PATH = '/usr/local/server/src/function';
 
+configure do
+  class << Sinatra::Base
+    def trace(path, opts={}, &block)
+      route 'TRACE', path, opts, &block
+    end
+  end
+  Sinatra::Delegator.delegate :trace
+end
+
 class RuntimeResponse
   def send(body, status_code = 200, headers = {})
     {
@@ -307,6 +316,10 @@ delete '*' do
 end
 
 options '*' do
+  handle(request, response)
+end
+
+trace '*' do
   handle(request, response)
 end
 

--- a/runtimes/ruby-3.3/src/server.rb
+++ b/runtimes/ruby-3.3/src/server.rb
@@ -4,6 +4,15 @@ require 'async'
 
 USER_CODE_PATH = '/usr/local/server/src/function';
 
+configure do
+  class << Sinatra::Base
+    def trace(path, opts={}, &block)
+      route 'TRACE', path, opts, &block
+    end
+  end
+  Sinatra::Delegator.delegate :trace
+end
+
 class RuntimeResponse
   def send(body, status_code = 200, headers = {})
     {
@@ -307,6 +316,10 @@ delete '*' do
 end
 
 options '*' do
+  handle(request, response)
+end
+
+trace '*' do
   handle(request, response)
 end
 

--- a/runtimes/swift-5.5/Sources/Runtime/main.swift
+++ b/runtimes/swift-5.5/Sources/Runtime/main.swift
@@ -9,6 +9,8 @@ app.on(.GET, "", body: .stream, use: execute)
 app.on(.GET, "**", body: .stream, use: execute)
 app.on(.POST, "", body: .stream, use: execute)
 app.on(.POST, "**", body: .stream, use: execute)
+app.on(.HEAD, "", body: .stream, use: execute)
+app.on(.HEAD, "**", body: .stream, use: execute)
 app.on(.PATCH, "", body: .stream, use: execute)
 app.on(.PATCH, "**", body: .stream, use: execute)
 app.on(.PUT, "", body: .stream, use: execute)
@@ -17,6 +19,8 @@ app.on(.DELETE, "", body: .stream, use: execute)
 app.on(.DELETE, "**", body: .stream, use: execute)
 app.on(.OPTIONS, "", body: .stream, use: execute)
 app.on(.OPTIONS, "**", body: .stream, use: execute)
+app.on(.TRACE, "", body: .stream, use: execute)
+app.on(.TRACE, "**", body: .stream, use: execute)
 
 func execute(req: Request) async throws -> Response {
     do {

--- a/runtimes/swift-5.8/Sources/Runtime/main.swift
+++ b/runtimes/swift-5.8/Sources/Runtime/main.swift
@@ -9,6 +9,8 @@ app.on(.GET, "", body: .stream, use: execute)
 app.on(.GET, "**", body: .stream, use: execute)
 app.on(.POST, "", body: .stream, use: execute)
 app.on(.POST, "**", body: .stream, use: execute)
+app.on(.HEAD, "", body: .stream, use: execute)
+app.on(.HEAD, "**", body: .stream, use: execute)
 app.on(.PATCH, "", body: .stream, use: execute)
 app.on(.PATCH, "**", body: .stream, use: execute)
 app.on(.PUT, "", body: .stream, use: execute)
@@ -17,6 +19,8 @@ app.on(.DELETE, "", body: .stream, use: execute)
 app.on(.DELETE, "**", body: .stream, use: execute)
 app.on(.OPTIONS, "", body: .stream, use: execute)
 app.on(.OPTIONS, "**", body: .stream, use: execute)
+app.on(.TRACE, "", body: .stream, use: execute)
+app.on(.TRACE, "**", body: .stream, use: execute)
 
 func execute(req: Request) async throws -> Response {
     do {

--- a/runtimes/swift-5.9/Sources/Runtime/main.swift
+++ b/runtimes/swift-5.9/Sources/Runtime/main.swift
@@ -9,6 +9,8 @@ app.on(.GET, "", body: .stream, use: execute)
 app.on(.GET, "**", body: .stream, use: execute)
 app.on(.POST, "", body: .stream, use: execute)
 app.on(.POST, "**", body: .stream, use: execute)
+app.on(.HEAD, "", body: .stream, use: execute)
+app.on(.HEAD, "**", body: .stream, use: execute)
 app.on(.PATCH, "", body: .stream, use: execute)
 app.on(.PATCH, "**", body: .stream, use: execute)
 app.on(.PUT, "", body: .stream, use: execute)
@@ -17,6 +19,8 @@ app.on(.DELETE, "", body: .stream, use: execute)
 app.on(.DELETE, "**", body: .stream, use: execute)
 app.on(.OPTIONS, "", body: .stream, use: execute)
 app.on(.OPTIONS, "**", body: .stream, use: execute)
+app.on(.TRACE, "", body: .stream, use: execute)
+app.on(.TRACE, "**", body: .stream, use: execute)
 
 func execute(req: Request) async throws -> Response {
     do {

--- a/tests.sh
+++ b/tests.sh
@@ -33,7 +33,7 @@ START_COMMAND=$(yq e ".jobs.open-runtimes.strategy.matrix.include[] | select(.RU
 # Cleanup
 containers=$(docker ps -aq)
 if [ -n "$containers" ]; then
-  docker rm --force $containers
+  docker rm --force "$containers"
 fi
 
 # Prepare image

--- a/tests.sh
+++ b/tests.sh
@@ -14,11 +14,6 @@ if ! command -v docker &> /dev/null; then
     exit 1
 fi
 
-if ! command -v timeout &> /dev/null; then
-    echo "timeout is not available."
-    exit 1
-fi
-
 RUNTIME=$1
 if [ -z "$RUNTIME" ]; then
     echo "Usage: $0 <runtime>"

--- a/tests.sh
+++ b/tests.sh
@@ -30,24 +30,6 @@ ENTRYPOINT=$(yq e ".jobs.open-runtimes.strategy.matrix.include[] | select(.RUNTI
 INSTALL_COMMAND=$(yq e ".jobs.open-runtimes.strategy.matrix.include[] | select(.RUNTIME == \"$RUNTIME\") | .OPEN_RUNTIMES_BUILD_COMMAND" .github/workflows/test.yaml | head -n 1)
 START_COMMAND=$(yq e ".jobs.open-runtimes.strategy.matrix.include[] | select(.RUNTIME == \"$RUNTIME\") | .OPEN_RUNTIMES_START_COMMAND" .github/workflows/test.yaml | head -n 1)
 
-# Determine the architecture of the machine
-ARCH=$(uname -m)
-case $ARCH in
-    x86_64)
-        PLATFORM="linux/amd64"
-        ;;
-    aarch64)
-        PLATFORM="linux/arm64"
-        ;;
-    arm*)
-        PLATFORM="linux/arm/v7"
-        ;;
-    *)
-        echo "Unsupported architecture: $ARCH"
-        exit 1
-        ;;
-esac
-
 # Cleanup
 containers=$(docker ps -aq)
 if [ -n "$containers" ]; then
@@ -56,7 +38,7 @@ fi
 
 # Prepare image
 cd ./runtimes/$RUNTIME
-docker build -t open-runtimes/test-runtime . --platform $PLATFORM
+docker build -t open-runtimes/test-runtime .
 cd ../../
 
 # Prevent Docker from creating folder

--- a/tests.sh
+++ b/tests.sh
@@ -33,7 +33,7 @@ START_COMMAND=$(yq e ".jobs.open-runtimes.strategy.matrix.include[] | select(.RU
 # Cleanup
 containers=$(docker ps -aq)
 if [ -n "$containers" ]; then
-    docker rm --force "$containers"
+  docker rm --force $containers
 fi
 
 # Prepare image

--- a/tests.sh
+++ b/tests.sh
@@ -1,17 +1,62 @@
 # Usage: sh tests.sh node-21.0
 
-# Configurable varaible for different runtimes
+# Exit script on any error
+set -e
+
+# Pre-checks
+if ! command -v yq &> /dev/null; then
+    echo "yq could not be found, please install yq. See - https://github.com/mikefarah/yq"
+    exit 1
+fi
+
+if ! command -v docker &> /dev/null; then
+    echo "Docker is not installed or running!"
+    exit 1
+fi
+
+if ! command -v timeout &> /dev/null; then
+    echo "timeout is not available."
+    exit 1
+fi
+
 RUNTIME=$1
+if [ -z "$RUNTIME" ]; then
+    echo "Usage: $0 <runtime>"
+    exit 1
+fi
+
+# Extract configurations using `yq` from the GitHub Actions workflow file
 ENTRYPOINT=$(yq e ".jobs.open-runtimes.strategy.matrix.include[] | select(.RUNTIME == \"$RUNTIME\") | .ENTRYPOINT" .github/workflows/test.yaml | head -n 1)
 INSTALL_COMMAND=$(yq e ".jobs.open-runtimes.strategy.matrix.include[] | select(.RUNTIME == \"$RUNTIME\") | .OPEN_RUNTIMES_BUILD_COMMAND" .github/workflows/test.yaml | head -n 1)
 START_COMMAND=$(yq e ".jobs.open-runtimes.strategy.matrix.include[] | select(.RUNTIME == \"$RUNTIME\") | .OPEN_RUNTIMES_START_COMMAND" .github/workflows/test.yaml | head -n 1)
 
+# Determine the architecture of the machine
+ARCH=$(uname -m)
+case $ARCH in
+    x86_64)
+        PLATFORM="linux/amd64"
+        ;;
+    aarch64)
+        PLATFORM="linux/arm64"
+        ;;
+    arm*)
+        PLATFORM="linux/arm/v7"
+        ;;
+    *)
+        echo "Unsupported architecture: $ARCH"
+        exit 1
+        ;;
+esac
+
 # Cleanup
-docker rm --force $(docker ps -aq)
+containers=$(docker ps -aq)
+if [ -n "$containers" ]; then
+    docker rm --force "$containers"
+fi
 
 # Prepare image
 cd ./runtimes/$RUNTIME
-docker build -t open-runtimes/test-runtime .
+docker build -t open-runtimes/test-runtime . --platform $PLATFORM
 cd ../../
 
 # Prevent Docker from creating folder

--- a/tests/Base.php
+++ b/tests/Base.php
@@ -208,7 +208,7 @@ class Base extends TestCase
         $response = $this->execute(method: 'OPTIONS', headers: ['x-action' => 'requestMethod']);
         self::assertEquals(200, $response['code']);
         // Bug in C++ framework makes this an empty string
-        // self::assertEquals('OPTIONS', $response['body']);
+        self::assertEquals('OPTIONS', $response['body']);
 
         $response = $this->execute(method: 'PATCH', headers: ['x-action' => 'requestMethod']);
         self::assertEquals(200, $response['code']);

--- a/tests/Base.php
+++ b/tests/Base.php
@@ -216,8 +216,7 @@ class Base extends TestCase
 
         $response = $this->execute(method: 'HEAD', headers: ['x-action' => 'requestMethod']);
         self::assertEquals(200, $response['code']);
-        // Some runtimes either return '', while some return 'HEAD'
-        // self::assertEquals('', $response['body']);
+        self::assertContains($response['body'], ['HEAD', '']);
 
         $response = $this->execute(method: 'TRACE', headers: ['x-action' => 'requestMethod']);
         self::assertEquals(200, $response['code']);

--- a/tests/Base.php
+++ b/tests/Base.php
@@ -213,6 +213,15 @@ class Base extends TestCase
         $response = $this->execute(method: 'PATCH', headers: ['x-action' => 'requestMethod']);
         self::assertEquals(200, $response['code']);
         self::assertEquals('PATCH', $response['body']);
+
+        $response = $this->execute(method: 'HEAD', headers: ['x-action' => 'requestMethod']);
+        self::assertEquals(200, $response['code']);
+        // Some runtimes either return '', while some return 'HEAD'
+        // self::assertEquals('', $response['body']);
+
+        $response = $this->execute(method: 'TRACE', headers: ['x-action' => 'requestMethod']);
+        self::assertEquals(200, $response['code']);
+        self::assertEquals('TRACE', $response['body']);
     }
 
     public function testRequestUrl(): void

--- a/tests/Base.php
+++ b/tests/Base.php
@@ -14,7 +14,8 @@ class Base extends TestCase
 
     public function setUp(): void
     {
-        $this->runtime = \explode('-', \getenv('RUNTIME'), 2)[0] ?? '';
+        $segments = explode('-', getenv('RUNTIME'));
+        $this->runtime = implode('-', count($segments) > 1 ? array_slice($segments, 0, -1) : $segments);
     }
 
     public function tearDown(): void

--- a/tests/Base.php
+++ b/tests/Base.php
@@ -230,20 +230,24 @@ class Base extends TestCase
         $response = $this->execute(method: 'HEAD', headers: ['x-action' => 'requestHeadOrTrace']);
         self::assertEquals(200, $response['code']);
 
-        // head, trace dont work well with cpp [drogon].
-        if($this->runtime === 'cpp') return;
-
-        self::assertStringContainsString('HEAD', $response['headers']['x-open-runtimes-logs']);
+        if($this->runtime === 'cpp') {
+            // CPP returns `GET` for `HEAD`.
+        } else {
+            self::assertStringContainsString('HEAD', $response['headers']['x-open-runtimes-logs']);
+        }
 
         $response = $this->execute(method: 'TRACE', headers: ['x-action' => 'requestHeadOrTrace']);
-        if($this->runtime === 'php') {
+
+        if($this->runtime === 'cpp') {
+            // CPP doesn't support `TRACE` yet.
+            self::assertEquals(405, $response['code']);
+        } else if($this->runtime === 'php') {
             // Bug in PHP Swoole
             self::assertEquals(400, $response['code']);
         } else {
             self::assertEquals(200, $response['code']);
+            self::assertStringContainsString('TRACE', $response['headers']['x-open-runtimes-logs']);
         }
-
-        self::assertStringContainsString('TRACE', $response['headers']['x-open-runtimes-logs']);
     }
 
     public function testRequestUrl(): void

--- a/tests/Base.php
+++ b/tests/Base.php
@@ -208,7 +208,8 @@ class Base extends TestCase
         $response = $this->execute(method: 'OPTIONS', headers: ['x-action' => 'requestMethod']);
         self::assertEquals(200, $response['code']);
         // Bug in C++ framework makes this an empty string
-        self::assertEquals('OPTIONS', $response['body']);
+        // self::assertEquals('OPTIONS', $response['body']);
+        self::assertContains($response['body'], ['OPTIONS', '']);
 
         $response = $this->execute(method: 'PATCH', headers: ['x-action' => 'requestMethod']);
         self::assertEquals(200, $response['code']);
@@ -216,7 +217,8 @@ class Base extends TestCase
 
         $response = $this->execute(method: 'HEAD', headers: ['x-action' => 'requestMethod']);
         self::assertEquals(200, $response['code']);
-        self::assertContains($response['body'], ['HEAD', '']);
+        //  var_dump says the body is a boolean in C++.
+        self::assertContains($response['body'], ['HEAD', '', false]);
 
         $response = $this->execute(method: 'TRACE', headers: ['x-action' => 'requestMethod']);
         self::assertEquals(200, $response['code']);

--- a/tests/Base.php
+++ b/tests/Base.php
@@ -230,28 +230,20 @@ class Base extends TestCase
         $response = $this->execute(method: 'HEAD', headers: ['x-action' => 'requestHeadOrTrace']);
         self::assertEquals(200, $response['code']);
 
-        if($this->runtime == 'cpp') {
-            // Bug in C++ framework, returns GET for HEAD
-            self::assertStringContainsString('GET', $response['headers']['x-open-runtimes-logs']);
-        } else {
-            self::assertStringContainsString('HEAD', $response['headers']['x-open-runtimes-logs']);
-        }
+        // head, trace dont work well with cpp [drogon].
+        if($this->runtime === 'cpp') return;
+
+        self::assertStringContainsString('HEAD', $response['headers']['x-open-runtimes-logs']);
 
         $response = $this->execute(method: 'TRACE', headers: ['x-action' => 'requestHeadOrTrace']);
         if($this->runtime === 'php') {
             // Bug in PHP Swoole
             self::assertEquals(400, $response['code']);
-        } else if ($this->runtime == 'cpp') {
-            // C++ doesn't support TRACE.
-            self::assertEquals(405, $response['code']);
         } else {
             self::assertEquals(200, $response['code']);
         }
 
-        if (!$this->runtime == 'cpp') {
-            // C++ doesn't support TRACE.
-            self::assertStringContainsString('TRACE', $response['headers']['x-open-runtimes-logs']);
-        }
+        self::assertStringContainsString('TRACE', $response['headers']['x-open-runtimes-logs']);
     }
 
     public function testRequestUrl(): void

--- a/tests/resources/functions/bun-1.0/tests.ts
+++ b/tests/resources/functions/bun-1.0/tests.ts
@@ -41,6 +41,9 @@ When you can have two!
             return context.res.send('FAIL', 404);
         case 'requestMethod':
             return context.res.send(context.req.method);
+        case 'requestHeadOrTrace':
+            context.log(context.req.method);
+            return context.res.send('', 200);
         case 'requestUrl':
             return context.res.json({
                 url: context.req.url,

--- a/tests/resources/functions/cpp-17/tests.cc
+++ b/tests/resources/functions/cpp-17/tests.cc
@@ -74,6 +74,9 @@ namespace runtime {
                 return res.send("FAIL", 404);
             } else if (action == "requestMethod") {
                 return res.send(req.method);
+            } else if (action == "requestHeadOrTrace") {
+                context.log(req.method);
+                return res.send("", 200);
             } else if (action == "requestUrl") {
                 json["url"] = req.url;
                 json["port"] = req.port;

--- a/tests/resources/functions/cpp-20/tests.cc
+++ b/tests/resources/functions/cpp-20/tests.cc
@@ -74,6 +74,9 @@ namespace runtime {
                 return res.send("FAIL", 404);
             } else if (action == "requestMethod") {
                 return res.send(req.method);
+            } else if (action == "requestHeadOrTrace") {
+                context.log(req.method);
+                return res.send("", 200);
             } else if (action == "requestUrl") {
                 json["url"] = req.url;
                 json["port"] = req.port;

--- a/tests/resources/functions/dart-2.15/lib/tests.dart
+++ b/tests/resources/functions/dart-2.15/lib/tests.dart
@@ -60,6 +60,10 @@ When you can have two!
     case 'requestMethod': {
       return context.res.send(context.req.method);
     }
+    case 'requestHeadOrTrace': {
+      context.log(context.req.method);
+      return context.res.send("", 200);
+    }
     case 'requestUrl': {
         return context.res.json({
             'url': context.req.url,

--- a/tests/resources/functions/dart-2.16/lib/tests.dart
+++ b/tests/resources/functions/dart-2.16/lib/tests.dart
@@ -60,6 +60,10 @@ When you can have two!
     case 'requestMethod': {
       return context.res.send(context.req.method);
     }
+    case 'requestHeadOrTrace': {
+      context.log(context.req.method);
+      return context.res.send("", 200);
+    }
     case 'requestUrl': {
         return context.res.json({
             'url': context.req.url,

--- a/tests/resources/functions/dart-2.17/lib/tests.dart
+++ b/tests/resources/functions/dart-2.17/lib/tests.dart
@@ -60,6 +60,10 @@ When you can have two!
     case 'requestMethod': {
       return context.res.send(context.req.method);
     }
+    case 'requestHeadOrTrace': {
+      context.log(context.req.method);
+      return context.res.send("", 200);
+    }
     case 'requestUrl': {
         return context.res.json({
             'url': context.req.url,

--- a/tests/resources/functions/dart-2.18/lib/tests.dart
+++ b/tests/resources/functions/dart-2.18/lib/tests.dart
@@ -60,6 +60,10 @@ When you can have two!
     case 'requestMethod': {
       return context.res.send(context.req.method);
     }
+    case 'requestHeadOrTrace': {
+      context.log(context.req.method);
+      return context.res.send("", 200);
+    }
     case 'requestUrl': {
         return context.res.json({
             'url': context.req.url,

--- a/tests/resources/functions/dart-2.19/lib/tests.dart
+++ b/tests/resources/functions/dart-2.19/lib/tests.dart
@@ -60,6 +60,10 @@ When you can have two!
     case 'requestMethod': {
       return context.res.send(context.req.method);
     }
+    case 'requestHeadOrTrace': {
+      context.log(context.req.method);
+      return context.res.send("", 200);
+    }
     case 'requestUrl': {
         return context.res.json({
             'url': context.req.url,

--- a/tests/resources/functions/dart-3.0/lib/tests.dart
+++ b/tests/resources/functions/dart-3.0/lib/tests.dart
@@ -60,6 +60,10 @@ When you can have two!
     case 'requestMethod': {
       return context.res.send(context.req.method);
     }
+    case 'requestHeadOrTrace': {
+      context.log(context.req.method);
+      return context.res.send("", 200);
+    }
     case 'requestUrl': {
         return context.res.json({
             'url': context.req.url,

--- a/tests/resources/functions/dart-3.1/lib/tests.dart
+++ b/tests/resources/functions/dart-3.1/lib/tests.dart
@@ -60,6 +60,10 @@ When you can have two!
     case 'requestMethod': {
       return context.res.send(context.req.method);
     }
+    case 'requestHeadOrTrace': {
+      context.log(context.req.method);
+      return context.res.send("", 200);
+    }
     case 'requestUrl': {
         return context.res.json({
             'url': context.req.url,

--- a/tests/resources/functions/dart-3.3/lib/tests.dart
+++ b/tests/resources/functions/dart-3.3/lib/tests.dart
@@ -60,6 +60,10 @@ When you can have two!
     case 'requestMethod': {
       return context.res.send(context.req.method);
     }
+    case 'requestHeadOrTrace': {
+      context.log(context.req.method);
+      return context.res.send("", 200);
+    }
     case 'requestUrl': {
         return context.res.json({
             'url': context.req.url,

--- a/tests/resources/functions/deno-1.21/tests.ts
+++ b/tests/resources/functions/deno-1.21/tests.ts
@@ -41,6 +41,9 @@ When you can have two!
             return context.res.send('FAIL', 404);
         case 'requestMethod':
             return context.res.send(context.req.method);
+        case 'requestHeadOrTrace':
+            context.log(context.req.method);
+            return context.res.send('', 200);
         case 'requestUrl':
             return context.res.json({
                 url: context.req.url,

--- a/tests/resources/functions/deno-1.24/tests.ts
+++ b/tests/resources/functions/deno-1.24/tests.ts
@@ -41,6 +41,9 @@ When you can have two!
             return context.res.send('FAIL', 404);
         case 'requestMethod':
             return context.res.send(context.req.method);
+        case 'requestHeadOrTrace':
+            context.log(context.req.method);
+            return context.res.send('', 200);
         case 'requestUrl':
             return context.res.json({
                 url: context.req.url,

--- a/tests/resources/functions/deno-1.35/tests.ts
+++ b/tests/resources/functions/deno-1.35/tests.ts
@@ -41,6 +41,9 @@ When you can have two!
             return context.res.send('FAIL', 404);
         case 'requestMethod':
             return context.res.send(context.req.method);
+        case 'requestHeadOrTrace':
+            context.log(context.req.method);
+            return context.res.send('', 200);
         case 'requestUrl':
             return context.res.json({
                 url: context.req.url,

--- a/tests/resources/functions/deno-1.40/tests.ts
+++ b/tests/resources/functions/deno-1.40/tests.ts
@@ -41,6 +41,9 @@ When you can have two!
             return context.res.send('FAIL', 404);
         case 'requestMethod':
             return context.res.send(context.req.method);
+        case 'requestHeadOrTrace':
+            context.log(context.req.method);
+            return context.res.send('', 200);
         case 'requestUrl':
             return context.res.json({
                 url: context.req.url,

--- a/tests/resources/functions/dotnet-6.0/Tests.cs
+++ b/tests/resources/functions/dotnet-6.0/Tests.cs
@@ -65,6 +65,9 @@ When you can have two!
                 return context.Res.Send("FAIL", 404);
             case "requestMethod":
                 return context.Res.Send(context.Req.Method);
+            case "requestHeadOrTrace":
+                context.Log(context.Req.Method);
+                return context.Res.Send("", 200);
             case "requestUrl":
                 return context.Res.Json(new()
                 {

--- a/tests/resources/functions/dotnet-7.0/Tests.cs
+++ b/tests/resources/functions/dotnet-7.0/Tests.cs
@@ -66,6 +66,9 @@ When you can have two!
                     return context.Res.Send("FAIL", 404);
                 case "requestMethod":
                     return context.Res.Send(context.Req.Method);
+                case "requestHeadOrTrace":
+                    context.Log(context.Req.Method);
+                    return context.Res.Send("", 200);
                 case "requestUrl":
                     return context.Res.Json(new Dictionary<string, object?>()
                     {

--- a/tests/resources/functions/dotnet-8.0/Tests.cs
+++ b/tests/resources/functions/dotnet-8.0/Tests.cs
@@ -62,6 +62,9 @@ When you can have two!
                     return context.Res.Send("FAIL", 404);
                 case "requestMethod":
                     return context.Res.Send(context.Req.Method);
+                case "requestHeadOrTrace":
+                    context.Log(context.Req.Method);
+                    return context.Res.Send("", 200);
                 case "requestUrl":
                     return context.Res.Json(new Dictionary<string, object?>()
                     {

--- a/tests/resources/functions/java-11.0/Tests.java
+++ b/tests/resources/functions/java-11.0/Tests.java
@@ -65,6 +65,9 @@ public class Tests {
                 return context.getRes().send("FAIL", 404);
             case "requestMethod":
                 return context.getRes().send(context.getReq().getMethod());
+            case "requestHeadOrTrace":
+                context.log(context.getReq().getMethod());
+                return context.getRes().send("", 200);
             case "requestUrl":
                 json.put("url", context.getReq().getUrl());
                 json.put("port", context.getReq().getPort());

--- a/tests/resources/functions/java-17.0/Tests.java
+++ b/tests/resources/functions/java-17.0/Tests.java
@@ -76,6 +76,10 @@ public class Tests {
             case "requestMethod" -> {
                 return context.getRes().send(context.getReq().getMethod());
             }
+            case "requestHeadOrTrace" -> {
+                context.log(context.getReq().getMethod());
+                return context.getRes().send("", 200);
+            }
             case "requestUrl" -> {
                 json.put("url", context.getReq().getUrl());
                 json.put("port", context.getReq().getPort());

--- a/tests/resources/functions/java-18.0/Tests.java
+++ b/tests/resources/functions/java-18.0/Tests.java
@@ -76,6 +76,10 @@ public class Tests {
             case "requestMethod" -> {
                 return context.getRes().send(context.getReq().getMethod());
             }
+            case "requestHeadOrTrace" -> {
+                context.log(context.getReq().getMethod());
+                return context.getRes().send("", 200);
+            }
             case "requestUrl" -> {
                 json.put("url", context.getReq().getUrl());
                 json.put("port", context.getReq().getPort());

--- a/tests/resources/functions/java-21.0/Tests.java
+++ b/tests/resources/functions/java-21.0/Tests.java
@@ -76,6 +76,10 @@ public class Tests {
             case "requestMethod" -> {
                 return context.getRes().send(context.getReq().getMethod());
             }
+            case "requestHeadOrTrace" -> {
+                context.log(context.getReq().getMethod());
+                return context.getRes().send("", 200);
+            }
             case "requestUrl" -> {
                 json.put("url", context.getReq().getUrl());
                 json.put("port", context.getReq().getPort());

--- a/tests/resources/functions/java-8.0/Tests.java
+++ b/tests/resources/functions/java-8.0/Tests.java
@@ -65,6 +65,9 @@ public class Tests {
                 return context.getRes().send("FAIL", 404);
             case "requestMethod":
                 return context.getRes().send(context.getReq().getMethod());
+            case "requestHeadOrTrace":
+                context.log(context.getReq().getMethod());
+                return context.getRes().send("", 200);
             case "requestUrl":
                 json.put("url", context.getReq().getUrl());
                 json.put("port", context.getReq().getPort());

--- a/tests/resources/functions/kotlin-1.6/Tests.kt
+++ b/tests/resources/functions/kotlin-1.6/Tests.kt
@@ -71,6 +71,10 @@ When you can have two!
             "requestMethod" -> {
                 return context.res.send(context.req.method)
             }
+            "requestHeadOrTrace" -> {
+                context.log(context.req.method)
+                return context.res.send("", 200)
+            }
             "requestUrl" -> {
                 return context.res.json(mutableMapOf(
                     "url" to context.req.url,

--- a/tests/resources/functions/kotlin-1.8/Tests.kt
+++ b/tests/resources/functions/kotlin-1.8/Tests.kt
@@ -71,6 +71,10 @@ When you can have two!
             "requestMethod" -> {
                 return context.res.send(context.req.method)
             }
+            "requestHeadOrTrace" -> {
+                context.log(context.req.method)
+                return context.res.send("", 200)
+            }
             "requestUrl" -> {
                 return context.res.json(mutableMapOf(
                     "url" to context.req.url,

--- a/tests/resources/functions/kotlin-1.9/Tests.kt
+++ b/tests/resources/functions/kotlin-1.9/Tests.kt
@@ -71,6 +71,10 @@ When you can have two!
             "requestMethod" -> {
                 return context.res.send(context.req.method)
             }
+            "requestHeadOrTrace" -> {
+                context.log(context.req.method)
+                return context.res.send("", 200)
+            }
             "requestUrl" -> {
                 return context.res.json(mutableMapOf(
                     "url" to context.req.url,

--- a/tests/resources/functions/node-14.5/tests.js
+++ b/tests/resources/functions/node-14.5/tests.js
@@ -41,6 +41,9 @@ When you can have two!
             return context.res.send('FAIL', 404);
         case 'requestMethod':
             return context.res.send(context.req.method);
+        case 'requestHeadOrTrace':
+            context.log(context.req.method);
+            return context.res.send('', 200);
         case 'requestUrl':
             return context.res.json({
                 url: context.req.url,

--- a/tests/resources/functions/node-14.5/tests.mjs
+++ b/tests/resources/functions/node-14.5/tests.mjs
@@ -41,6 +41,9 @@ When you can have two!
             return context.res.send('FAIL', 404);
         case 'requestMethod':
             return context.res.send(context.req.method);
+        case 'requestHeadOrTrace':
+            context.log(context.req.method);
+            return context.res.send('', 200);
         case 'requestUrl':
             return context.res.json({
                 url: context.req.url,

--- a/tests/resources/functions/node-16.0/tests.js
+++ b/tests/resources/functions/node-16.0/tests.js
@@ -41,6 +41,9 @@ When you can have two!
             return context.res.send('FAIL', 404);
         case 'requestMethod':
             return context.res.send(context.req.method);
+        case 'requestHeadOrTrace':
+            context.log(context.req.method);
+            return context.res.send('', 200);
         case 'requestUrl':
             return context.res.json({
                 url: context.req.url,

--- a/tests/resources/functions/node-16.0/tests.mjs
+++ b/tests/resources/functions/node-16.0/tests.mjs
@@ -41,6 +41,9 @@ When you can have two!
             return context.res.send('FAIL', 404);
         case 'requestMethod':
             return context.res.send(context.req.method);
+        case 'requestHeadOrTrace':
+            context.log(context.req.method);
+            return context.res.send('', 200);
         case 'requestUrl':
             return context.res.json({
                 url: context.req.url,

--- a/tests/resources/functions/node-18.0/tests.js
+++ b/tests/resources/functions/node-18.0/tests.js
@@ -41,6 +41,9 @@ When you can have two!
             return context.res.send('FAIL', 404);
         case 'requestMethod':
             return context.res.send(context.req.method);
+        case 'requestHeadOrTrace':
+            context.log(context.req.method);
+            return context.res.send('', 200);
         case 'requestUrl':
             return context.res.json({
                 url: context.req.url,

--- a/tests/resources/functions/node-18.0/tests.mjs
+++ b/tests/resources/functions/node-18.0/tests.mjs
@@ -41,6 +41,9 @@ When you can have two!
             return context.res.send('FAIL', 404);
         case 'requestMethod':
             return context.res.send(context.req.method);
+        case 'requestHeadOrTrace':
+            context.log(context.req.method);
+            return context.res.send('', 200);
         case 'requestUrl':
             return context.res.json({
                 url: context.req.url,

--- a/tests/resources/functions/node-19.0/tests.js
+++ b/tests/resources/functions/node-19.0/tests.js
@@ -41,6 +41,9 @@ When you can have two!
             return context.res.send('FAIL', 404);
         case 'requestMethod':
             return context.res.send(context.req.method);
+        case 'requestHeadOrTrace':
+            context.log(context.req.method);
+            return context.res.send('', 200);
         case 'requestUrl':
             return context.res.json({
                 url: context.req.url,

--- a/tests/resources/functions/node-19.0/tests.mjs
+++ b/tests/resources/functions/node-19.0/tests.mjs
@@ -41,6 +41,9 @@ When you can have two!
             return context.res.send('FAIL', 404);
         case 'requestMethod':
             return context.res.send(context.req.method);
+        case 'requestHeadOrTrace':
+            context.log(context.req.method);
+            return context.res.send('', 200);
         case 'requestUrl':
             return context.res.json({
                 url: context.req.url,

--- a/tests/resources/functions/node-20.0/tests.js
+++ b/tests/resources/functions/node-20.0/tests.js
@@ -41,6 +41,9 @@ When you can have two!
             return context.res.send('FAIL', 404);
         case 'requestMethod':
             return context.res.send(context.req.method);
+        case 'requestHeadOrTrace':
+            context.log(context.req.method);
+            return context.res.send('', 200);
         case 'requestUrl':
             return context.res.json({
                 url: context.req.url,

--- a/tests/resources/functions/node-20.0/tests.mjs
+++ b/tests/resources/functions/node-20.0/tests.mjs
@@ -41,6 +41,9 @@ When you can have two!
             return context.res.send('FAIL', 404);
         case 'requestMethod':
             return context.res.send(context.req.method);
+        case 'requestHeadOrTrace':
+            context.log(context.req.method);
+            return context.res.send('', 200);
         case 'requestUrl':
             return context.res.json({
                 url: context.req.url,

--- a/tests/resources/functions/node-21.0/tests.js
+++ b/tests/resources/functions/node-21.0/tests.js
@@ -41,6 +41,9 @@ When you can have two!
             return context.res.send('FAIL', 404);
         case 'requestMethod':
             return context.res.send(context.req.method);
+        case 'requestHeadOrTrace':
+            context.log(context.req.method);
+            return context.res.send('', 200);
         case 'requestUrl':
             return context.res.json({
                 url: context.req.url,

--- a/tests/resources/functions/node-21.0/tests.mjs
+++ b/tests/resources/functions/node-21.0/tests.mjs
@@ -41,6 +41,9 @@ When you can have two!
             return context.res.send('FAIL', 404);
         case 'requestMethod':
             return context.res.send(context.req.method);
+        case 'requestHeadOrTrace':
+            context.log(context.req.method);
+            return context.res.send('', 200);
         case 'requestUrl':
             return context.res.json({
                 url: context.req.url,

--- a/tests/resources/functions/php-8.0/tests.php
+++ b/tests/resources/functions/php-8.0/tests.php
@@ -49,6 +49,9 @@ When you can have two!
           return $context->res->send('FAIL', 404);
       case 'requestMethod':
           return $context->res->send($context->req->method);
+      case 'requestHeadOrTrace':
+          $context->log($context->req->method);
+          return $context->res->send("", 200);
       case 'requestUrl':
           return $context->res->json([
             'url' => $context->req->url,

--- a/tests/resources/functions/php-8.1/tests.php
+++ b/tests/resources/functions/php-8.1/tests.php
@@ -49,6 +49,9 @@ When you can have two!
           return $context->res->send('FAIL', 404);
       case 'requestMethod':
           return $context->res->send($context->req->method);
+      case 'requestHeadOrTrace':
+          $context->log($context->req->method);
+          return $context->res->send("", 200);
       case 'requestUrl':
           return $context->res->json([
             'url' => $context->req->url,

--- a/tests/resources/functions/php-8.2/tests.php
+++ b/tests/resources/functions/php-8.2/tests.php
@@ -49,6 +49,9 @@ When you can have two!
           return $context->res->send('FAIL', 404);
       case 'requestMethod':
           return $context->res->send($context->req->method);
+      case 'requestHeadOrTrace':
+          $context->log($context->req->method);
+          return $context->res->send("", 200);
       case 'requestUrl':
           return $context->res->json([
             'url' => $context->req->url,

--- a/tests/resources/functions/php-8.3/tests.php
+++ b/tests/resources/functions/php-8.3/tests.php
@@ -49,6 +49,9 @@ When you can have two!
           return $context->res->send('FAIL', 404);
       case 'requestMethod':
           return $context->res->send($context->req->method);
+      case 'requestHeadOrTrace':
+          $context->log($context->req->method);
+          return $context->res->send("", 200);
       case 'requestUrl':
           return $context->res->json([
             'url' => $context->req->url,

--- a/tests/resources/functions/python-3.10/tests.py
+++ b/tests/resources/functions/python-3.10/tests.py
@@ -41,6 +41,9 @@ When you can have two!
         return context.res.send('FAIL', 404)
     elif action == 'requestMethod':
         return context.res.send(context.req.method)
+    elif action == 'requestHeadOrTrace':
+        context.log(context.req.method)
+        return context.res.send('', 200)
     elif action == 'requestUrl':
         return context.res.json({
             'url': context.req.url,

--- a/tests/resources/functions/python-3.11/tests.py
+++ b/tests/resources/functions/python-3.11/tests.py
@@ -41,6 +41,9 @@ When you can have two!
         return context.res.send('FAIL', 404)
     elif action == 'requestMethod':
         return context.res.send(context.req.method)
+    elif action == 'requestHeadOrTrace':
+        context.log(context.req.method)
+        return context.res.send('', 200)
     elif action == 'requestUrl':
         return context.res.json({
             'url': context.req.url,

--- a/tests/resources/functions/python-3.12/tests.py
+++ b/tests/resources/functions/python-3.12/tests.py
@@ -41,6 +41,9 @@ When you can have two!
         return context.res.send('FAIL', 404)
     elif action == 'requestMethod':
         return context.res.send(context.req.method)
+    elif action == 'requestHeadOrTrace':
+        context.log(context.req.method)
+        return context.res.send('', 200)
     elif action == 'requestUrl':
         return context.res.json({
             'url': context.req.url,

--- a/tests/resources/functions/python-3.8/tests.py
+++ b/tests/resources/functions/python-3.8/tests.py
@@ -41,6 +41,9 @@ When you can have two!
         return context.res.send('FAIL', 404)
     elif action == 'requestMethod':
         return context.res.send(context.req.method)
+    elif action == 'requestHeadOrTrace':
+        context.log(context.req.method)
+        return context.res.send('', 200)
     elif action == 'requestUrl':
         return context.res.json({
             'url': context.req.url,

--- a/tests/resources/functions/python-3.9/tests.py
+++ b/tests/resources/functions/python-3.9/tests.py
@@ -41,6 +41,9 @@ When you can have two!
         return context.res.send('FAIL', 404)
     elif action == 'requestMethod':
         return context.res.send(context.req.method)
+    elif action == 'requestHeadOrTrace':
+        context.log(context.req.method)
+        return context.res.send('', 200)
     elif action == 'requestUrl':
         return context.res.json({
             'url': context.req.url,

--- a/tests/resources/functions/python-ml-3.11/tests.py
+++ b/tests/resources/functions/python-ml-3.11/tests.py
@@ -43,6 +43,9 @@ When you can have two!
         return context.res.send('FAIL', 404)
     elif action == 'requestMethod':
         return context.res.send(context.req.method)
+    elif action == 'requestHeadOrTrace':
+        context.log(context.req.method)
+        return context.res.send('', 200)
     elif action == 'requestUrl':
         return context.res.json({
             'url': context.req.url,

--- a/tests/resources/functions/ruby-3.0/tests.rb
+++ b/tests/resources/functions/ruby-3.0/tests.rb
@@ -42,6 +42,9 @@ When you can have two!
         return context.res.send('FAIL', 404)
     when 'requestMethod'
         return context.res.send(context.req.method)
+    when 'requestHeadOrTrace'
+        context.log(context.req.method)
+        return context.res.send('', 200)
     when 'requestUrl'
         return context.res.json({
             'url': context.req.url,

--- a/tests/resources/functions/ruby-3.1/tests.rb
+++ b/tests/resources/functions/ruby-3.1/tests.rb
@@ -42,6 +42,9 @@ When you can have two!
         return context.res.send('FAIL', 404)
     when 'requestMethod'
         return context.res.send(context.req.method)
+    when 'requestHeadOrTrace'
+        context.log(context.req.method)
+        return context.res.send('', 200)
     when 'requestUrl'
         return context.res.json({
             'url': context.req.url,

--- a/tests/resources/functions/ruby-3.2/tests.rb
+++ b/tests/resources/functions/ruby-3.2/tests.rb
@@ -42,6 +42,9 @@ When you can have two!
         return context.res.send('FAIL', 404)
     when 'requestMethod'
         return context.res.send(context.req.method)
+    when 'requestHeadOrTrace'
+        context.log(context.req.method)
+        return context.res.send('', 200)
     when 'requestUrl'
         return context.res.json({
             'url': context.req.url,

--- a/tests/resources/functions/ruby-3.3/tests.rb
+++ b/tests/resources/functions/ruby-3.3/tests.rb
@@ -42,6 +42,9 @@ When you can have two!
         return context.res.send('FAIL', 404)
     when 'requestMethod'
         return context.res.send(context.req.method)
+    when 'requestHeadOrTrace'
+        context.log(context.req.method)
+        return context.res.send('', 200)
     when 'requestUrl'
         return context.res.json({
             'url': context.req.url,

--- a/tests/resources/functions/swift-5.5/Sources/Tests.swift
+++ b/tests/resources/functions/swift-5.5/Sources/Tests.swift
@@ -55,6 +55,9 @@ When you can have two!
         return context.res.send("FAIL", statusCode: 404)
     case "requestMethod":
         return context.res.send(context.req.method)
+    case "requestHeadOrTrace":
+        context.log(context.req.method)
+        return context.res.send("", statusCode: 200)
     case "requestUrl":
         return try context.res.json([
             "url": context.req.url,

--- a/tests/resources/functions/swift-5.8/Sources/Tests.swift
+++ b/tests/resources/functions/swift-5.8/Sources/Tests.swift
@@ -55,6 +55,9 @@ When you can have two!
         return context.res.send("FAIL", statusCode: 404)
     case "requestMethod":
         return context.res.send(context.req.method)
+    case "requestHeadOrTrace":
+        context.log(context.req.method)
+        return context.res.send("", statusCode: 200)
     case "requestUrl":
         return try context.res.json([
             "url": context.req.url,

--- a/tests/resources/functions/swift-5.9/Sources/Tests.swift
+++ b/tests/resources/functions/swift-5.9/Sources/Tests.swift
@@ -55,6 +55,9 @@ When you can have two!
         return context.res.send("FAIL", statusCode: 404)
     case "requestMethod":
         return context.res.send(context.req.method)
+    case "requestHeadOrTrace":
+        context.log(context.req.method)
+        return context.res.send("", statusCode: 200)
     case "requestUrl":
         return try context.res.json([
             "url": context.req.url,


### PR DESCRIPTION
The runtimes use an external library to manage the http server where not all the underlying libraries/modules support `TRACE` method. Below is a list of the one's I've tested with findings -

---
### Tested
* Dart-3.3
* Bun-1.0
* Ruby-3.3
* Kotlin 1.9
* Deno-1.40
* Node-21.0
* Python-3.12
* Python-ML-3.11
* Swift-5.9, 5.8, 5.5

---
### `TRACE` not supported -
* PHP
* C++ - 17, 20 (Drogon Library)
   There might be a possibility of using a Middleware approach but I am not entirely sure on that