### PR TITLE
Fix: Enforced headers

### DIFF
--- a/runtimes/go-1.22/src/main.go
+++ b/runtimes/go-1.22/src/main.go
@@ -61,6 +61,21 @@ func action(w http.ResponseWriter, r *http.Request, logger types.Logger) error {
 		}
 	}
 
+	enforcedHeadersBytes, err := json.Marshal(os.Getenv("OPEN_RUNTIMES_HEADERS") == "" ? "{}" : os.Getenv("OPEN_RUNTIMES_HEADERS"))
+	if err != nil {
+		enforcedHeadersBytes = []byte{}
+	}
+	enforcedHeadersString := string(enforcedHeadersBytes)
+
+	for key, value := range enforcedHeadersString {
+		valueString, ok := value.(string)
+		if !ok {
+			valueString = ""
+		}
+
+		headers[strings.ToLower(key)] = strings.ToLower(valueString)
+    }
+
 	method := r.Method
 
 	scheme := "http"

--- a/tests/Base.php
+++ b/tests/Base.php
@@ -590,6 +590,36 @@ class Base extends TestCase
         self::assertEquals('POST', $response['headers']['x-method']);
     }
 
+    function testEnforcedHeaders(): void
+    {
+        $response = Client::execute(headers: ['x-action' => 'enforcedHeaders'], method: "POST");
+        self::assertEquals(200, $response['code']);
+        self::assertNotEmpty($response['body']);
+
+        $body = \json_decode($response['body'], true);
+        self::assertEquals("value", $body['x-custom']);
+        self::assertEquals("value2", $body['x-custom-uppercase']);
+        self::assertEquals("248", $body['x-open-runtimes-custom']);
+
+        $response = Client::execute(headers: ['x-action' => 'enforcedHeaders', 'x-custom' => 'IS_IGNORED', 'x-custom-uppercase' => 'IS_IGNORED', 'x-open-runtimes-custom' => 'IS_IGNORED'], method: "POST");
+        self::assertEquals(200, $response['code']);
+        self::assertNotEmpty($response['body']);
+
+        $body = \json_decode($response['body'], true);
+        self::assertEquals("value", $body['x-custom']);
+        self::assertEquals("value2", $body['x-custom-uppercase']);
+        self::assertEquals("248", $body['x-open-runtimes-custom']);
+
+        $response = Client::execute(headers: ['x-action' => 'enforcedHeaders', 'X-CUSTOM-UPPERCASE' => 'IS_IGNORED'], method: "POST");
+        self::assertEquals(200, $response['code']);
+        self::assertNotEmpty($response['body']);
+
+        $body = \json_decode($response['body'], true);
+        self::assertEquals("value", $body['x-custom']);
+        self::assertEquals("value2", $body['x-custom-uppercase']);
+        self::assertEquals("248", $body['x-open-runtimes-custom']);
+    }
+
     function assertEqualsIgnoringWhitespace($expected, $actual, $message = '') {
         $expected = preg_replace('/\s+/', '', $expected);
         $actual = preg_replace('/\s+/', '', $actual);

--- a/tests/resources/functions/bun-1.0/tests.ts
+++ b/tests/resources/functions/bun-1.0/tests.ts
@@ -32,6 +32,12 @@ When you can have two!
         case 'doubleResponse':
             context.res.text('This should be ignored.');
             return context.res.text('This should be returned.');
+        case "enforcedHeaders":
+            return context.res.json({
+                "x-custom": context.req.headers["x-custom"],
+                "x-custom-uppercase": context.req.headers["x-custom-uppercase"],
+                "x-open-runtimes-custom": context.req.headers["x-open-runtimes-custom"],
+            });
         case 'headersResponse':
             return context.res.text('OK', 200, {
                 'first-header': 'first-value',

--- a/tests/resources/functions/cpp-17/tests.cc
+++ b/tests/resources/functions/cpp-17/tests.cc
@@ -60,6 +60,12 @@ namespace runtime {
             } else if (action == "doubleResponse") {
                 res.text("This should be ignored.");
                 return res.text("This should be returned.");
+            } else if (action == "enforcedHeaders") {
+                json["x-custom"] = req.headers["x-custom"].asString();
+                json["x-custom-uppercase"] = req.headers["x-custom-uppercase"].asString();
+                json["x-open-runtimes-custom"] = req.headers["x-open-runtimes-custom"].asString();
+
+                return res.json(json);
             } else if (action == "headersResponse") {
                 auto secondHeader = req.headers["x-open-runtimes-custom-in-header"].asString();
                 if (secondHeader.empty()) {

--- a/tests/resources/functions/cpp-20/tests.cc
+++ b/tests/resources/functions/cpp-20/tests.cc
@@ -60,6 +60,12 @@ namespace runtime {
             } else if (action == "doubleResponse") {
                 res.text("This should be ignored.");
                 return res.text("This should be returned.");
+            } else if (action == "enforcedHeaders") {
+                json["x-custom"] = req.headers["x-custom"].asString();
+                json["x-custom-uppercase"] = req.headers["x-custom-uppercase"].asString();
+                json["x-open-runtimes-custom"] = req.headers["x-open-runtimes-custom"].asString();
+
+                return res.json(json);
             } else if (action == "headersResponse") {
                 auto secondHeader = req.headers["x-open-runtimes-custom-in-header"].asString();
                 if (secondHeader.empty()) {

--- a/tests/resources/functions/dart-2.15/lib/tests.dart
+++ b/tests/resources/functions/dart-2.15/lib/tests.dart
@@ -53,6 +53,13 @@ When you can have two!
       context.res.text('This should be ignored.');
       return context.res.text('This should be returned.');
     }
+    case 'enforcedHeaders': {
+      return context.res.json({
+        'x-custom': context.req.headers['x-custom'],
+        'x-custom-uppercase': context.req.headers['x-custom-uppercase'],
+        'x-open-runtimes-custom': context.req.headers['x-open-runtimes-custom']
+      });
+    }
     case 'headersResponse': {
       return context.res.text('OK', 200, {
         'first-header': 'first-value',

--- a/tests/resources/functions/dart-2.16/lib/tests.dart
+++ b/tests/resources/functions/dart-2.16/lib/tests.dart
@@ -53,6 +53,13 @@ When you can have two!
       context.res.text('This should be ignored.');
       return context.res.text('This should be returned.');
     }
+    case 'enforcedHeaders': {
+      return context.res.json({
+        'x-custom': context.req.headers['x-custom'],
+        'x-custom-uppercase': context.req.headers['x-custom-uppercase'],
+        'x-open-runtimes-custom': context.req.headers['x-open-runtimes-custom']
+      });
+    }
     case 'headersResponse': {
       return context.res.text('OK', 200, {
         'first-header': 'first-value',

--- a/tests/resources/functions/dart-2.17/lib/tests.dart
+++ b/tests/resources/functions/dart-2.17/lib/tests.dart
@@ -60,6 +60,14 @@ When you can have two!
         context.res.text('This should be ignored.');
         return context.res.text('This should be returned.');
       }
+    case 'enforcedHeaders':
+      {
+        return context.res.json({
+          'x-custom': context.req.headers['x-custom'],
+          'x-custom-uppercase': context.req.headers['x-custom-uppercase'],
+          'x-open-runtimes-custom': context.req.headers['x-open-runtimes-custom']
+        });
+      }
     case 'headersResponse':
       {
         return context.res.text('OK', 200, {

--- a/tests/resources/functions/dart-2.18/lib/tests.dart
+++ b/tests/resources/functions/dart-2.18/lib/tests.dart
@@ -53,6 +53,13 @@ When you can have two!
       context.res.text('This should be ignored.');
       return context.res.text('This should be returned.');
     }
+    case 'enforcedHeaders': {
+      return context.res.json({
+        'x-custom': context.req.headers['x-custom'],
+        'x-custom-uppercase': context.req.headers['x-custom-uppercase'],
+        'x-open-runtimes-custom': context.req.headers['x-open-runtimes-custom']
+      });
+    }
     case 'headersResponse': {
       return context.res.text('OK', 200, {
         'first-header': 'first-value',

--- a/tests/resources/functions/dart-2.19/lib/tests.dart
+++ b/tests/resources/functions/dart-2.19/lib/tests.dart
@@ -53,6 +53,13 @@ When you can have two!
       context.res.text('This should be ignored.');
       return context.res.text('This should be returned.');
     }
+    case 'enforcedHeaders': {
+      return context.res.json({
+        'x-custom': context.req.headers['x-custom'],
+        'x-custom-uppercase': context.req.headers['x-custom-uppercase'],
+        'x-open-runtimes-custom': context.req.headers['x-open-runtimes-custom']
+      });
+    }
     case 'headersResponse': {
       return context.res.text('OK', 200, {
         'first-header': 'first-value',

--- a/tests/resources/functions/dart-3.0/lib/tests.dart
+++ b/tests/resources/functions/dart-3.0/lib/tests.dart
@@ -53,6 +53,13 @@ When you can have two!
       context.res.text('This should be ignored.');
       return context.res.text('This should be returned.');
     }
+    case 'enforcedHeaders': {
+      return context.res.json({
+        'x-custom': context.req.headers['x-custom'],
+        'x-custom-uppercase': context.req.headers['x-custom-uppercase'],
+        'x-open-runtimes-custom': context.req.headers['x-open-runtimes-custom']
+      });
+    }
     case 'headersResponse': {
       return context.res.text('OK', 200, {
         'first-header': 'first-value',

--- a/tests/resources/functions/dart-3.1/lib/tests.dart
+++ b/tests/resources/functions/dart-3.1/lib/tests.dart
@@ -53,6 +53,13 @@ When you can have two!
       context.res.text('This should be ignored.');
       return context.res.text('This should be returned.');
     }
+    case 'enforcedHeaders': {
+      return context.res.json({
+        'x-custom': context.req.headers['x-custom'],
+        'x-custom-uppercase': context.req.headers['x-custom-uppercase'],
+        'x-open-runtimes-custom': context.req.headers['x-open-runtimes-custom']
+      });
+    }
     case 'headersResponse': {
       return context.res.text('OK', 200, {
         'first-header': 'first-value',

--- a/tests/resources/functions/dart-3.3/lib/tests.dart
+++ b/tests/resources/functions/dart-3.3/lib/tests.dart
@@ -53,6 +53,13 @@ When you can have two!
       context.res.text('This should be ignored.');
       return context.res.text('This should be returned.');
     }
+    case 'enforcedHeaders': {
+      return context.res.json({
+        'x-custom': context.req.headers['x-custom'],
+        'x-custom-uppercase': context.req.headers['x-custom-uppercase'],
+        'x-open-runtimes-custom': context.req.headers['x-open-runtimes-custom']
+      });
+    }
     case 'headersResponse': {
       return context.res.text('OK', 200, {
         'first-header': 'first-value',

--- a/tests/resources/functions/deno-1.21/tests.ts
+++ b/tests/resources/functions/deno-1.21/tests.ts
@@ -33,6 +33,12 @@ When you can have two!
         case 'doubleResponse':
             context.res.text('This should be ignored.');
             return context.res.text('This should be returned.');
+        case "enforcedHeaders":
+            return context.res.json({
+                "x-custom": context.req.headers["x-custom"],
+                "x-custom-uppercase": context.req.headers["x-custom-uppercase"],
+                "x-open-runtimes-custom": context.req.headers["x-open-runtimes-custom"],
+            });
         case 'headersResponse':
             return context.res.text('OK', 200, {
                 'first-header': 'first-value',

--- a/tests/resources/functions/deno-1.24/tests.ts
+++ b/tests/resources/functions/deno-1.24/tests.ts
@@ -33,6 +33,12 @@ When you can have two!
         case 'doubleResponse':
             context.res.text('This should be ignored.');
             return context.res.text('This should be returned.');
+        case "enforcedHeaders":
+            return context.res.json({
+                "x-custom": context.req.headers["x-custom"],
+                "x-custom-uppercase": context.req.headers["x-custom-uppercase"],
+                "x-open-runtimes-custom": context.req.headers["x-open-runtimes-custom"],
+            });
         case 'headersResponse':
             return context.res.text('OK', 200, {
                 'first-header': 'first-value',

--- a/tests/resources/functions/deno-1.35/tests.ts
+++ b/tests/resources/functions/deno-1.35/tests.ts
@@ -33,6 +33,12 @@ When you can have two!
         case 'doubleResponse':
             context.res.text('This should be ignored.');
             return context.res.text('This should be returned.');
+        case "enforcedHeaders":
+            return context.res.json({
+                "x-custom": context.req.headers["x-custom"],
+                "x-custom-uppercase": context.req.headers["x-custom-uppercase"],
+                "x-open-runtimes-custom": context.req.headers["x-open-runtimes-custom"],
+            });
         case 'headersResponse':
             return context.res.text('OK', 200, {
                 'first-header': 'first-value',

--- a/tests/resources/functions/deno-1.40/tests.ts
+++ b/tests/resources/functions/deno-1.40/tests.ts
@@ -33,6 +33,12 @@ When you can have two!
         case 'doubleResponse':
             context.res.text('This should be ignored.');
             return context.res.text('This should be returned.');
+        case "enforcedHeaders":
+            return context.res.json({
+                "x-custom": context.req.headers["x-custom"],
+                "x-custom-uppercase": context.req.headers["x-custom-uppercase"],
+                "x-open-runtimes-custom": context.req.headers["x-open-runtimes-custom"],
+            });
         case 'headersResponse':
             return context.res.text('OK', 200, {
                 'first-header': 'first-value',

--- a/tests/resources/functions/dotnet-6.0/Tests.cs
+++ b/tests/resources/functions/dotnet-6.0/Tests.cs
@@ -81,6 +81,17 @@ When you can have two!
                     { "scheme", context.Req.Scheme },
                     { "host", context.Req.Host }
                 });
+            case "enforcedHeaders":
+                var xCustom = context.Req.Headers.TryGetValue("x-custom", out string xCustomValue) ? xCustomValue : "";
+                var xCustomUppercase = context.Req.Headers.TryGetValue("x-custom-uppercase", out string xCustomUppercaseValue) ? xCustomUppercaseValue : "";
+                var xOpenRuntimesCustom = context.Req.Headers.TryGetValue("x-open-runtimes-custom", out string xOpenRuntimesCustomValue) ? xOpenRuntimesCustomValue : "";
+
+                return context.Res.Json(new()
+                {
+                    { "x-custom", xCustom },
+                    { "x-custom-uppercase", xCustomUppercase },
+                    { "x-open-runtimes-custom", xOpenRuntimesCustom },
+                });
             case "requestHeaders":
                 var json = new Dictionary<string, object>();
 

--- a/tests/resources/functions/dotnet-7.0/Tests.cs
+++ b/tests/resources/functions/dotnet-7.0/Tests.cs
@@ -82,6 +82,17 @@ When you can have two!
                         { "scheme", context.Req.Scheme },
                         { "host", context.Req.Host }
                     });
+                case "enforcedHeaders":
+                    var xCustom = context.Req.Headers.TryGetValue("x-custom", out string xCustomValue) ? xCustomValue : "";
+                    var xCustomUppercase = context.Req.Headers.TryGetValue("x-custom-uppercase", out string xCustomUppercaseValue) ? xCustomUppercaseValue : "";
+                    var xOpenRuntimesCustom = context.Req.Headers.TryGetValue("x-open-runtimes-custom", out string xOpenRuntimesCustomValue) ? xOpenRuntimesCustomValue : "";
+
+                    return context.Res.Json(new()
+                    {
+                        { "x-custom", xCustom },
+                        { "x-custom-uppercase", xCustomUppercase },
+                        { "x-open-runtimes-custom", xOpenRuntimesCustom },
+                    });
                 case "requestHeaders":
                     var json = new Dictionary<string, object>();
 

--- a/tests/resources/functions/dotnet-8.0/Tests.cs
+++ b/tests/resources/functions/dotnet-8.0/Tests.cs
@@ -78,6 +78,17 @@ When you can have two!
                         { "scheme", context.Req.Scheme },
                         { "host", context.Req.Host }
                     });
+                case "enforcedHeaders":
+                    var xCustom = context.Req.Headers.TryGetValue("x-custom", out string xCustomValue) ? xCustomValue : "";
+                    var xCustomUppercase = context.Req.Headers.TryGetValue("x-custom-uppercase", out string xCustomUppercaseValue) ? xCustomUppercaseValue : "";
+                    var xOpenRuntimesCustom = context.Req.Headers.TryGetValue("x-open-runtimes-custom", out string xOpenRuntimesCustomValue) ? xOpenRuntimesCustomValue : "";
+
+                    return context.Res.Json(new()
+                    {
+                        { "x-custom", xCustom },
+                        { "x-custom-uppercase", xCustomUppercase },
+                        { "x-open-runtimes-custom", xOpenRuntimesCustom },
+                    });
                 case "requestHeaders":
                     var json = new Dictionary<string, object>();
 

--- a/tests/resources/functions/go-1.22/tests.go
+++ b/tests/resources/functions/go-1.22/tests.go
@@ -56,6 +56,12 @@ When you can have two!
 	case "doubleResponse":
 		Context.Res.Text("This should be ignored.", 200, nil)
 		return Context.Res.Text("This should be returned.", 200, nil)
+	case "enforcedHeaders":
+		return Context.Res.Json(map[string]interface{}{
+			"x-custom":               Context.Req.Headers["x-custom"],
+			"x-custom-uppercase":     Context.Req.Headers["x-custom-uppercase"],
+			"x-open-runtimes-custom": Context.Req.Headers["x-open-runtimes-custom"],
+		}, 200, nil)
 	case "headersResponse":
 		secondHeader, ok := Context.Req.Headers["x-open-runtimes-custom-in-header"]
 		if !ok {

--- a/tests/resources/functions/java-11.0/Tests.java
+++ b/tests/resources/functions/java-11.0/Tests.java
@@ -60,6 +60,12 @@ public class Tests {
             case "doubleResponse":
                 context.getRes().text("This should be ignored.");
                 return context.getRes().text("This should be returned.");
+            case "enforcedHeaders":
+                json.put("x-custom", context.getReq().getHeaders().getOrDefault("x-custom", ""));
+                json.put("x-custom-uppercase", context.getReq().getHeaders().getOrDefault("x-custom-uppercase", ""));
+                json.put("x-open-runtimes-custom", context.getReq().getHeaders().getOrDefault("x-open-runtimes-custom", ""));
+
+                return context.getRes().json(json);
             case "headersResponse":
                 headers.put("first-header", "first-value");
                 headers.put("second-header", context.getReq().getHeaders().getOrDefault("x-open-runtimes-custom-in-header", "missing"));

--- a/tests/resources/functions/java-17.0/Tests.java
+++ b/tests/resources/functions/java-17.0/Tests.java
@@ -69,6 +69,13 @@ public class Tests {
                 context.getRes().text("This should be ignored.");
                 return context.getRes().text("This should be returned.");
             }
+            case "enforcedHeaders" -> {
+                json.put("x-custom", context.getReq().getHeaders().getOrDefault("x-custom", ""));
+                json.put("x-custom-uppercase", context.getReq().getHeaders().getOrDefault("x-custom-uppercase", ""));
+                json.put("x-open-runtimes-custom", context.getReq().getHeaders().getOrDefault("x-open-runtimes-custom", ""));
+
+                return context.getRes().json(json);
+            }
             case "headersResponse" -> {
                 headers.put("first-header", "first-value");
                 headers.put("second-header", context.getReq().getHeaders().getOrDefault("x-open-runtimes-custom-in-header", "missing"));

--- a/tests/resources/functions/java-18.0/Tests.java
+++ b/tests/resources/functions/java-18.0/Tests.java
@@ -69,6 +69,13 @@ public class Tests {
                 context.getRes().text("This should be ignored.");
                 return context.getRes().text("This should be returned.");
             }
+            case "enforcedHeaders" -> {
+                json.put("x-custom", context.getReq().getHeaders().getOrDefault("x-custom", ""));
+                json.put("x-custom-uppercase", context.getReq().getHeaders().getOrDefault("x-custom-uppercase", ""));
+                json.put("x-open-runtimes-custom", context.getReq().getHeaders().getOrDefault("x-open-runtimes-custom", ""));
+
+                return context.getRes().json(json);
+            }
             case "headersResponse" -> {
                 headers.put("first-header", "first-value");
                 headers.put("second-header", context.getReq().getHeaders().getOrDefault("x-open-runtimes-custom-in-header", "missing"));

--- a/tests/resources/functions/java-21.0/Tests.java
+++ b/tests/resources/functions/java-21.0/Tests.java
@@ -69,6 +69,13 @@ public class Tests {
                 context.getRes().text("This should be ignored.");
                 return context.getRes().text("This should be returned.");
             }
+            case "enforcedHeaders" -> {
+                json.put("x-custom", context.getReq().getHeaders().getOrDefault("x-custom", ""));
+                json.put("x-custom-uppercase", context.getReq().getHeaders().getOrDefault("x-custom-uppercase", ""));
+                json.put("x-open-runtimes-custom", context.getReq().getHeaders().getOrDefault("x-open-runtimes-custom", ""));
+
+                return context.getRes().json(json);
+            }
             case "headersResponse" -> {
                 headers.put("first-header", "first-value");
                 headers.put("second-header", context.getReq().getHeaders().getOrDefault("x-open-runtimes-custom-in-header", "missing"));

--- a/tests/resources/functions/java-8.0/Tests.java
+++ b/tests/resources/functions/java-8.0/Tests.java
@@ -60,6 +60,12 @@ public class Tests {
             case "doubleResponse":
                 context.getRes().text("This should be ignored.");
                 return context.getRes().text("This should be returned.");
+            case "enforcedHeaders":
+                json.put("x-custom", context.getReq().getHeaders().getOrDefault("x-custom", ""));
+                json.put("x-custom-uppercase", context.getReq().getHeaders().getOrDefault("x-custom-uppercase", ""));
+                json.put("x-open-runtimes-custom", context.getReq().getHeaders().getOrDefault("x-open-runtimes-custom", ""));
+
+                return context.getRes().json(json);
             case "headersResponse":
                 headers.put("first-header", "first-value");
                 headers.put("second-header", context.getReq().getHeaders().getOrDefault("x-open-runtimes-custom-in-header", "missing"));

--- a/tests/resources/functions/kotlin-1.6/Tests.kt
+++ b/tests/resources/functions/kotlin-1.6/Tests.kt
@@ -66,6 +66,13 @@ When you can have two!
                 context.res.text("This should be ignored.")
                 return context.res.text("This should be returned.")
             }
+            "enforcedHeaders" -> {
+                return context.res.json(mutableMapOf(
+                    "x-custom" to context.req.headers.getOrDefault("x-custom", ""),
+                    "x-custom-uppercase" to context.req.headers.getOrDefault("x-custom-uppercase", ""),
+                    "x-open-runtimes-custom" to context.req.headers.getOrDefault("x-open-runtimes-custom", ""),
+                ))
+            }
             "headersResponse" -> {
                 return context.res.text("OK", 200, mutableMapOf(
                     "first-header" to "first-value",

--- a/tests/resources/functions/kotlin-1.8/Tests.kt
+++ b/tests/resources/functions/kotlin-1.8/Tests.kt
@@ -66,6 +66,13 @@ When you can have two!
                 context.res.text("This should be ignored.")
                 return context.res.text("This should be returned.")
             }
+            "enforcedHeaders" -> {
+                return context.res.json(mutableMapOf(
+                    "x-custom" to context.req.headers.getOrDefault("x-custom", ""),
+                    "x-custom-uppercase" to context.req.headers.getOrDefault("x-custom-uppercase", ""),
+                    "x-open-runtimes-custom" to context.req.headers.getOrDefault("x-open-runtimes-custom", ""),
+                ))
+            }
             "headersResponse" -> {
                 return context.res.text("OK", 200, mutableMapOf(
                     "first-header" to "first-value",

--- a/tests/resources/functions/kotlin-1.9/Tests.kt
+++ b/tests/resources/functions/kotlin-1.9/Tests.kt
@@ -66,6 +66,13 @@ When you can have two!
                 context.res.text("This should be ignored.")
                 return context.res.text("This should be returned.")
             }
+            "enforcedHeaders" -> {
+                return context.res.json(mutableMapOf(
+                    "x-custom" to context.req.headers.getOrDefault("x-custom", ""),
+                    "x-custom-uppercase" to context.req.headers.getOrDefault("x-custom-uppercase", ""),
+                    "x-open-runtimes-custom" to context.req.headers.getOrDefault("x-open-runtimes-custom", ""),
+                ))
+            }
             "headersResponse" -> {
                 return context.res.text("OK", 200, mutableMapOf(
                     "first-header" to "first-value",

--- a/tests/resources/functions/node-14.5/tests.js
+++ b/tests/resources/functions/node-14.5/tests.js
@@ -33,6 +33,12 @@ When you can have two!
         case 'doubleResponse':
             context.res.text('This should be ignored.');
             return context.res.text('This should be returned.');
+        case "enforcedHeaders":
+            return context.res.json({
+                "x-custom": context.req.headers["x-custom"],
+                "x-custom-uppercase": context.req.headers["x-custom-uppercase"],
+                "x-open-runtimes-custom": context.req.headers["x-open-runtimes-custom"],
+            });
         case 'headersResponse':
             return context.res.text('OK', 200, {
                 'first-header': 'first-value',

--- a/tests/resources/functions/node-14.5/tests.mjs
+++ b/tests/resources/functions/node-14.5/tests.mjs
@@ -33,6 +33,12 @@ When you can have two!
         case 'doubleResponse':
             context.res.text('This should be ignored.');
             return context.res.text('This should be returned.');
+        case "enforcedHeaders":
+            return context.res.json({
+                "x-custom": context.req.headers["x-custom"],
+                "x-custom-uppercase": context.req.headers["x-custom-uppercase"],
+                "x-open-runtimes-custom": context.req.headers["x-open-runtimes-custom"],
+            });
         case 'headersResponse':
             return context.res.text('OK', 200, {
                 'first-header': 'first-value',

--- a/tests/resources/functions/node-16.0/tests.js
+++ b/tests/resources/functions/node-16.0/tests.js
@@ -33,6 +33,12 @@ When you can have two!
         case 'doubleResponse':
             context.res.text('This should be ignored.');
             return context.res.text('This should be returned.');
+        case "enforcedHeaders":
+            return context.res.json({
+                "x-custom": context.req.headers["x-custom"],
+                "x-custom-uppercase": context.req.headers["x-custom-uppercase"],
+                "x-open-runtimes-custom": context.req.headers["x-open-runtimes-custom"],
+            });
         case 'headersResponse':
             return context.res.text('OK', 200, {
                 'first-header': 'first-value',

--- a/tests/resources/functions/node-16.0/tests.mjs
+++ b/tests/resources/functions/node-16.0/tests.mjs
@@ -33,6 +33,12 @@ When you can have two!
         case 'doubleResponse':
             context.res.text('This should be ignored.');
             return context.res.text('This should be returned.');
+        case "enforcedHeaders":
+            return context.res.json({
+                "x-custom": context.req.headers["x-custom"],
+                "x-custom-uppercase": context.req.headers["x-custom-uppercase"],
+                "x-open-runtimes-custom": context.req.headers["x-open-runtimes-custom"],
+            });
         case 'headersResponse':
             return context.res.text('OK', 200, {
                 'first-header': 'first-value',

--- a/tests/resources/functions/node-18.0/tests.js
+++ b/tests/resources/functions/node-18.0/tests.js
@@ -33,6 +33,12 @@ When you can have two!
         case 'doubleResponse':
             context.res.text('This should be ignored.');
             return context.res.text('This should be returned.');
+        case "enforcedHeaders":
+            return context.res.json({
+                "x-custom": context.req.headers["x-custom"],
+                "x-custom-uppercase": context.req.headers["x-custom-uppercase"],
+                "x-open-runtimes-custom": context.req.headers["x-open-runtimes-custom"],
+            });
         case 'headersResponse':
             return context.res.text('OK', 200, {
                 'first-header': 'first-value',

--- a/tests/resources/functions/node-18.0/tests.mjs
+++ b/tests/resources/functions/node-18.0/tests.mjs
@@ -33,6 +33,12 @@ When you can have two!
         case 'doubleResponse':
             context.res.text('This should be ignored.');
             return context.res.text('This should be returned.');
+        case "enforcedHeaders":
+            return context.res.json({
+                "x-custom": context.req.headers["x-custom"],
+                "x-custom-uppercase": context.req.headers["x-custom-uppercase"],
+                "x-open-runtimes-custom": context.req.headers["x-open-runtimes-custom"],
+            });
         case 'headersResponse':
             return context.res.text('OK', 200, {
                 'first-header': 'first-value',

--- a/tests/resources/functions/node-19.0/tests.js
+++ b/tests/resources/functions/node-19.0/tests.js
@@ -33,6 +33,12 @@ When you can have two!
         case 'doubleResponse':
             context.res.text('This should be ignored.');
             return context.res.text('This should be returned.');
+        case "enforcedHeaders":
+            return context.res.json({
+                "x-custom": context.req.headers["x-custom"],
+                "x-custom-uppercase": context.req.headers["x-custom-uppercase"],
+                "x-open-runtimes-custom": context.req.headers["x-open-runtimes-custom"],
+            });
         case 'headersResponse':
             return context.res.text('OK', 200, {
                 'first-header': 'first-value',

--- a/tests/resources/functions/node-19.0/tests.mjs
+++ b/tests/resources/functions/node-19.0/tests.mjs
@@ -33,6 +33,12 @@ When you can have two!
         case 'doubleResponse':
             context.res.text('This should be ignored.');
             return context.res.text('This should be returned.');
+        case "enforcedHeaders":
+            return context.res.json({
+                "x-custom": context.req.headers["x-custom"],
+                "x-custom-uppercase": context.req.headers["x-custom-uppercase"],
+                "x-open-runtimes-custom": context.req.headers["x-open-runtimes-custom"],
+            });
         case 'headersResponse':
             return context.res.text('OK', 200, {
                 'first-header': 'first-value',

--- a/tests/resources/functions/node-20.0/tests.js
+++ b/tests/resources/functions/node-20.0/tests.js
@@ -33,6 +33,12 @@ When you can have two!
         case 'doubleResponse':
             context.res.text('This should be ignored.');
             return context.res.text('This should be returned.');
+        case "enforcedHeaders":
+            return context.res.json({
+                "x-custom": context.req.headers["x-custom"],
+                "x-custom-uppercase": context.req.headers["x-custom-uppercase"],
+                "x-open-runtimes-custom": context.req.headers["x-open-runtimes-custom"],
+            });
         case 'headersResponse':
             return context.res.text('OK', 200, {
                 'first-header': 'first-value',

--- a/tests/resources/functions/node-20.0/tests.mjs
+++ b/tests/resources/functions/node-20.0/tests.mjs
@@ -33,6 +33,12 @@ When you can have two!
         case 'doubleResponse':
             context.res.text('This should be ignored.');
             return context.res.text('This should be returned.');
+        case "enforcedHeaders":
+            return context.res.json({
+                "x-custom": context.req.headers["x-custom"],
+                "x-custom-uppercase": context.req.headers["x-custom-uppercase"],
+                "x-open-runtimes-custom": context.req.headers["x-open-runtimes-custom"],
+            });
         case 'headersResponse':
             return context.res.text('OK', 200, {
                 'first-header': 'first-value',

--- a/tests/resources/functions/node-21.0/tests.js
+++ b/tests/resources/functions/node-21.0/tests.js
@@ -33,6 +33,12 @@ When you can have two!
         case 'doubleResponse':
             context.res.text('This should be ignored.');
             return context.res.text('This should be returned.');
+        case "enforcedHeaders":
+            return context.res.json({
+                "x-custom": context.req.headers["x-custom"],
+                "x-custom-uppercase": context.req.headers["x-custom-uppercase"],
+                "x-open-runtimes-custom": context.req.headers["x-open-runtimes-custom"],
+            });
         case 'headersResponse':
             return context.res.text('OK', 200, {
                 'first-header': 'first-value',

--- a/tests/resources/functions/node-21.0/tests.mjs
+++ b/tests/resources/functions/node-21.0/tests.mjs
@@ -33,6 +33,12 @@ When you can have two!
         case 'doubleResponse':
             context.res.text('This should be ignored.');
             return context.res.text('This should be returned.');
+        case "enforcedHeaders":
+            return context.res.json({
+                "x-custom": context.req.headers["x-custom"],
+                "x-custom-uppercase": context.req.headers["x-custom-uppercase"],
+                "x-open-runtimes-custom": context.req.headers["x-open-runtimes-custom"],
+            });
         case 'headersResponse':
             return context.res.text('OK', 200, {
                 'first-header': 'first-value',

--- a/tests/resources/functions/php-8.0/tests.php
+++ b/tests/resources/functions/php-8.0/tests.php
@@ -40,6 +40,12 @@ When you can have two!
       case 'doubleResponse':
           $context->res->text('This should be ignored.');
           return $context->res->text('This should be returned.');
+      case "enforcedHeaders":
+          return $context->res->json([
+              "x-custom" => $context->req->headers["x-custom"],
+              "x-custom-uppercase" => $context->req->headers["x-custom-uppercase"],
+              "x-open-runtimes-custom" => $context->req->headers["x-open-runtimes-custom"],
+          ]);
       case 'headersResponse':
           return $context->res->text('OK', 200, [
               'first-header' => 'first-value',

--- a/tests/resources/functions/php-8.1/tests.php
+++ b/tests/resources/functions/php-8.1/tests.php
@@ -40,6 +40,12 @@ When you can have two!
         case 'doubleResponse':
             $context->res->text('This should be ignored.');
             return $context->res->text('This should be returned.');
+        case "enforcedHeaders":
+            return $context->res->json([
+                "x-custom" => $context->req->headers["x-custom"],
+                "x-custom-uppercase" => $context->req->headers["x-custom-uppercase"],
+                "x-open-runtimes-custom" => $context->req->headers["x-open-runtimes-custom"],
+            ]);
         case 'headersResponse':
             return $context->res->text('OK', 200, [
                 'first-header' => 'first-value',

--- a/tests/resources/functions/php-8.2/tests.php
+++ b/tests/resources/functions/php-8.2/tests.php
@@ -40,6 +40,12 @@ When you can have two!
         case 'doubleResponse':
             $context->res->text('This should be ignored.');
             return $context->res->text('This should be returned.');
+        case "enforcedHeaders":
+            return $context->res->json([
+                "x-custom" => $context->req->headers["x-custom"],
+                "x-custom-uppercase" => $context->req->headers["x-custom-uppercase"],
+                "x-open-runtimes-custom" => $context->req->headers["x-open-runtimes-custom"],
+            ]);
         case 'headersResponse':
             return $context->res->text('OK', 200, [
                 'first-header' => 'first-value',

--- a/tests/resources/functions/php-8.3/tests.php
+++ b/tests/resources/functions/php-8.3/tests.php
@@ -40,6 +40,12 @@ When you can have two!
         case 'doubleResponse':
             $context->res->text('This should be ignored.');
             return $context->res->text('This should be returned.');
+        case "enforcedHeaders":
+            return $context->res->json([
+                "x-custom" => $context->req->headers["x-custom"],
+                "x-custom-uppercase" => $context->req->headers["x-custom-uppercase"],
+                "x-open-runtimes-custom" => $context->req->headers["x-open-runtimes-custom"],
+            ]);
         case 'headersResponse':
             return $context->res->text('OK', 200, [
                 'first-header' => 'first-value',

--- a/tests/resources/functions/python-3.10/tests.py
+++ b/tests/resources/functions/python-3.10/tests.py
@@ -34,6 +34,12 @@ When you can have two!
     elif action == 'doubleResponse':
         context.res.text('This should be ignored.')
         return context.res.text('This should be returned.')
+    elif action == 'enforcedHeaders':
+        return context.res.json({
+            'x-custom': context.req.headers['x-custom'],
+            'x-custom-uppercase': context.req.headers['x-custom-uppercase'],
+            'x-open-runtimes-custom': context.req.headers['x-open-runtimes-custom'],
+        })
     elif action == 'headersResponse':
         return context.res.text('OK', 200, {
             'first-header': 'first-value',

--- a/tests/resources/functions/python-3.11/tests.py
+++ b/tests/resources/functions/python-3.11/tests.py
@@ -34,6 +34,12 @@ When you can have two!
     elif action == 'doubleResponse':
         context.res.text('This should be ignored.')
         return context.res.text('This should be returned.')
+    elif action == 'enforcedHeaders':
+        return context.res.json({
+            'x-custom': context.req.headers['x-custom'],
+            'x-custom-uppercase': context.req.headers['x-custom-uppercase'],
+            'x-open-runtimes-custom': context.req.headers['x-open-runtimes-custom'],
+        })
     elif action == 'headersResponse':
         return context.res.text('OK', 200, {
             'first-header': 'first-value',

--- a/tests/resources/functions/python-3.12/tests.py
+++ b/tests/resources/functions/python-3.12/tests.py
@@ -34,6 +34,12 @@ When you can have two!
     elif action == 'doubleResponse':
         context.res.text('This should be ignored.')
         return context.res.text('This should be returned.')
+    elif action == 'enforcedHeaders':
+        return context.res.json({
+            'x-custom': context.req.headers['x-custom'],
+            'x-custom-uppercase': context.req.headers['x-custom-uppercase'],
+            'x-open-runtimes-custom': context.req.headers['x-open-runtimes-custom'],
+        })
     elif action == 'headersResponse':
         return context.res.text('OK', 200, {
             'first-header': 'first-value',

--- a/tests/resources/functions/python-3.8/tests.py
+++ b/tests/resources/functions/python-3.8/tests.py
@@ -34,6 +34,12 @@ When you can have two!
     elif action == 'doubleResponse':
         context.res.text('This should be ignored.')
         return context.res.text('This should be returned.')
+    elif action == 'enforcedHeaders':
+        return context.res.json({
+            'x-custom': context.req.headers['x-custom'],
+            'x-custom-uppercase': context.req.headers['x-custom-uppercase'],
+            'x-open-runtimes-custom': context.req.headers['x-open-runtimes-custom'],
+        })
     elif action == 'headersResponse':
         return context.res.text('OK', 200, {
             'first-header': 'first-value',

--- a/tests/resources/functions/python-3.9/tests.py
+++ b/tests/resources/functions/python-3.9/tests.py
@@ -34,6 +34,12 @@ When you can have two!
     elif action == 'doubleResponse':
         context.res.text('This should be ignored.')
         return context.res.text('This should be returned.')
+    elif action == 'enforcedHeaders':
+        return context.res.json({
+            'x-custom': context.req.headers['x-custom'],
+            'x-custom-uppercase': context.req.headers['x-custom-uppercase'],
+            'x-open-runtimes-custom': context.req.headers['x-open-runtimes-custom'],
+        })
     elif action == 'headersResponse':
         return context.res.text('OK', 200, {
             'first-header': 'first-value',

--- a/tests/resources/functions/python-ml-3.11/tests.py
+++ b/tests/resources/functions/python-ml-3.11/tests.py
@@ -35,6 +35,12 @@ When you can have two!
     elif action == 'doubleResponse':
         context.res.text('This should be ignored.')
         return context.res.text('This should be returned.')
+    elif action == 'enforcedHeaders':
+        return context.res.json({
+            'x-custom': context.req.headers['x-custom'],
+            'x-custom-uppercase': context.req.headers['x-custom-uppercase'],
+            'x-open-runtimes-custom': context.req.headers['x-open-runtimes-custom'],
+        })
     elif action == 'headersResponse':
         return context.res.text('OK', 200, {
             'first-header': 'first-value',

--- a/tests/resources/functions/ruby-3.0/tests.rb
+++ b/tests/resources/functions/ruby-3.0/tests.rb
@@ -34,6 +34,12 @@ When you can have two!
     when 'doubleResponse'
         context.res.text('This should be ignored.')
         return context.res.text('This should be returned.')
+    when 'enforcedHeaders'
+        return context.res.json({
+            'x-custom': context.req.headers['x-custom'],
+            'x-custom-uppercase': context.req.headers['x-custom-uppercase'],
+            'x-open-runtimes-custom': context.req.headers['x-open-runtimes-custom'],
+        })
     when 'headersResponse'
         return context.res.text('OK', 200, {
             'first-header': 'first-value',

--- a/tests/resources/functions/ruby-3.1/tests.rb
+++ b/tests/resources/functions/ruby-3.1/tests.rb
@@ -34,6 +34,12 @@ When you can have two!
     when 'doubleResponse'
         context.res.text('This should be ignored.')
         return context.res.text('This should be returned.')
+    when 'enforcedHeaders'
+        return context.res.json({
+            'x-custom': context.req.headers['x-custom'],
+            'x-custom-uppercase': context.req.headers['x-custom-uppercase'],
+            'x-open-runtimes-custom': context.req.headers['x-open-runtimes-custom'],
+        })
     when 'headersResponse'
         return context.res.text('OK', 200, {
             'first-header': 'first-value',

--- a/tests/resources/functions/ruby-3.2/tests.rb
+++ b/tests/resources/functions/ruby-3.2/tests.rb
@@ -34,6 +34,12 @@ When you can have two!
     when 'doubleResponse'
         context.res.text('This should be ignored.')
         return context.res.text('This should be returned.')
+    when 'enforcedHeaders'
+        return context.res.json({
+            'x-custom': context.req.headers['x-custom'],
+            'x-custom-uppercase': context.req.headers['x-custom-uppercase'],
+            'x-open-runtimes-custom': context.req.headers['x-open-runtimes-custom'],
+        })
     when 'headersResponse'
         return context.res.text('OK', 200, {
             'first-header': 'first-value',

--- a/tests/resources/functions/ruby-3.3/tests.rb
+++ b/tests/resources/functions/ruby-3.3/tests.rb
@@ -34,6 +34,12 @@ When you can have two!
     when 'doubleResponse'
         context.res.text('This should be ignored.')
         return context.res.text('This should be returned.')
+    when 'enforcedHeaders'
+        return context.res.json({
+            'x-custom': context.req.headers['x-custom'],
+            'x-custom-uppercase': context.req.headers['x-custom-uppercase'],
+            'x-open-runtimes-custom': context.req.headers['x-open-runtimes-custom'],
+        })
     when 'headersResponse'
         return context.res.text('OK', 200, {
             'first-header': 'first-value',

--- a/tests/resources/functions/swift-5.5/Sources/Tests.swift
+++ b/tests/resources/functions/swift-5.5/Sources/Tests.swift
@@ -49,6 +49,12 @@ When you can have two!
     case "doubleResponse":
         _ = context.res.text("This should be ignored.")
         return context.res.text("This should be returned.")
+    case "enforcedHeaders":
+        return try context.res.json([
+            "x-custom": context.req.headers["x-custom"] ?? "",
+            "x-custom-uppercase": context.req.headers["x-custom-uppercase"] ?? "",
+            "x-open-runtimes-custom": context.req.headers["x-open-runtimes-custom"] ?? "",
+        ])
     case "headersResponse":
         return context.res.text("OK", statusCode: 200, headers: [
             "first-header": "first-value",

--- a/tests/resources/functions/swift-5.8/Sources/Tests.swift
+++ b/tests/resources/functions/swift-5.8/Sources/Tests.swift
@@ -49,6 +49,12 @@ When you can have two!
     case "doubleResponse":
         _ = context.res.text("This should be ignored.")
         return context.res.text("This should be returned.")
+    case "enforcedHeaders":
+        return try context.res.json([
+            "x-custom": context.req.headers["x-custom"] ?? "",
+            "x-custom-uppercase": context.req.headers["x-custom-uppercase"] ?? "",
+            "x-open-runtimes-custom": context.req.headers["x-open-runtimes-custom"] ?? "",
+        ])
     case "headersResponse":
         return context.res.text("OK", statusCode: 200, headers: [
             "first-header": "first-value",

--- a/tests/resources/functions/swift-5.9/Sources/Tests.swift
+++ b/tests/resources/functions/swift-5.9/Sources/Tests.swift
@@ -49,6 +49,12 @@ When you can have two!
     case "doubleResponse":
         _ = context.res.text("This should be ignored.")
         return context.res.text("This should be returned.")
+    case "enforcedHeaders":
+        return try context.res.json([
+            "x-custom": context.req.headers["x-custom"] ?? "",
+            "x-custom-uppercase": context.req.headers["x-custom-uppercase"] ?? "",
+            "x-open-runtimes-custom": context.req.headers["x-open-runtimes-custom"] ?? "",
+        ])
     case "headersResponse":
         return context.res.text("OK", statusCode: 200, headers: [
             "first-header": "first-value",


### PR DESCRIPTION
Fix enforced headers in Go, and add test case in all runtimes.