### PR TITLE
Feat: Upgrade namespacing

### DIFF
--- a/runtimes/go/README.md
+++ b/runtimes/go/README.md
@@ -15,7 +15,7 @@ package handler
 import (
 	"math/rand"
 	
-	"github.com/open-runtimes/types-for-go/v4"
+	"github.com/open-runtimes/types-for-go/v4/openruntimes"
 )
 
 type MainResponse struct {
@@ -38,7 +38,7 @@ END
 tee -a go.mod << END
 module openruntimes/handler
 
-require github.com/open-runtimes/types-for-go/v4 v4.0.4
+require github.com/open-runtimes/types-for-go/v4 v4.0.5
 
 END
 
@@ -73,10 +73,10 @@ Output `{"n":0.7232589496628183}` with random float will be displayed after the 
 package handler
 
 import (
-	"github.com/open-runtimes/types-for-go/v4"
+	"github.com/open-runtimes/types-for-go/v4/openruntimes"
 )
 
-func Main(Context types.Context) types.Response {
+func Main(Context openruntimes.Context) openruntimes.Response {
 }
 ```
 

--- a/runtimes/go/versions/latest/src/go.mod
+++ b/runtimes/go/versions/latest/src/go.mod
@@ -5,4 +5,4 @@ go 1.22.5
 replace openruntimes/handler v0.0.0 => /usr/local/build
 
 require openruntimes/handler v0.0.0
-require github.com/open-runtimes/types-for-go/v4 v4.0.4
+require github.com/open-runtimes/types-for-go/v4 v4.0.5

--- a/runtimes/go/versions/latest/src/go.sum
+++ b/runtimes/go/versions/latest/src/go.sum
@@ -8,3 +8,7 @@ github.com/open-runtimes/types-for-go/v4 v4.0.3 h1:rlxECrwSzB+FW/ymIsQXdS/4Ua2ZX
 github.com/open-runtimes/types-for-go/v4 v4.0.3/go.mod h1:ab4mDSfgeG4kN8wWpaBSv0Ao3m9P6oEfN5gsXtx+iaI=
 github.com/open-runtimes/types-for-go/v4 v4.0.4 h1:94zFTDNYtF8t7v2TlMqwAedyKftjS4FcGKUmRQ1uNXQ=
 github.com/open-runtimes/types-for-go/v4 v4.0.4/go.mod h1:ab4mDSfgeG4kN8wWpaBSv0Ao3m9P6oEfN5gsXtx+iaI=
+github.com/open-runtimes/types-for-go/v4 v4.0.5-0.20240723074015-667f31acc810 h1:W/JiELiXXgpjirUrC2zl+fHT3WjpDizIAFLp6BSoufU=
+github.com/open-runtimes/types-for-go/v4 v4.0.5-0.20240723074015-667f31acc810/go.mod h1:ab4mDSfgeG4kN8wWpaBSv0Ao3m9P6oEfN5gsXtx+iaI=
+github.com/open-runtimes/types-for-go/v4 v4.0.5 h1:Lw82fnOoaEmGgOoQmJhEOsYjs6Ginie4TdS2RYsvayk=
+github.com/open-runtimes/types-for-go/v4 v4.0.5/go.mod h1:ab4mDSfgeG4kN8wWpaBSv0Ao3m9P6oEfN5gsXtx+iaI=

--- a/runtimes/go/versions/latest/src/main.go
+++ b/runtimes/go/versions/latest/src/main.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 	"time"
 
-	openruntimes "github.com/open-runtimes/types-for-go/v4"
+	"github.com/open-runtimes/types-for-go/v4/openruntimes"
 )
 
 func action(w http.ResponseWriter, r *http.Request, logger openruntimes.Logger) error {

--- a/tests/resources/functions/go/latest/go.mod
+++ b/tests/resources/functions/go/latest/go.mod
@@ -4,7 +4,7 @@ go 1.22.5
 
 require (
 	github.com/go-resty/resty/v2 v2.11.0
-	github.com/open-runtimes/types-for-go/v4 v4.0.4
+	github.com/open-runtimes/types-for-go/v4 v4.0.5
 )
 
 require (

--- a/tests/resources/functions/go/latest/go.sum
+++ b/tests/resources/functions/go/latest/go.sum
@@ -10,6 +10,8 @@ github.com/open-runtimes/types-for-go/v4 v4.0.3 h1:rlxECrwSzB+FW/ymIsQXdS/4Ua2ZX
 github.com/open-runtimes/types-for-go/v4 v4.0.3/go.mod h1:ab4mDSfgeG4kN8wWpaBSv0Ao3m9P6oEfN5gsXtx+iaI=
 github.com/open-runtimes/types-for-go/v4 v4.0.4 h1:94zFTDNYtF8t7v2TlMqwAedyKftjS4FcGKUmRQ1uNXQ=
 github.com/open-runtimes/types-for-go/v4 v4.0.4/go.mod h1:ab4mDSfgeG4kN8wWpaBSv0Ao3m9P6oEfN5gsXtx+iaI=
+github.com/open-runtimes/types-for-go/v4 v4.0.5 h1:Lw82fnOoaEmGgOoQmJhEOsYjs6Ginie4TdS2RYsvayk=
+github.com/open-runtimes/types-for-go/v4 v4.0.5/go.mod h1:ab4mDSfgeG4kN8wWpaBSv0Ao3m9P6oEfN5gsXtx+iaI=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=

--- a/tests/resources/functions/go/latest/tests.go
+++ b/tests/resources/functions/go/latest/tests.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/go-resty/resty/v2"
-	openruntimes "github.com/open-runtimes/types-for-go/v4"
+	"github.com/open-runtimes/types-for-go/v4/openruntimes"
 )
 
 func Main(Context openruntimes.Context) openruntimes.Response {


### PR DESCRIPTION
Makes import of types without alias - more common approach across Go community