### PR TITLE
Fix: Go context refference

### DIFF
--- a/runtimes/go/README.md
+++ b/runtimes/go/README.md
@@ -18,10 +18,14 @@ import (
 	"github.com/open-runtimes/types-for-go/v4"
 )
 
-func Main(Context *types.Context) types.ResponseOutput {
-	return Context.Res.Json(map[string]any{
-		"n": rand.Float64(),
-	}, 200, nil)
+type MainResponse struct {
+	N    float    `json:"n"`
+}
+
+func Main(Context types.Context) types.Response {
+	return Context.Res.Json(MainResponse{
+		N: rand.Float64(),
+	})
 }
 
 END
@@ -72,7 +76,7 @@ import (
 	"github.com/open-runtimes/types-for-go/v4"
 )
 
-func Main(Context *types.Context) types.ResponseOutput {
+func Main(Context types.Context) types.Response {
 }
 ```
 

--- a/runtimes/go/versions/latest/src/main.go
+++ b/runtimes/go/versions/latest/src/main.go
@@ -178,7 +178,7 @@ func action(w http.ResponseWriter, r *http.Request, logger openruntimes.Logger) 
 	}
 
 	actionPromise := func(ch chan openruntimes.Response) {
-		output = handler.Main(&context)
+		output = handler.Main(context)
 		ch <- output
 	}
 

--- a/tests/resources/functions/go/latest/tests.go
+++ b/tests/resources/functions/go/latest/tests.go
@@ -13,7 +13,7 @@ import (
 	openruntimes "github.com/open-runtimes/types-for-go/v4"
 )
 
-func Main(Context *openruntimes.Context) openruntimes.Response {
+func Main(Context openruntimes.Context) openruntimes.Response {
 	action := Context.Req.Headers["x-action"]
 
 	switch a := action; a {


### PR DESCRIPTION
Removes refferernce for context class