### PR TITLE
Fix: context.req.bodyText

### DIFF
--- a/runtimes/php/versions/latest/src/types.php
+++ b/runtimes/php/versions/latest/src/types.php
@@ -59,6 +59,7 @@ class RuntimeRequest
             'body' => $this->getBody(),
             'bodyRaw' => $this->getRawBody(),
             'bodyJson' => $this->getBodyJson(),
+            'bodyText' => $this->getBodyText(),
             default => ''
         };
     }

--- a/tests/resources/functions/bun/latest/tests.ts
+++ b/tests/resources/functions/bun/latest/tests.ts
@@ -95,7 +95,7 @@ When you can have two!
 			const buffer = Buffer.from(context.req.bodyBinary);
 			const md5 = new Bun.CryptoHasher("md5");
 			const hash = md5.update(buffer).digest("hex");
-			return context.res.send(hash, 200, {
+			return context.res.text(hash, 200, {
 				"x-method": context.req.method,
 			});
 		case "envVars":

--- a/tests/resources/functions/cpp/latest/tests.cc
+++ b/tests/resources/functions/cpp/latest/tests.cc
@@ -162,7 +162,7 @@ namespace runtime {
                 auto bytes = req.bodyBinary;
                 auto hex = Handler::md5HexDigest(bytes);
                 headers["x-method"] = req.method;
-                return context.res.send(hex, 200, headers);
+                return context.res.text(hex, 200, headers);
             } else if (action == "envVars") {
                 auto customEnvVar = std::getenv("CUSTOM_ENV_VAR");
                 auto notDefinedVar = std::getenv("NOT_DEFINED_VAR");

--- a/tests/resources/functions/dart/latest/lib/tests.dart
+++ b/tests/resources/functions/dart/latest/lib/tests.dart
@@ -154,7 +154,7 @@ When you can have two!
         final bytes = Uint8List.fromList(context.req.bodyBinary);
         final hash = md5.convert(bytes);
         return context.res
-            .send(hash.toString(), 200, {'x-method': context.req.method});
+            .text(hash.toString(), 200, {'x-method': context.req.method});
       }
     case 'envVars':
       {

--- a/tests/resources/functions/deno/latest/tests.ts
+++ b/tests/resources/functions/deno/latest/tests.ts
@@ -97,7 +97,7 @@ When you can have two!
       const buffer = Uint8Array.from(context.req.bodyBinary);
       const md5 = new Md5();
       const hash = md5.update(buffer).toString("hex");
-      return context.res.send(hash, 200, {
+      return context.res.text(hash, 200, {
         "x-method": context.req.method,
       });
     case "envVars":

--- a/tests/resources/functions/dotnet/6.0/Tests.cs
+++ b/tests/resources/functions/dotnet/6.0/Tests.cs
@@ -173,7 +173,7 @@ When you can have two!
                     hash = md5.Hash;
                 }
                 string hex = BitConverter.ToString(hash).Replace("-", "").ToLower();
-                return context.Res.Send(hex, 200, new() { { "x-method", context.Req.Method } });
+                return context.Res.Text(hex, 200, new() { { "x-method", context.Req.Method } });
             case "envVars":
                 return context.Res.Json(
                     new()

--- a/tests/resources/functions/dotnet/6.0/Tests.cs
+++ b/tests/resources/functions/dotnet/6.0/Tests.cs
@@ -102,7 +102,7 @@ When you can have two!
 
                 return context.Res.Json(json);
             case "requestBodyText":
-                return context.Res.Text((string) context.Req.Body);
+                return context.Res.Text(context.Req.BodyText);
             case "requestBodyJson":
                 return context.Res.Json(context.Req.BodyJson);
             case "requestBodyBinary":

--- a/tests/resources/functions/dotnet/7.0/Tests.cs
+++ b/tests/resources/functions/dotnet/7.0/Tests.cs
@@ -182,7 +182,7 @@ When you can have two!
                         hash = md5.Hash;
                     }
                     string hex = BitConverter.ToString(hash).Replace("-", "").ToLower();
-                    return context.Res.Send(hex, 200, new() { { "x-method", context.Req.Method } });
+                    return context.Res.Text(hex, 200, new() { { "x-method", context.Req.Method } });
                 case "envVars":
                     return context.Res.Json(
                         new Dictionary<string, object?>()

--- a/tests/resources/functions/dotnet/7.0/Tests.cs
+++ b/tests/resources/functions/dotnet/7.0/Tests.cs
@@ -103,7 +103,7 @@ When you can have two!
 
                     return context.Res.Json(json);
                 case "requestBodyText":
-                    return context.Res.Text((string) context.Req.Body);
+                    return context.Res.Text(context.Req.BodyText);
                 case "requestBodyJson":
                     return context.Res.Json(context.Req.BodyJson);
                 case "requestBodyBinary":

--- a/tests/resources/functions/dotnet/8.0/Tests.cs
+++ b/tests/resources/functions/dotnet/8.0/Tests.cs
@@ -99,7 +99,7 @@ When you can have two!
 
                     return context.Res.Json(json);
                 case "requestBodyText":
-                    return context.Res.Text((string) context.Req.Body);
+                    return context.Res.Text(context.Req.BodyText);
                 case "requestBodyJson":
                     return context.Res.Json(context.Req.BodyJson);
                 case "requestBodyBinary":

--- a/tests/resources/functions/dotnet/8.0/Tests.cs
+++ b/tests/resources/functions/dotnet/8.0/Tests.cs
@@ -178,7 +178,7 @@ When you can have two!
                         hash = md5.Hash;
                     }
                     string hex = BitConverter.ToString(hash).Replace("-", "").ToLower();
-                    return context.Res.Send(hex, 200, new() { { "x-method", context.Req.Method } });
+                    return context.Res.Text(hex, 200, new() { { "x-method", context.Req.Method } });
                 case "envVars":
                     return context.Res.Json(
                         new Dictionary<string, object?>()

--- a/tests/resources/functions/go/latest/tests.go
+++ b/tests/resources/functions/go/latest/tests.go
@@ -201,7 +201,7 @@ When you can have two!
 	case "binaryResponseLarge":
 		hashBinary := md5.Sum(Context.Req.BodyBinary())
 		hashHex := hex.EncodeToString(hashBinary[:])
-		return Context.Res.Send(hashHex, Context.Res.WithHeaders(map[string]string{
+		return Context.Res.Text(hashHex, Context.Res.WithHeaders(map[string]string{
 			"x-method": Context.Req.Method,
 		}))
 	case "spreadOperatorLogs":

--- a/tests/resources/functions/go/latest/tests.go
+++ b/tests/resources/functions/go/latest/tests.go
@@ -111,7 +111,7 @@ When you can have two!
 	case "requestBodyBinary":
 		return Context.Res.Binary(Context.Req.BodyBinary())
 	case "requestBodyTextAuto":
-		return Context.Res.Text(Context.Req.Body().(string))
+		return Context.Res.Text(Context.Req.BodyText())
 	case "requestBodyJsonAuto":
 		return Context.Res.Json(Context.Req.Body().(map[string]interface{}))
 	case "binaryResponse1":

--- a/tests/resources/functions/java/11.0/Tests.java
+++ b/tests/resources/functions/java/11.0/Tests.java
@@ -91,7 +91,7 @@ public class Tests {
                 }
                 return context.getRes().json(json);
             case "requestBodyText":
-                return context.getRes().text((String) context.getReq().getBody());
+                return context.getRes().text((String) context.getReq().getBodyText());
             case "requestBodyJson":
                 return context.getRes().json(context.getReq().getBodyJson());
             case "requestBodyBinary":

--- a/tests/resources/functions/java/11.0/Tests.java
+++ b/tests/resources/functions/java/11.0/Tests.java
@@ -140,7 +140,7 @@ public class Tests {
         byte[] digestBytes = md5Digest.digest();
         String hex = bytesToHex(digestBytes).toLowerCase(Locale.ROOT);
         headers.put("x-method", context.getReq().getMethod());
-        return context.getRes().send(hex, 200, headers);
+        return context.getRes().text(hex, 200, headers);
       case "envVars":
         json.put("var", System.getenv().getOrDefault("CUSTOM_ENV_VAR", null));
         json.put("emptyVar", System.getenv().getOrDefault("NOT_DEFINED_VAR", null));

--- a/tests/resources/functions/java/8.0/Tests.java
+++ b/tests/resources/functions/java/8.0/Tests.java
@@ -91,7 +91,7 @@ public class Tests {
                 }
                 return context.getRes().json(json);
             case "requestBodyText":
-                return context.getRes().text((String) context.getReq().getBody());
+                return context.getRes().text((String) context.getReq().getBodyText());
             case "requestBodyJson":
                 return context.getRes().json(context.getReq().getBodyJson());
             case "requestBodyBinary":

--- a/tests/resources/functions/java/8.0/Tests.java
+++ b/tests/resources/functions/java/8.0/Tests.java
@@ -140,7 +140,7 @@ public class Tests {
         byte[] digestBytes = md5Digest.digest();
         String hex = bytesToHex(digestBytes).toLowerCase(Locale.ROOT);
         headers.put("x-method", context.getReq().getMethod());
-        return context.getRes().send(hex, 200, headers);
+        return context.getRes().text(hex, 200, headers);
       case "envVars":
         json.put("var", System.getenv().getOrDefault("CUSTOM_ENV_VAR", null));
         json.put("emptyVar", System.getenv().getOrDefault("NOT_DEFINED_VAR", null));

--- a/tests/resources/functions/java/latest/Tests.java
+++ b/tests/resources/functions/java/latest/Tests.java
@@ -106,7 +106,7 @@ public class Tests {
                 return context.getRes().json(json);
             }
             case "requestBodyText" -> {
-                return context.getRes().text((String) context.getReq().getBody());
+                return context.getRes().text((String) context.getReq().getBodyText());
             }
             case "requestBodyJson" -> {
                 return context.getRes().json(context.getReq().getBodyJson());

--- a/tests/resources/functions/java/latest/Tests.java
+++ b/tests/resources/functions/java/latest/Tests.java
@@ -165,7 +165,7 @@ public class Tests {
         byte[] digestBytes = md5Digest.digest();
         String hex = bytesToHex(digestBytes).toLowerCase();
         headers.put("x-method", context.getReq().getMethod());
-        return context.getRes().send(hex, 200, headers);
+        return context.getRes().text(hex, 200, headers);
       }
       case "envVars" -> {
         json.put("var", System.getenv().getOrDefault("CUSTOM_ENV_VAR", null));

--- a/tests/resources/functions/kotlin/latest/Tests.kt
+++ b/tests/resources/functions/kotlin/latest/Tests.kt
@@ -121,7 +121,7 @@ When you can have two!
                 return context.res.json(context.req.headers as MutableMap<String, Any>)
             }
             "requestBodyText" -> {
-                return context.res.text(context.req.body as String)
+                return context.res.text(context.req.bodyText)
             }
             "requestBodyJson" -> {
                 return context.res.json(context.req.bodyJson)
@@ -190,7 +190,7 @@ When you can have two!
                 md5Digest!!.update(bytes)
                 val digestBytes: ByteArray = md5Digest!!.digest()
                 val hex: String = bytesToHex(digestBytes).lowercase()
-                return context.res.send(
+                return context.res.text(
                     hex,
                     200,
                     mapOf(

--- a/tests/resources/functions/node/latest/tests.js
+++ b/tests/resources/functions/node/latest/tests.js
@@ -95,7 +95,7 @@ When you can have two!
 		case "binaryResponseLarge":
 			const buffer = Buffer.from(context.req.bodyBinary);
 			const hash = crypto.createHash("md5").update(buffer).digest("hex");
-			return context.res.send(hash, 200, {
+			return context.res.text(hash, 200, {
 				"x-method": context.req.method,
 			});
 		case "envVars":

--- a/tests/resources/functions/node/latest/tests.mjs
+++ b/tests/resources/functions/node/latest/tests.mjs
@@ -95,7 +95,7 @@ When you can have two!
 		case "binaryResponseLarge":
 			const buffer = Buffer.from(context.req.bodyBinary);
 			const hash = crypto.createHash("md5").update(buffer).digest("hex");
-			return context.res.send(hash, 200, {
+			return context.res.text(hash, 200, {
 				"x-method": context.req.method,
 			});
 		case "envVars":

--- a/tests/resources/functions/php/latest/tests.php
+++ b/tests/resources/functions/php/latest/tests.php
@@ -71,7 +71,7 @@ When you can have two!
         case 'requestHeaders':
             return $context->res->json($context->req->headers);
         case 'requestBodyText':
-            return $context->res->text($context->req->body);
+            return $context->res->text($context->req->bodyText);
         case 'requestBodyJson':
             return $context->res->json($context->req->bodyJson);
         case 'requestBodyBinary':

--- a/tests/resources/functions/php/latest/tests.php
+++ b/tests/resources/functions/php/latest/tests.php
@@ -105,7 +105,7 @@ When you can have two!
         case 'binaryResponseLarge':
             $hash = md5($context->req->bodyBinary);
 
-            return $context->res->send($hash, 200, [
+            return $context->res->text($hash, 200, [
                 'x-method' => $context->req->method,
             ]);
         case 'envVars':

--- a/tests/resources/functions/python/latest/tests.py
+++ b/tests/resources/functions/python/latest/tests.py
@@ -103,7 +103,7 @@ When you can have two!
     elif action == "binaryResponseLarge":
         bytes_body = context.req.body_binary
         hex = md5(bytes_body).hexdigest()
-        return context.res.send(hex, 200, {"x-method": context.req.method})
+        return context.res.text(hex, 200, {"x-method": context.req.method})
     elif action == "envVars":
         return context.res.json(
             {

--- a/tests/resources/functions/python/ml-3.11/tests.py
+++ b/tests/resources/functions/python/ml-3.11/tests.py
@@ -105,7 +105,7 @@ When you can have two!
     elif action == "binaryResponseLarge":
         bytes_body = context.req.body_binary
         hex = md5(bytes_body).hexdigest()
-        return context.res.send(hex, 200, {"x-method": context.req.method})
+        return context.res.text(hex, 200, {"x-method": context.req.method})
     elif action == "envVars":
         return context.res.json(
             {

--- a/tests/resources/functions/ruby/latest/tests.rb
+++ b/tests/resources/functions/ruby/latest/tests.rb
@@ -89,7 +89,7 @@ When you can have two!
     when 'binaryResponseLarge'
         bytes_body = context.req.body_binary
         hex = Digest::MD5.hexdigest bytes_body
-        return context.res.send(hex, 200, {
+        return context.res.text(hex, 200, {
             'x-method': context.req.method
         })
     when 'envVars'

--- a/tests/resources/functions/swift/latest/Sources/Tests.swift
+++ b/tests/resources/functions/swift/latest/Sources/Tests.swift
@@ -121,7 +121,7 @@ func main(context: RuntimeContext) async throws -> RuntimeOutput {
     case "binaryResponseLarge":
         let bytes = context.req.bodyBinary
         let hex = Insecure.MD5.hash(data: bytes).map { String(format: "%02hhx", $0) }.joined()
-        return context.res.send(hex, statusCode: 200, headers: [
+        return context.res.text(hex, statusCode: 200, headers: [
             "x-method": context.req.method,
         ])
     case "envVars":


### PR DESCRIPTION
In PHP bodyText was not working at all. Test was not checking it.

Tests were missing in many other runtimes too.


Also fixed deprecated uses of `send` instead of `text` in tests. Send still tested, but only in deprecated tests