### PR TITLE
Feat: Support spread operator in logs

### DIFF
--- a/runtimes/bun/versions/latest/src/logger.ts
+++ b/runtimes/bun/versions/latest/src/logger.ts
@@ -33,16 +33,16 @@ export class Logger {
     }
   }
 
-  write(message, type = Logger.TYPE_LOG, native = false) {
+  write(messages: any[], type = Logger.TYPE_LOG, native = false) {
     if (!this.enabled) {
       return;
     }
 
     if (native && !this.includesNativeInfo) {
       this.includesNativeInfo = true;
-      this.write(
+      this.write([
         "Native logs detected. Use context.log() or context.error() for better experience.",
-      );
+      ]);
     }
 
     const stream =
@@ -53,12 +53,18 @@ export class Logger {
     }
 
     let stringLog = "";
-    if (message instanceof Error) {
-      stringLog = [message.stack || message].join("\n");
-    } else if (message instanceof Object || Array.isArray(message)) {
-      stringLog = JSON.stringify(message);
-    } else {
-      stringLog = `${message}`;
+    for (let i = 0; i < messages.length; i++) {
+      const message = messages[i];
+      if (message instanceof Error) {
+        stringLog += [message.stack || message].join("\n");
+      } else if (message instanceof Object || Array.isArray(message)) {
+        stringLog += JSON.stringify(message);
+      } else {
+        stringLog += `${message}`;
+      }
+      if (i < messages.length - 1) {
+        stringLog += " ";
+      }
     }
 
     stream.write(stringLog + "\n");
@@ -98,10 +104,7 @@ export class Logger {
       console.warn =
       console.error =
         (...args: any[]) => {
-          const formattedArgs = args.map((arg) =>
-            typeof arg === "object" ? JSON.stringify(arg) : arg,
-          );
-          this.write(formattedArgs.join(" "), Logger.TYPE_LOG, true);
+          this.write(args, Logger.TYPE_LOG, true);
         };
   }
 

--- a/runtimes/bun/versions/latest/src/server.ts
+++ b/runtimes/bun/versions/latest/src/server.ts
@@ -154,11 +154,11 @@ const action = async (logger: Logger, request: any) => {
         return this.text("", statusCode, headers);
       },
     },
-    log: function (message: any) {
-      logger.write(message, Logger.TYPE_LOG);
+    log: function (...messages: any) {
+      logger.write(messages, Logger.TYPE_LOG);
     },
-    error: function (message: any) {
-      logger.write(message, Logger.TYPE_ERROR);
+    error: function (...messages: any) {
+      logger.write(messages, Logger.TYPE_ERROR);
     },
   };
 
@@ -268,7 +268,7 @@ Bun.serve({
     try {
       return await action(logger, request);
     } catch (e) {
-      logger.write(e, Logger.TYPE_ERROR);
+      logger.write([e], Logger.TYPE_ERROR);
 
       const responseHeaders: any = {};
       responseHeaders["x-open-runtimes-log-id"] = logger.id;

--- a/runtimes/deno/versions/1.21/src/logger.ts
+++ b/runtimes/deno/versions/1.21/src/logger.ts
@@ -50,16 +50,16 @@ export class Logger {
     }
   }
 
-  write(message: any, type = Logger.TYPE_LOG, native = false) {
+  write(messages: any[], type = Logger.TYPE_LOG, native = false) {
     if (!this.enabled) {
       return;
     }
 
     if (native && !this.includesNativeInfo) {
       this.includesNativeInfo = true;
-      this.write(
+      this.write([
         "Native logs detected. Use context.log() or context.error() for better experience.",
-      );
+      ]);
     }
 
     const stream = type === Logger.TYPE_ERROR
@@ -71,12 +71,18 @@ export class Logger {
     }
 
     let stringLog = "";
-    if (message instanceof Error) {
-      stringLog = [message.stack || message].join("\n");
-    } else if (message instanceof Object || Array.isArray(message)) {
-      stringLog = JSON.stringify(message);
-    } else {
-      stringLog = `${message}`;
+    for (let i = 0; i < messages.length; i++) {
+      const message = messages[i];
+      if (message instanceof Error) {
+        stringLog += [message.stack || message].join("\n");
+      } else if (message instanceof Object || Array.isArray(message)) {
+        stringLog += JSON.stringify(message);
+      } else {
+        stringLog += `${message}`;
+      }
+      if (i < messages.length - 1) {
+        stringLog += " ";
+      }
     }
 
     const encoded = new TextEncoder().encode(stringLog + "\n");
@@ -117,10 +123,7 @@ export class Logger {
       console.warn =
       console.error =
         (...args: any[]) => {
-          const formattedArgs = args.map((arg) =>
-            typeof arg === "object" ? JSON.stringify(arg) : arg
-          );
-          this.write(formattedArgs.join(" "), Logger.TYPE_LOG, true);
+          this.write(args, Logger.TYPE_LOG, true);
         };
   }
 

--- a/runtimes/deno/versions/1.21/src/server.ts
+++ b/runtimes/deno/versions/1.21/src/server.ts
@@ -19,7 +19,7 @@ app.use(async (ctx: any) => {
   try {
     await action(logger, ctx);
   } catch (e) {
-    logger.write(e, Logger.TYPE_ERROR);
+    logger.write([e], Logger.TYPE_ERROR);
 
     ctx.response.headers.set("x-open-runtimes-log-id", logger.id);
     await logger.end();
@@ -179,11 +179,11 @@ const action = async (logger: Logger, ctx: any) => {
         return this.text("", statusCode, headers);
       },
     },
-    log: function (message: any) {
-      logger.write(message, Logger.TYPE_LOG);
+    log: function (...messages: any) {
+      logger.write(messages, Logger.TYPE_LOG);
     },
-    error: function (message: any) {
-      logger.write(message, Logger.TYPE_ERROR);
+    error: function (...messages: any) {
+      logger.write(messages, Logger.TYPE_ERROR);
     },
   };
 

--- a/runtimes/deno/versions/latest/src/logger.ts
+++ b/runtimes/deno/versions/latest/src/logger.ts
@@ -47,16 +47,16 @@ export class Logger {
     }
   }
 
-  write(message: any, type = Logger.TYPE_LOG, native = false) {
+  write(messages: any[], type = Logger.TYPE_LOG, native = false) {
     if (!this.enabled) {
       return;
     }
 
     if (native && !this.includesNativeInfo) {
       this.includesNativeInfo = true;
-      this.write(
+      this.write([
         "Native logs detected. Use context.log() or context.error() for better experience.",
-      );
+      ]);
     }
 
     const stream = type === Logger.TYPE_ERROR
@@ -68,12 +68,18 @@ export class Logger {
     }
 
     let stringLog = "";
-    if (message instanceof Error) {
-      stringLog = [message.stack || message].join("\n");
-    } else if (message instanceof Object || Array.isArray(message)) {
-      stringLog = JSON.stringify(message);
-    } else {
-      stringLog = `${message}`;
+    for (let i = 0; i < messages.length; i++) {
+      const message = messages[i];
+      if (message instanceof Error) {
+        stringLog += [message.stack || message].join("\n");
+      } else if (message instanceof Object || Array.isArray(message)) {
+        stringLog += JSON.stringify(message);
+      } else {
+        stringLog += `${message}`;
+      }
+      if (i < messages.length - 1) {
+        stringLog += " ";
+      }
     }
 
     const encoded = new TextEncoder().encode(stringLog + "\n");
@@ -114,10 +120,7 @@ export class Logger {
       console.warn =
       console.error =
         (...args: any[]) => {
-          const formattedArgs = args.map((arg) =>
-            typeof arg === "object" ? JSON.stringify(arg) : arg
-          );
-          this.write(formattedArgs.join(" "), Logger.TYPE_LOG, true);
+          this.write(args, Logger.TYPE_LOG, true);
         };
   }
 

--- a/runtimes/deno/versions/latest/src/server.ts
+++ b/runtimes/deno/versions/latest/src/server.ts
@@ -19,7 +19,7 @@ app.use(async (ctx: any) => {
   try {
     await action(logger, ctx);
   } catch (e) {
-    logger.write(e, Logger.TYPE_ERROR);
+    logger.write([e], Logger.TYPE_ERROR);
 
     ctx.response.headers.set("x-open-runtimes-log-id", logger.id);
     await logger.end();
@@ -179,11 +179,11 @@ const action = async (logger: Logger, ctx: any) => {
         return this.text("", statusCode, headers);
       },
     },
-    log: function (message: any) {
-      logger.write(message, Logger.TYPE_LOG);
+    log: function (...messages: any) {
+      logger.write(messages, Logger.TYPE_LOG);
     },
-    error: function (message: any) {
-      logger.write(message, Logger.TYPE_ERROR);
+    error: function (...messages: any) {
+      logger.write(messages, Logger.TYPE_ERROR);
     },
   };
 

--- a/runtimes/go/README.md
+++ b/runtimes/go/README.md
@@ -38,7 +38,7 @@ END
 tee -a go.mod << END
 module openruntimes/handler
 
-require github.com/open-runtimes/types-for-go/v4 v4.0.5
+require github.com/open-runtimes/types-for-go/v4 v4.0.6
 
 END
 

--- a/runtimes/go/versions/latest/src/go.mod
+++ b/runtimes/go/versions/latest/src/go.mod
@@ -4,5 +4,5 @@ go 1.22.5
 
 replace openruntimes/handler v0.0.0 => /usr/local/build
 
-// require openruntimes/handler v0.0.0
-require github.com/open-runtimes/types-for-go/v4 v4.0.6-0.20240818164233-b4d5d5df2b30
+require openruntimes/handler v0.0.0
+require github.com/open-runtimes/types-for-go/v4 v4.0.6

--- a/runtimes/go/versions/latest/src/go.mod
+++ b/runtimes/go/versions/latest/src/go.mod
@@ -4,5 +4,5 @@ go 1.22.5
 
 replace openruntimes/handler v0.0.0 => /usr/local/build
 
-require openruntimes/handler v0.0.0
-require github.com/open-runtimes/types-for-go/v4 v4.0.5
+// require openruntimes/handler v0.0.0
+require github.com/open-runtimes/types-for-go/v4 v4.0.6-0.20240818164233-b4d5d5df2b30

--- a/runtimes/go/versions/latest/src/go.sum
+++ b/runtimes/go/versions/latest/src/go.sum
@@ -12,3 +12,5 @@ github.com/open-runtimes/types-for-go/v4 v4.0.5-0.20240723074015-667f31acc810 h1
 github.com/open-runtimes/types-for-go/v4 v4.0.5-0.20240723074015-667f31acc810/go.mod h1:ab4mDSfgeG4kN8wWpaBSv0Ao3m9P6oEfN5gsXtx+iaI=
 github.com/open-runtimes/types-for-go/v4 v4.0.5 h1:Lw82fnOoaEmGgOoQmJhEOsYjs6Ginie4TdS2RYsvayk=
 github.com/open-runtimes/types-for-go/v4 v4.0.5/go.mod h1:ab4mDSfgeG4kN8wWpaBSv0Ao3m9P6oEfN5gsXtx+iaI=
+github.com/open-runtimes/types-for-go/v4 v4.0.6-0.20240818164233-b4d5d5df2b30 h1:PuUh8RBMXuQXlk4Mn8/HnnlI+sutXh/K6ImhCfXVviI=
+github.com/open-runtimes/types-for-go/v4 v4.0.6-0.20240818164233-b4d5d5df2b30/go.mod h1:ab4mDSfgeG4kN8wWpaBSv0Ao3m9P6oEfN5gsXtx+iaI=

--- a/runtimes/go/versions/latest/src/main.go
+++ b/runtimes/go/versions/latest/src/main.go
@@ -249,7 +249,7 @@ func main() {
 		logger, loggerErr := openruntimes.NewLogger(logging, logId)
 
 		if loggerErr != nil {
-			logger.Write([]string{
+			logger.Write([]interface{}{
 				loggerErr.Error(),
 			}, openruntimes.LOGGER_TYPE_ERROR, false)
 
@@ -265,7 +265,7 @@ func main() {
 		err := action(w, r, logger)
 
 		if err != nil {
-			logger.Write([]string{
+			logger.Write([]interface{}{
 				err.Error(),
 			}, openruntimes.LOGGER_TYPE_ERROR, false)
 

--- a/runtimes/java/versions/11.0/src/main/java/io/openruntimes/java/RuntimeLogger.java
+++ b/runtimes/java/versions/11.0/src/main/java/io/openruntimes/java/RuntimeLogger.java
@@ -72,7 +72,7 @@ public class RuntimeLogger {
     return this.id;
   }
 
-  public void write(Object message, String type, Boolean xnative) throws IOException {
+  public void write(Object[] messages, String type, Boolean xnative) throws IOException {
     if (this.enabled == false) {
       return;
     }
@@ -87,10 +87,10 @@ public class RuntimeLogger {
 
     if (xnative && !this.includesNativeInfo) {
       this.includesNativeInfo = true;
-      this.write(
-          "Native logs detected. Use context.log() or context.error() for better experience.",
-          type,
-          xnative);
+
+      String[] logs = new String[1];
+      logs[0] = "Native logs detected. Use context.log() or context.error() for better experience.";
+      this.write(logs, type, xnative);
     }
 
     FileWriter stream = this.streamLogs;
@@ -100,10 +100,21 @@ public class RuntimeLogger {
     }
 
     String stringLog = "";
-    if (message instanceof Map || message instanceof List || message instanceof Set) {
-      stringLog = gson.toJson(message);
-    } else {
-      stringLog = message.toString();
+
+    int i = 0;
+
+    for (Object message : messages) {
+      if (message instanceof Map || message instanceof List || message instanceof Set) {
+        stringLog += gson.toJson(message);
+      } else {
+        stringLog += message.toString();
+      }
+
+      if (i < messages.length - 1) {
+        stringLog += " ";
+      }
+
+      i += 1;
     }
 
     stream.write(stringLog);
@@ -138,7 +149,9 @@ public class RuntimeLogger {
 
     if (!this.customStdStream.toString().isEmpty()) {
       try {
-        this.write(customStdStream.toString(), RuntimeLogger.TYPE_LOG, true);
+        String[] logs = new String[1];
+        logs[0] = customStdStream.toString();
+        this.write(logs, RuntimeLogger.TYPE_LOG, true);
       } catch (IOException e) {
         // Ignore missing logs
       }

--- a/runtimes/java/versions/8.0/src/main/java/io/openruntimes/java/RuntimeLogger.java
+++ b/runtimes/java/versions/8.0/src/main/java/io/openruntimes/java/RuntimeLogger.java
@@ -72,7 +72,7 @@ public class RuntimeLogger {
     return this.id;
   }
 
-  public void write(Object message, String type, Boolean xnative) throws IOException {
+  public void write(Object[] messages, String type, Boolean xnative) throws IOException {
     if (this.enabled == false) {
       return;
     }
@@ -87,10 +87,10 @@ public class RuntimeLogger {
 
     if (xnative && !this.includesNativeInfo) {
       this.includesNativeInfo = true;
-      this.write(
-          "Native logs detected. Use context.log() or context.error() for better experience.",
-          type,
-          xnative);
+
+      String[] logs = new String[1];
+      logs[0] = "Native logs detected. Use context.log() or context.error() for better experience.";
+      this.write(logs, type, xnative);
     }
 
     FileWriter stream = this.streamLogs;
@@ -100,10 +100,21 @@ public class RuntimeLogger {
     }
 
     String stringLog = "";
-    if (message instanceof Map || message instanceof List || message instanceof Set) {
-      stringLog = gson.toJson(message);
-    } else {
-      stringLog = message.toString();
+
+    int i = 0;
+
+    for (Object message : messages) {
+      if (message instanceof Map || message instanceof List || message instanceof Set) {
+        stringLog += gson.toJson(message);
+      } else {
+        stringLog += message.toString();
+      }
+
+      if (i < messages.length - 1) {
+        stringLog += " ";
+      }
+
+      i += 1;
     }
 
     stream.write(stringLog);
@@ -138,7 +149,9 @@ public class RuntimeLogger {
 
     if (!this.customStdStream.toString().isEmpty()) {
       try {
-        this.write(customStdStream.toString(), RuntimeLogger.TYPE_LOG, true);
+        String[] logs = new String[1];
+        logs[0] = customStdStream.toString();
+        this.write(logs, RuntimeLogger.TYPE_LOG, true);
       } catch (IOException e) {
         // Ignore missing logs
       }

--- a/runtimes/java/versions/8.0/src/main/java/io/openruntimes/java/Server.java
+++ b/runtimes/java/versions/8.0/src/main/java/io/openruntimes/java/Server.java
@@ -66,7 +66,9 @@ public class Server {
       ctx.header("x-open-runtimes-log-id", logger.getId());
 
       try {
-        logger.write(message, RuntimeLogger.TYPE_ERROR, false);
+        String[] logs = new String[1];
+        logs[0] = message.toString();
+        logger.write(logs, RuntimeLogger.TYPE_ERROR, false);
         logger.end();
       } catch (IOException e2) {
         // Ignore missing logs

--- a/runtimes/java/versions/latest/src/main/java/io/openruntimes/java/RuntimeContext.java
+++ b/runtimes/java/versions/latest/src/main/java/io/openruntimes/java/RuntimeContext.java
@@ -21,17 +21,23 @@ public class RuntimeContext {
     this.logger = logger;
   }
 
-  public void log(Object message) {
+  public void log(Object... messages) {
     try {
-      this.logger.write(message + "\n", RuntimeLogger.TYPE_LOG, false);
+      this.logger.write(messages, RuntimeLogger.TYPE_LOG, false);
+      String[] linebreak = new String[1];
+      linebreak[0] = "\n";
+      this.logger.write(linebreak, RuntimeLogger.TYPE_LOG, false);
     } catch (IOException e) {
       // Ignore missing logs
     }
   }
 
-  public void error(Object message) {
+  public void error(Object... messages) {
     try {
-      this.logger.write(message + "\n", RuntimeLogger.TYPE_ERROR, false);
+      this.logger.write(messages, RuntimeLogger.TYPE_ERROR, false);
+      String[] linebreak = new String[1];
+      linebreak[0] = "\n";
+      this.logger.write(linebreak, RuntimeLogger.TYPE_ERROR, false);
     } catch (IOException e) {
       // Ignore missing logs
     }

--- a/runtimes/java/versions/latest/src/main/java/io/openruntimes/java/RuntimeLogger.java
+++ b/runtimes/java/versions/latest/src/main/java/io/openruntimes/java/RuntimeLogger.java
@@ -72,7 +72,7 @@ public class RuntimeLogger {
     return this.id;
   }
 
-  public void write(Object message, String type, Boolean xnative) throws IOException {
+  public void write(Object[] messages, String type, Boolean xnative) throws IOException {
     if (this.enabled == false) {
       return;
     }
@@ -87,10 +87,10 @@ public class RuntimeLogger {
 
     if (xnative && !this.includesNativeInfo) {
       this.includesNativeInfo = true;
-      this.write(
-          "Native logs detected. Use context.log() or context.error() for better experience.",
-          type,
-          xnative);
+
+      String[] logs = new String[1];
+      logs[0] = "Native logs detected. Use context.log() or context.error() for better experience.";
+      this.write(logs, type, xnative);
     }
 
     FileWriter stream = this.streamLogs;
@@ -100,10 +100,21 @@ public class RuntimeLogger {
     }
 
     String stringLog = "";
-    if (message instanceof Map || message instanceof List || message instanceof Set) {
-      stringLog = gson.toJson(message);
-    } else {
-      stringLog = message.toString();
+
+    int i = 0;
+
+    for (Object message : messages) {
+      if (message instanceof Map || message instanceof List || message instanceof Set) {
+        stringLog += gson.toJson(message);
+      } else {
+        stringLog += message.toString();
+      }
+
+      if (i < messages.length - 1) {
+        stringLog += " ";
+      }
+
+      i += 1;
     }
 
     stream.write(stringLog);
@@ -138,7 +149,9 @@ public class RuntimeLogger {
 
     if (!this.customStdStream.toString().isEmpty()) {
       try {
-        this.write(customStdStream.toString(), RuntimeLogger.TYPE_LOG, true);
+        String[] logs = new String[1];
+        logs[0] = customStdStream.toString();
+        this.write(logs, RuntimeLogger.TYPE_LOG, true);
       } catch (IOException e) {
         // Ignore missing logs
       }

--- a/runtimes/java/versions/latest/src/main/java/io/openruntimes/java/Server.java
+++ b/runtimes/java/versions/latest/src/main/java/io/openruntimes/java/Server.java
@@ -67,7 +67,9 @@ public class Server {
       ctx.header("x-open-runtimes-log-id", logger.getId());
 
       try {
-        logger.write(arrayOf(message), RuntimeLogger.TYPE_ERROR, false);
+        String[] logs = new String[1];
+        logs[0] = message.toString();
+        logger.write(logs, RuntimeLogger.TYPE_ERROR, false);
         logger.end();
       } catch (IOException e2) {
         // Ignore missing logs

--- a/runtimes/java/versions/latest/src/main/java/io/openruntimes/java/Server.java
+++ b/runtimes/java/versions/latest/src/main/java/io/openruntimes/java/Server.java
@@ -67,7 +67,7 @@ public class Server {
       ctx.header("x-open-runtimes-log-id", logger.getId());
 
       try {
-        logger.write(message, RuntimeLogger.TYPE_ERROR, false);
+        logger.write(arrayOf(message), RuntimeLogger.TYPE_ERROR, false);
         logger.end();
       } catch (IOException e2) {
         // Ignore missing logs

--- a/runtimes/kotlin/versions/latest/src/main/kotlin/io/openruntimes/kotlin/RuntimeContext.kt
+++ b/runtimes/kotlin/versions/latest/src/main/kotlin/io/openruntimes/kotlin/RuntimeContext.kt
@@ -5,13 +5,13 @@ class RuntimeContext(
     val res: RuntimeResponse,
     val logger: RuntimeLogger,
 ) {
-    fun log(message: Any) {
-        this.logger.write(message, RuntimeLogger.TYPE_LOG)
-        this.logger.write("\n", RuntimeLogger.TYPE_LOG)
+    fun log(vararg messages: Any) {
+        this.logger.write(messages, RuntimeLogger.TYPE_LOG)
+        this.logger.write(arrayOf("\n"), RuntimeLogger.TYPE_LOG)
     }
 
-    fun error(message: Any) {
-        this.logger.write(message, RuntimeLogger.TYPE_ERROR)
-        this.logger.write("\n", RuntimeLogger.TYPE_ERROR)
+    fun error(vararg messages: Any) {
+        this.logger.write(messages, RuntimeLogger.TYPE_ERROR)
+        this.logger.write(arrayOf("\n"), RuntimeLogger.TYPE_ERROR)
     }
 }

--- a/runtimes/kotlin/versions/latest/src/main/kotlin/io/openruntimes/kotlin/RuntimeLogger.kt
+++ b/runtimes/kotlin/versions/latest/src/main/kotlin/io/openruntimes/kotlin/RuntimeLogger.kt
@@ -70,7 +70,7 @@ class RuntimeLogger(
     }
 
     fun write(
-        message: Any,
+        messages: Array<out Any>,
         type: String = RuntimeLogger.TYPE_LOG,
         native: Boolean = false,
     ) {
@@ -80,7 +80,8 @@ class RuntimeLogger(
 
         if (native && !this.includesNativeInfo) {
             this.includesNativeInfo = true
-            this.write("Native logs detected. Use context.log() or context.error() for better experience.", type, native)
+
+            this.write(arrayOf("Native logs detected. Use context.log() or context.error() for better experience."), type, native)
         }
 
         var stream: FileWriter? = this.streamLogs
@@ -90,10 +91,20 @@ class RuntimeLogger(
         }
 
         var stringLog: String = ""
-        if (message is Map<*, *> || message is List<*> || message is Set<*>) {
-            stringLog = gson.toJson(message)
-        } else {
-            stringLog = message.toString()
+
+        var i = 0
+        for (message in messages) {
+            if (message is Map<*, *> || message is List<*> || message is Set<*>) {
+                stringLog += gson.toJson(message)
+            } else {
+                stringLog += message.toString()
+            }
+
+            if (i < messages.size - 1) {
+                stringLog += " "
+            }
+
+            i += 1
         }
 
         if (stream != null) {
@@ -129,7 +140,7 @@ class RuntimeLogger(
         System.setErr(this.nativeErrorsCache)
 
         if (!this.customStdStream.toString().isEmpty()) {
-            this.write(customStdStream.toString(), RuntimeLogger.TYPE_LOG, true)
+            this.write(arrayOf(customStdStream.toString()), RuntimeLogger.TYPE_LOG, true)
         }
     }
 

--- a/runtimes/kotlin/versions/latest/src/main/kotlin/io/openruntimes/kotlin/Server.kt
+++ b/runtimes/kotlin/versions/latest/src/main/kotlin/io/openruntimes/kotlin/Server.kt
@@ -46,7 +46,7 @@ suspend fun execute(ctx: Context) {
 
         ctx.header("x-open-runtimes-log-id", logger.id ?: "")
 
-        logger.write(message, RuntimeLogger.TYPE_ERROR, false)
+        logger.write(arrayOf(message), RuntimeLogger.TYPE_ERROR, false)
         logger.end()
 
         ctx.status(500).result("")

--- a/runtimes/node/versions/latest/src/logger.js
+++ b/runtimes/node/versions/latest/src/logger.js
@@ -33,28 +33,35 @@ class Logger {
     }
   }
 
-  write(message, type = Logger.TYPE_LOG, native = false) {
+  write(messages, type = Logger.TYPE_LOG, native = false) {
     if (!this.enabled) {
       return;
     }
 
     if (native && !this.includesNativeInfo) {
       this.includesNativeInfo = true;
-      this.write(
+      this.write([
         "Native logs detected. Use context.log() or context.error() for better experience.",
-      );
+      ]);
     }
 
     const stream =
       type === Logger.TYPE_ERROR ? this.streamErrors : this.streamLogs;
 
     let stringLog = "";
-    if (message instanceof Error) {
-      stringLog = [message.stack || message].join("\n");
-    } else if (message instanceof Object || Array.isArray(message)) {
-      stringLog = JSON.stringify(message);
-    } else {
-      stringLog = `${message}`;
+    for (let i = 0; i < messages.length; i++) {
+      const message = messages[i];
+      if (message instanceof Error) {
+        stringLog += [message.stack || message].join("\n");
+      } else if (message instanceof Object || Array.isArray(message)) {
+        stringLog += JSON.stringify(message);
+      } else {
+        stringLog += `${message}`;
+      }
+
+      if (i < messages.length - 1) {
+        stringLog += " ";
+      }
     }
 
     stream.write(stringLog + "\n");
@@ -94,10 +101,7 @@ class Logger {
       console.warn =
       console.error =
         (...args) => {
-          const formattedArgs = args.map((arg) =>
-            typeof arg === "object" ? JSON.stringify(arg) : arg,
-          );
-          this.write(formattedArgs.join(" "), Logger.TYPE_LOG, true);
+          this.write(args, Logger.TYPE_LOG, true);
         };
   }
 

--- a/runtimes/node/versions/latest/src/server.js
+++ b/runtimes/node/versions/latest/src/server.js
@@ -13,7 +13,7 @@ const server = micro(async (req, res) => {
   try {
     await action(logger, req, res);
   } catch (e) {
-    logger.write(e, Logger.TYPE_ERROR);
+    logger.write([e], Logger.TYPE_ERROR);
 
     res.setHeader("x-open-runtimes-log-id", logger.id);
     await logger.end();
@@ -168,11 +168,11 @@ const action = async (logger, req, res) => {
         return this.text("", statusCode, headers);
       },
     },
-    log: function (message) {
-      logger.write(message, Logger.TYPE_LOG);
+    log: function (...messages) {
+      logger.write(messages, Logger.TYPE_LOG);
     },
-    error: function (message) {
-      logger.write(message, Logger.TYPE_ERROR);
+    error: function (...messages) {
+      logger.write(messages, Logger.TYPE_ERROR);
     },
   };
 

--- a/runtimes/php/versions/latest/src/logger.php
+++ b/runtimes/php/versions/latest/src/logger.php
@@ -24,7 +24,7 @@ class Logger
         }
     }
 
-    public function write(mixed $message, string $type = Logger::TYPE_LOG, bool $isNative = false): void
+    public function write(array $messages, string $type = Logger::TYPE_LOG, bool $isNative = false): void
     {
         if (!$this->enabled) {
             return;
@@ -32,18 +32,28 @@ class Logger
 
         if ($isNative && !$this->includesNativeInfo) {
             $this->includesNativeInfo = true;
-            $this->write('Native logs detected. Use context.log() or context.error() for better experience.');
+            $this->write(['Native logs detected. Use context.log() or context.error() for better experience.']);
         }
 
         $stream = $type == Logger::TYPE_ERROR ? $this->streamErrors : $this->streamLogs;
 
         $stringLog = "";
 
-        if (\is_array($message) || \is_object($message)) {
-            $stringLog = \json_encode($message);
-        } else {
-            $stringLog = \strval($message);
+        $i = 0;
+        foreach ($messages as $message) {
+            if (\is_array($message) || \is_object($message)) {
+                $stringLog .= \json_encode($message);
+            } else {
+                $stringLog .= \strval($message);
+            }
+
+            if ($i < \count($messages) - 1) {
+                $stringLog .= " ";
+            }
+
+            $i++;
         }
+
 
         \fwrite($stream, $stringLog . "\n");
     }
@@ -79,7 +89,7 @@ class Logger
         $customStd = ob_get_clean();
 
         if (!empty($customStd)) {
-            $this->write($customStd, Logger::TYPE_LOG, true);
+            $this->write([$customStd], Logger::TYPE_LOG, true);
         }
     }
 

--- a/runtimes/php/versions/latest/src/server.php
+++ b/runtimes/php/versions/latest/src/server.php
@@ -192,7 +192,7 @@ $server->on("Request", function ($req, $res) use ($action) {
         $message .= $e->getTraceAsString() . "\n";
         $message .= 'In ' . $e->getFile() . ':' . $e->getLine() . "\n";
 
-        $logger->write($message, Logger::TYPE_ERROR);
+        $logger->write([$message], Logger::TYPE_ERROR);
 
         $res->header('x-open-runtimes-log-id', $logger->id);
         $logger->end();

--- a/runtimes/php/versions/latest/src/types.php
+++ b/runtimes/php/versions/latest/src/types.php
@@ -111,13 +111,13 @@ class RuntimeContext
         $this->logger = $logger;
     }
 
-    public function log(mixed $message): void
+    public function log(mixed ...$messages): void
     {
-        $this->logger->write($message, Logger::TYPE_LOG);
+        $this->logger->write($messages, Logger::TYPE_LOG);
     }
 
-    public function error(mixed $message): void
+    public function error(mixed ...$messages): void
     {
-        $this->logger->write($message, Logger::TYPE_ERROR);
+        $this->logger->write($messages, Logger::TYPE_ERROR);
     }
 }

--- a/runtimes/python/versions/latest/src/function_types.py
+++ b/runtimes/python/versions/latest/src/function_types.py
@@ -89,10 +89,10 @@ class Context:
         self.res = Response()
         self.logger = logger
 
-    def log(self, message):
-        self.logger.write(message, Logger.TYPE_LOG)
+    def log(self, *messages):
+        self.logger.write(messages, Logger.TYPE_LOG)
         self.logger.write("\n", Logger.TYPE_LOG)
 
-    def error(self, message):
-        self.logger.write(message, Logger.TYPE_ERROR)
+    def error(self, *messages):
+        self.logger.write(messages, Logger.TYPE_ERROR)
         self.logger.write("\n", Logger.TYPE_ERROR)

--- a/runtimes/python/versions/latest/src/function_types.py
+++ b/runtimes/python/versions/latest/src/function_types.py
@@ -91,8 +91,8 @@ class Context:
 
     def log(self, *messages):
         self.logger.write(messages, Logger.TYPE_LOG)
-        self.logger.write("\n", Logger.TYPE_LOG)
+        self.logger.write(["\n"], Logger.TYPE_LOG)
 
     def error(self, *messages):
         self.logger.write(messages, Logger.TYPE_ERROR)
-        self.logger.write("\n", Logger.TYPE_ERROR)
+        self.logger.write(["\n"], Logger.TYPE_ERROR)

--- a/runtimes/python/versions/latest/src/logger.py
+++ b/runtimes/python/versions/latest/src/logger.py
@@ -74,7 +74,7 @@ class Logger:
 
             if i < len(messages) - 1:
                 string_log += " "
-            
+
             i += 1
 
         stream.write(string_log)

--- a/runtimes/python/versions/latest/src/logger.py
+++ b/runtimes/python/versions/latest/src/logger.py
@@ -44,7 +44,7 @@ class Logger:
             self.stream_logs = open("/mnt/logs/" + self.id + "_logs.log", "a")
             self.stream_errors = open("/mnt/logs/" + self.id + "_errors.log", "a")
 
-    def write(self, message, xtype=None, is_native=False):
+    def write(self, messages, xtype=None, is_native=False):
         if xtype is None:
             xtype = Logger.TYPE_LOG
 
@@ -54,7 +54,9 @@ class Logger:
         if is_native is True and self.includes_native_info is False:
             self.includes_native_info = True
             self.write(
-                "Native logs detected. Use context.log() or context.error() for better experience."
+                [
+                    "Native logs detected. Use context.log() or context.error() for better experience."
+                ]
             )
 
         stream = self.stream_logs
@@ -63,11 +65,17 @@ class Logger:
             stream = self.stream_errors
 
         string_log = ""
+        i = 0
+        for message in messages:
+            if isinstance(message, (list, dict, tuple)):
+                string_log += json.dumps(message, separators=(",", ":"))
+            else:
+                string_log += str(message)
 
-        if isinstance(message, (list, dict, tuple)):
-            string_log = json.dumps(message, separators=(",", ":"))
-        else:
-            string_log = str(message)
+            if i < len(messages) - 1:
+                string_log += " "
+            
+            i += 1
 
         stream.write(string_log)
 
@@ -85,7 +93,7 @@ class Logger:
 
     def revert_native_logs(self):
         if self.custom_std is not None and self.custom_std.getvalue():
-            self.write(self.custom_std.getvalue(), Logger.TYPE_LOG, True)
+            self.write([self.custom_std.getvalue()], Logger.TYPE_LOG, True)
 
         sys.stdout = sys.__stdout__
         sys.stderr = sys.__stderr__

--- a/runtimes/python/versions/latest/src/server.py
+++ b/runtimes/python/versions/latest/src/server.py
@@ -173,7 +173,7 @@ async def handler(u_path):
         return await action(logger, request)
     except Exception as e:
         message = "".join(traceback.TracebackException.from_exception(e).format())
-        logger.write(message, Logger.TYPE_ERROR)
+        logger.write([message], Logger.TYPE_ERROR)
 
     resp = FlaskResponse("", 500)
 

--- a/runtimes/ruby/versions/latest/src/logger.rb
+++ b/runtimes/ruby/versions/latest/src/logger.rb
@@ -40,14 +40,14 @@ class RuntimeLogger
     end
   end
 
-  def write(message, type = RuntimeLogger::TYPE_LOG, native = false)
+  def write(messages, type = RuntimeLogger::TYPE_LOG, native = false)
     if !@enabled
       return
     end
 
     if native && !@includes_native_info
       @includes_native_info = true
-      self.write("Native logs detected. Use context.log() or context.error() for better experience.", type,
+      self.write(["Native logs detected. Use context.log() or context.error() for better experience."], type,
                  native)
     end
 
@@ -58,10 +58,19 @@ class RuntimeLogger
     end
 
     string_log = ""
-    if message.kind_of?(Array) || message.kind_of?(Hash)
-      string_log = message.to_json
-    else
-      string_log = message.to_s
+    i = 0
+    messages.each do |message|
+      if message.kind_of?(Array) || message.kind_of?(Hash)
+        string_log += message.to_json
+      else
+        string_log += message.to_s
+      end
+
+      if i < messages.length() - 1
+        string_log += " ";
+      end
+
+      i += 1
     end
 
     stream.write(string_log)
@@ -91,7 +100,7 @@ class RuntimeLogger
     $stderr = @native_errors_cache
 
     unless @custom_std_stream.string.nil? || @custom_std_stream.string.empty?
-      self.write(custom_std_stream.string, RuntimeLogger::TYPE_LOG, true)
+      self.write([custom_std_stream.string], RuntimeLogger::TYPE_LOG, true)
     end
   end
 

--- a/runtimes/ruby/versions/latest/src/server.rb
+++ b/runtimes/ruby/versions/latest/src/server.rb
@@ -178,7 +178,7 @@ def handle(request, response)
     message += "\n"
     message += e.backtrace.join("\n")
 
-    logger.write(message, RuntimeLogger::TYPE_ERROR)
+    logger.write([message], RuntimeLogger::TYPE_ERROR)
     logger.end
 
     response.headers['x-open-runtimes-log-id'] = logger.id

--- a/runtimes/ruby/versions/latest/src/types.rb
+++ b/runtimes/ruby/versions/latest/src/types.rb
@@ -106,13 +106,13 @@ class RuntimeContext
     @logger = logger
   end
 
-  def log(message)
-    @logger.write(message, RuntimeLogger::TYPE_LOG)
-    @logger.write("\n", RuntimeLogger::TYPE_LOG)
+  def log(*messages)
+    @logger.write(messages, RuntimeLogger::TYPE_LOG)
+    @logger.write(["\n"], RuntimeLogger::TYPE_LOG)
   end
 
-  def error(message)
-    @logger.write(message, RuntimeLogger::TYPE_ERROR)
-    @logger.write("\n", RuntimeLogger::TYPE_ERROR)
+  def error(*messages)
+    @logger.write(messages, RuntimeLogger::TYPE_ERROR)
+    @logger.write(["\n"], RuntimeLogger::TYPE_ERROR)
   end
 end

--- a/tests/Base.php
+++ b/tests/Base.php
@@ -664,7 +664,7 @@ class Base extends TestCase
     {
         $response = Client::execute(body: '', headers: ['x-action' => 'spreadOperatorLogs']);
 
-        $affectedRuntimes = [ 'node', 'deno', 'bun', 'python', 'ruby', 'php' ];
+        $affectedRuntimes = [ 'node', 'deno', 'bun', 'python', 'ruby', 'php', 'java', 'kotlin' ];
         if(\in_array($this->runtimeName, $affectedRuntimes)) {
             self::assertEquals(200, $response['code']);
             self::assertEquals('OK', $response['body']);

--- a/tests/Base.php
+++ b/tests/Base.php
@@ -659,4 +659,21 @@ class Base extends TestCase
         $actual = preg_replace('/\s+/', '', $actual);
         self::assertEquals($expected, $actual, $message);
     }
+
+    public function testSpreadOperatorLogs(): void
+    {
+        $response = Client::execute(body: '', headers: ['x-action' => 'spreadOperatorLogs']);
+
+        $affectedRuntimes = [ 'node' ];
+        if(\in_array($this->runtimeName, $affectedRuntimes)) {
+            self::assertEquals(200, $response['code']);
+            self::assertEquals('OK', $response['body']);
+            self::assertStringContainsString('engine:', Client::getLogs($response['headers']['x-open-runtimes-log-id']));
+            self::assertStringContainsString(' ', Client::getLogs($response['headers']['x-open-runtimes-log-id']));
+            self::assertStringContainsString('open-runtimes', Client::getLogs($response['headers']['x-open-runtimes-log-id']));
+        } else {
+            self::assertEquals(500, $response['code']);
+            self::assertStringContainsString('Unknown action', Client::getErrors($response['headers']['x-open-runtimes-log-id']));
+        }
+    }
 }

--- a/tests/Base.php
+++ b/tests/Base.php
@@ -664,7 +664,7 @@ class Base extends TestCase
     {
         $response = Client::execute(body: '', headers: ['x-action' => 'spreadOperatorLogs']);
 
-        $affectedRuntimes = [ 'node', 'deno', 'bun', 'python', 'ruby', 'php', 'java', 'kotlin' ];
+        $affectedRuntimes = [ 'node', 'deno', 'bun', 'python', 'ruby', 'php', 'java', 'kotlin', 'go' ];
         if(\in_array($this->runtimeName, $affectedRuntimes)) {
             self::assertEquals(200, $response['code']);
             self::assertEquals('OK', $response['body']);

--- a/tests/Base.php
+++ b/tests/Base.php
@@ -672,6 +672,7 @@ class Base extends TestCase
             self::assertStringContainsString('open-runtimes', Client::getLogs($response['headers']['x-open-runtimes-log-id']));
             self::assertStringContainsString(' ', Client::getLogs($response['headers']['x-open-runtimes-log-id']));
             $spaceOccurances = \substr_count(Client::getLogs($response['headers']['x-open-runtimes-log-id']), ' ');
+            self::assertEquals(1, $spaceOccurances);
             self::assertStringContainsString('engine:', Client::getErrors($response['headers']['x-open-runtimes-log-id']));
             self::assertStringContainsString('open-runtimes', Client::getErrors($response['headers']['x-open-runtimes-log-id']));
             self::assertStringContainsString(' ', Client::getErrors($response['headers']['x-open-runtimes-log-id']));

--- a/tests/Base.php
+++ b/tests/Base.php
@@ -664,13 +664,19 @@ class Base extends TestCase
     {
         $response = Client::execute(body: '', headers: ['x-action' => 'spreadOperatorLogs']);
 
-        $affectedRuntimes = [ 'node' ];
+        $affectedRuntimes = [ 'node', 'deno', 'bun', 'python', 'ruby', 'php' ];
         if(\in_array($this->runtimeName, $affectedRuntimes)) {
             self::assertEquals(200, $response['code']);
             self::assertEquals('OK', $response['body']);
             self::assertStringContainsString('engine:', Client::getLogs($response['headers']['x-open-runtimes-log-id']));
-            self::assertStringContainsString(' ', Client::getLogs($response['headers']['x-open-runtimes-log-id']));
             self::assertStringContainsString('open-runtimes', Client::getLogs($response['headers']['x-open-runtimes-log-id']));
+            self::assertStringContainsString(' ', Client::getLogs($response['headers']['x-open-runtimes-log-id']));
+            $spaceOccurances = \substr_count(Client::getLogs($response['headers']['x-open-runtimes-log-id']), ' ');
+            self::assertStringContainsString('engine:', Client::getErrors($response['headers']['x-open-runtimes-log-id']));
+            self::assertStringContainsString('open-runtimes', Client::getErrors($response['headers']['x-open-runtimes-log-id']));
+            self::assertStringContainsString(' ', Client::getErrors($response['headers']['x-open-runtimes-log-id']));
+            $spaceOccurances = \substr_count(Client::getErrors($response['headers']['x-open-runtimes-log-id']), ' ');
+            self::assertEquals(1, $spaceOccurances);
         } else {
             self::assertEquals(500, $response['code']);
             self::assertStringContainsString('Unknown action', Client::getErrors($response['headers']['x-open-runtimes-log-id']));

--- a/tests/resources/functions/bun/latest/tests.ts
+++ b/tests/resources/functions/bun/latest/tests.ts
@@ -133,6 +133,11 @@ When you can have two!
             return context.res.send(image, 200, {
                 'content-type': 'image/png'
             });
+        case 'spreadOperatorLogs':
+            const engine = 'open-runtimes';
+            context.log("engine:", engine);
+            context.error("engine:", engine);
+            return context.res.text('OK');
         default:
             throw new Error('Unknown action.');
     }

--- a/tests/resources/functions/deno/latest/tests.ts
+++ b/tests/resources/functions/deno/latest/tests.ts
@@ -135,6 +135,11 @@ When you can have two!
             return context.res.send(image, 200, {
                 'content-type': 'image/png'
             });
+        case 'spreadOperatorLogs':
+            const engine = 'open-runtimes';
+            context.log("engine:", engine);
+            context.error("engine:", engine);
+            return context.res.text('OK');
         default:
             throw new Error('Unknown action');
     }

--- a/tests/resources/functions/go/latest/go.mod
+++ b/tests/resources/functions/go/latest/go.mod
@@ -4,7 +4,7 @@ go 1.22.5
 
 require (
 	github.com/go-resty/resty/v2 v2.11.0
-	github.com/open-runtimes/types-for-go/v4 v4.0.5
+	github.com/open-runtimes/types-for-go/v4 v4.0.6-0.20240818164233-b4d5d5df2b30
 )
 
 require (

--- a/tests/resources/functions/go/latest/go.mod
+++ b/tests/resources/functions/go/latest/go.mod
@@ -4,7 +4,7 @@ go 1.22.5
 
 require (
 	github.com/go-resty/resty/v2 v2.11.0
-	github.com/open-runtimes/types-for-go/v4 v4.0.6-0.20240818164233-b4d5d5df2b30
+	github.com/open-runtimes/types-for-go/v4 v4.0.6
 )
 
 require (

--- a/tests/resources/functions/go/latest/go.sum
+++ b/tests/resources/functions/go/latest/go.sum
@@ -14,6 +14,8 @@ github.com/open-runtimes/types-for-go/v4 v4.0.5 h1:Lw82fnOoaEmGgOoQmJhEOsYjs6Gin
 github.com/open-runtimes/types-for-go/v4 v4.0.5/go.mod h1:ab4mDSfgeG4kN8wWpaBSv0Ao3m9P6oEfN5gsXtx+iaI=
 github.com/open-runtimes/types-for-go/v4 v4.0.6-0.20240818164233-b4d5d5df2b30 h1:PuUh8RBMXuQXlk4Mn8/HnnlI+sutXh/K6ImhCfXVviI=
 github.com/open-runtimes/types-for-go/v4 v4.0.6-0.20240818164233-b4d5d5df2b30/go.mod h1:ab4mDSfgeG4kN8wWpaBSv0Ao3m9P6oEfN5gsXtx+iaI=
+github.com/open-runtimes/types-for-go/v4 v4.0.6 h1:0Xf58LMy/vwWkiRN6BvvpWt1mWzcWUWQ5wsWSezG2TU=
+github.com/open-runtimes/types-for-go/v4 v4.0.6/go.mod h1:ab4mDSfgeG4kN8wWpaBSv0Ao3m9P6oEfN5gsXtx+iaI=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=

--- a/tests/resources/functions/go/latest/go.sum
+++ b/tests/resources/functions/go/latest/go.sum
@@ -12,6 +12,8 @@ github.com/open-runtimes/types-for-go/v4 v4.0.4 h1:94zFTDNYtF8t7v2TlMqwAedyKftjS
 github.com/open-runtimes/types-for-go/v4 v4.0.4/go.mod h1:ab4mDSfgeG4kN8wWpaBSv0Ao3m9P6oEfN5gsXtx+iaI=
 github.com/open-runtimes/types-for-go/v4 v4.0.5 h1:Lw82fnOoaEmGgOoQmJhEOsYjs6Ginie4TdS2RYsvayk=
 github.com/open-runtimes/types-for-go/v4 v4.0.5/go.mod h1:ab4mDSfgeG4kN8wWpaBSv0Ao3m9P6oEfN5gsXtx+iaI=
+github.com/open-runtimes/types-for-go/v4 v4.0.6-0.20240818164233-b4d5d5df2b30 h1:PuUh8RBMXuQXlk4Mn8/HnnlI+sutXh/K6ImhCfXVviI=
+github.com/open-runtimes/types-for-go/v4 v4.0.6-0.20240818164233-b4d5d5df2b30/go.mod h1:ab4mDSfgeG4kN8wWpaBSv0Ao3m9P6oEfN5gsXtx+iaI=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=

--- a/tests/resources/functions/go/latest/tests.go
+++ b/tests/resources/functions/go/latest/tests.go
@@ -206,6 +206,11 @@ When you can have two!
 		return Context.Res.Send(hashHex, Context.Res.WithHeaders(map[string]string{
 			"x-method": Context.Req.Method,
 		}))
+	case "spreadOperatorLogs":
+		engine := "open-runtimes"
+		Context.Log("engine:", engine)
+		Context.Error("engine:", engine)
+		return Context.Res.Text("OK")
 	default:
 		Context.Error("Unknown action in tests.go")
 		return Context.Res.Text("", Context.Res.WithStatusCode(500))

--- a/tests/resources/functions/java/11.0/Tests.java
+++ b/tests/resources/functions/java/11.0/Tests.java
@@ -182,6 +182,11 @@ public class Tests {
                 return context.getRes().send(context.getReq().getBodyRaw());
             case "deprecatedMethodsUntypedBody":
                 return context.getRes().send("50"); // Send only supported String
+            case "spreadOperatorLogs":
+                String engine = "open-runtimes";
+                context.log("engine:", engine);
+                context.error("engine:", engine);
+                return context.getRes().text("OK");
             default:
                 throw new Exception("Unknown action");
         }

--- a/tests/resources/functions/java/8.0/Tests.java
+++ b/tests/resources/functions/java/8.0/Tests.java
@@ -182,6 +182,11 @@ public class Tests {
                 return context.getRes().send(context.getReq().getBodyRaw());
             case "deprecatedMethodsUntypedBody":
                 return context.getRes().send("50"); // Send only supported String
+            case "spreadOperatorLogs":
+                String engine = "open-runtimes";
+                context.log("engine:", engine);
+                context.error("engine:", engine);
+                return context.getRes().text("OK");
             default:
                 throw new Exception("Unknown action");
         }

--- a/tests/resources/functions/java/latest/Tests.java
+++ b/tests/resources/functions/java/latest/Tests.java
@@ -215,6 +215,12 @@ public class Tests {
             case "deprecatedMethodsUntypedBody" -> {
                 return context.getRes().send("50"); // Send only supported String
             }
+            case "spreadOperatorLogs" -> {
+                String engine = "open-runtimes";
+                context.log("engine:", engine);
+                context.error("engine:", engine);
+                return context.getRes().text("OK");
+            }
             default -> throw new Exception("Unknown action");
         }
     }

--- a/tests/resources/functions/kotlin/latest/Tests.kt
+++ b/tests/resources/functions/kotlin/latest/Tests.kt
@@ -243,6 +243,12 @@ When you can have two!
             "deprecatedMethodsUntypedBody" -> {
                 return context.res.send("50"); // Send only supported String
             }
+            "spreadOperatorLogs" -> {
+                var engine = "open-runtimes";
+                context.log("engine:", engine);
+                context.error("engine:", engine);
+                return context.res.text("OK");
+            }
             else -> {
                 throw Exception("Unknown action")
             }

--- a/tests/resources/functions/node/latest/tests.js
+++ b/tests/resources/functions/node/latest/tests.js
@@ -133,6 +133,10 @@ When you can have two!
             return context.res.send(image, 200, {
                 'content-type': 'image/png'
             });
+        case 'spreadOperatorLogs':
+            const engine = 'open-runtimes';
+            context.log("engine:", engine);
+            return context.res.text('OK');
         default:
             throw new Error('Unknown action');
     }

--- a/tests/resources/functions/node/latest/tests.js
+++ b/tests/resources/functions/node/latest/tests.js
@@ -136,6 +136,7 @@ When you can have two!
         case 'spreadOperatorLogs':
             const engine = 'open-runtimes';
             context.log("engine:", engine);
+            context.error("engine:", engine);
             return context.res.text('OK');
         default:
             throw new Error('Unknown action');

--- a/tests/resources/functions/node/latest/tests.mjs
+++ b/tests/resources/functions/node/latest/tests.mjs
@@ -133,6 +133,10 @@ When you can have two!
             return context.res.send(image, 200, {
                 'content-type': 'image/png'
             });
+        case 'spreadOperatorLogs':
+            const engine = 'open-runtimes';
+            context.log("engine:", engine);
+            return context.res.text('OK');
         default:
             throw new Error('Unknown action');
     }

--- a/tests/resources/functions/node/latest/tests.mjs
+++ b/tests/resources/functions/node/latest/tests.mjs
@@ -136,6 +136,7 @@ When you can have two!
         case 'spreadOperatorLogs':
             const engine = 'open-runtimes';
             context.log("engine:", engine);
+            context.error("engine:", engine);
             return context.res.text('OK');
         default:
             throw new Error('Unknown action');

--- a/tests/resources/functions/php/latest/tests.php
+++ b/tests/resources/functions/php/latest/tests.php
@@ -145,6 +145,11 @@ When you can have two!
             return $context->res->send($image, 200, [
                 'content-type' => 'image/png'
             ]);
+        case 'spreadOperatorLogs':
+            $engine = 'open-runtimes';
+            $context->log("engine:", $engine);
+            $context->error("engine:", $engine);
+            return $context->res->text('OK');
         default:
             throw new Exception('Unknown action');
     }

--- a/tests/resources/functions/python/latest/tests.py
+++ b/tests/resources/functions/python/latest/tests.py
@@ -132,5 +132,10 @@ When you can have two!
         return context.res.send(image, 200, {
             'content-type': 'image/png'
         })
+    elif action == 'spreadOperatorLogs':
+        engine = 'open-runtimes'
+        context.log("engine:", engine)
+        context.error("engine:", engine)
+        return context.res.text('OK')
     else:
         raise Exception('Unknown action')

--- a/tests/resources/functions/python/ml-3.11/tests.py
+++ b/tests/resources/functions/python/ml-3.11/tests.py
@@ -134,5 +134,10 @@ When you can have two!
         return context.res.send(image, 200, {
             'content-type': 'image/png'
         })
+    elif action == 'spreadOperatorLogs':
+        engine = 'open-runtimes'
+        context.log("engine:", engine)
+        context.error("engine:", engine)
+        return context.res.text('OK')
     else:
         raise Exception('Unknown action')

--- a/tests/resources/functions/ruby/latest/tests.rb
+++ b/tests/resources/functions/ruby/latest/tests.rb
@@ -133,6 +133,11 @@ When you can have two!
         return context.res.send(image, 200, {
             'content-type': 'image/png'
         });
+    when 'spreadOperatorLogs'
+        engine = 'open-runtimes'
+        context.log("engine:", engine)
+        context.error("engine:", engine)
+        return context.res.text('OK')
     else
         raise 'Unknown action'
     end


### PR DESCRIPTION
Allows multiple params in log and write methods.

Runtimes:

- [x] Bun
- [x] CPP (Doesnt seem supported by language)
- [x] Dart (Doesnt seem supported by language)
- [x] Deno
- [x] Dotnet (Not supported by language)
- [x] Go
- [x] Java
- [x] Kotlin
- [x] Node
- [x] PHP
- [x] Python
- [x] Ruby
- [x] Swift (Not supported by language)