### PR TITLE
Fix: go permissions

### DIFF
--- a/runtimes/go-1.22/Dockerfile
+++ b/runtimes/go-1.22/Dockerfile
@@ -19,7 +19,7 @@ RUN mkdir -p /usr/local/server/src/function
 
 WORKDIR /usr/local/server
 
-COPY ./helpers ./helpers
+COPY . .
 
 RUN chmod +x /usr/local/server/helpers/before-start.sh
 RUN chmod +x /usr/local/server/helpers/start.sh
@@ -27,7 +27,5 @@ RUN chmod +x /usr/local/server/helpers/start.sh
 RUN chmod +x /usr/local/server/helpers/before-build.sh
 RUN chmod +x /usr/local/server/helpers/build.sh
 RUN chmod +x /usr/local/server/helpers/after-build.sh
-
-COPY . .
 
 EXPOSE 3000


### PR DESCRIPTION
Fixes:


Failed to execute command: {"ID":"1affbbe77311fc34b48396a63fc565e8e7c1cb2ab5608a218eff8aa0225e609f","Running":false,"ExitCode":126,"ProcessConfig":{"tty":false,"entrypoint":"sh","arguments":["-c","touch /var/tmp/logs.txt && (tar -zxf /tmp/code.tar.gz -C /mnt/code && helpers/build.sh "") >> /var/tmp/logs.txt 2>&1 && cat /var/tmp/logs.txt"],"privileged":false},"OpenStdin":false,"OpenStderr":true,"OpenStdout":true,"CanRemove":false,"ContainerID":"3feb5ea15d58dc5e8a7352dd65c94d79ff98b5badd2f21bde23daa3608da88dd","DetachKeys":"","Pid":874797}
 Exit Code: 126sh: helpers/build.sh: Permission denied