### PR TITLE
Chores: Improve Go tests for native Errors

### DIFF
--- a/runtimes/go-1.22/README.md
+++ b/runtimes/go-1.22/README.md
@@ -37,7 +37,7 @@ END
 tee -a go.mod << END
 module openruntimes/handler
 
-require github.com/open-runtimes/types-for-go/v4 v4.0.0
+require github.com/open-runtimes/types-for-go/v4 v4.0.2
 
 END
 

--- a/runtimes/go-1.22/example/go.mod
+++ b/runtimes/go-1.22/example/go.mod
@@ -1,5 +1,5 @@
 module openruntimes/handler
 
 
-require github.com/open-runtimes/types-for-go/v4 v4.0.0
+require github.com/open-runtimes/types-for-go/v4 v4.0.2
 require github.com/go-resty/resty/v2 v2.13.1

--- a/runtimes/go-1.22/src/go.mod
+++ b/runtimes/go-1.22/src/go.mod
@@ -5,4 +5,4 @@ go 1.22.2
 replace openruntimes/handler v0.0.0 => /usr/local/build
 
 require openruntimes/handler v0.0.0
-require github.com/open-runtimes/types-for-go/v4 v4.0.0
+require github.com/open-runtimes/types-for-go/v4 v4.0.2

--- a/tests/resources/functions/go-1.22/go.mod
+++ b/tests/resources/functions/go-1.22/go.mod
@@ -1,5 +1,5 @@
 module openruntimes/handler
 
-require github.com/open-runtimes/types-for-go/v4 v4.0.0
+require github.com/open-runtimes/types-for-go/v4 v4.0.2
 require github.com/go-resty/resty/v2 v2.11.0
 

--- a/tests/resources/functions/go-1.22/tests.go
+++ b/tests/resources/functions/go-1.22/tests.go
@@ -4,6 +4,7 @@ import (
 	"crypto/md5"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"time"
@@ -142,7 +143,7 @@ When you can have two!
 		}, 200, nil)
 	case "logs":
 		fmt.Println("Native log")
-		Context.Log("Debug log")
+		Context.Log(errors.New("Debug log"))
 		Context.Error("Error log")
 
 		Context.Log("Log+With+Plus+Symbol")


### PR DESCRIPTION
Upgrade types lib, and ensure error class now prints well. Before it just printed `{}`