### PR TITLE
Fix: Version consistency

### DIFF
--- a/runtimes/deno/versions/1.40/Dockerfile
+++ b/runtimes/deno/versions/1.40/Dockerfile
@@ -1,5 +1,5 @@
 # syntax = devthefuture/dockerfile-x:1.4.2
-FROM denoland/deno:alpine-1.41.3
+FROM denoland/deno:alpine-1.40.5
 
 INCLUDE ./base-before
 INCLUDE ./deno

--- a/runtimes/go/versions/1.23/Dockerfile
+++ b/runtimes/go/versions/1.23/Dockerfile
@@ -1,5 +1,5 @@
 # syntax = devthefuture/dockerfile-x:1.4.2
-FROM golang:1.23-alpine
+FROM golang:1.23.1-alpine3.20
 
 INCLUDE ./base-before
 INCLUDE ./go

--- a/runtimes/node/versions/14.5/Dockerfile
+++ b/runtimes/node/versions/14.5/Dockerfile
@@ -1,5 +1,5 @@
 # syntax = devthefuture/dockerfile-x:1.4.2
-FROM node:14.5-alpine3.12
+FROM node:14.5.0-alpine3.12
 
 INCLUDE ./base-before
 INCLUDE ./node

--- a/runtimes/node/versions/19.0/Dockerfile
+++ b/runtimes/node/versions/19.0/Dockerfile
@@ -1,5 +1,5 @@
 # syntax = devthefuture/dockerfile-x:1.4.2
-FROM node:19.9-alpine3.18
+FROM node:19.9.0-alpine3.18
 
 INCLUDE ./base-before
 INCLUDE ./node

--- a/runtimes/php/versions/8.0/Dockerfile
+++ b/runtimes/php/versions/8.0/Dockerfile
@@ -1,11 +1,11 @@
 # syntax = devthefuture/dockerfile-x:1.4.2
 
-FROM php:8.0-cli-alpine3.16 as step0
+FROM php:8.0.30-cli-alpine3.16 as step0
 ARG PHP_SWOOLE_VERSION=v4.7.0
 ENV PHP_SWOOLE_VERSION=$PHP_SWOOLE_VERSION
 INCLUDE ./build
 
-FROM php:8.0-cli-alpine3.16 as final
+FROM php:8.0.30-cli-alpine3.16 as final
 INCLUDE ./base-before
 INCLUDE ./php
 COPY --from=step0 /usr/local/lib/php/extensions/no-debug-non-zts-20200930/swoole.so /usr/local/lib/php/extensions/no-debug-non-zts-20200930/yasd.so* /usr/local/lib/php/extensions/no-debug-non-zts-20200930/

--- a/runtimes/php/versions/8.1/Dockerfile
+++ b/runtimes/php/versions/8.1/Dockerfile
@@ -1,11 +1,11 @@
 # syntax = devthefuture/dockerfile-x:1.4.2
 
-FROM php:8.1-cli-alpine3.20 as step0
+FROM php:8.1.30-cli-alpine3.20 as step0
 ARG PHP_SWOOLE_VERSION=v5.1.2
 ENV PHP_SWOOLE_VERSION=$PHP_SWOOLE_VERSION
 INCLUDE ./build
 
-FROM php:8.1-cli-alpine3.19 as final
+FROM php:8.1.30-cli-alpine3.20 as final
 INCLUDE ./base-before
 INCLUDE ./php
 COPY --from=step0 /usr/local/lib/php/extensions/no-debug-non-zts-20210902/swoole.so /usr/local/lib/php/extensions/no-debug-non-zts-20210902/yasd.so* /usr/local/lib/php/extensions/no-debug-non-zts-20210902/

--- a/runtimes/php/versions/8.2/Dockerfile
+++ b/runtimes/php/versions/8.2/Dockerfile
@@ -1,12 +1,12 @@
 # syntax = devthefuture/dockerfile-x:1.4.2
 
-FROM php:8.2-cli-alpine3.20 as step0
+FROM php:8.2.24-cli-alpine3.20 as step0
 RUN apk update && apk add --no-cache linux-headers
 ARG PHP_SWOOLE_VERSION=v5.1.2
 ENV PHP_SWOOLE_VERSION=$PHP_SWOOLE_VERSION
 INCLUDE ./build
 
-FROM php:8.2-cli-alpine3.19 as final
+FROM php:8.2.24-cli-alpine3.20 as final
 INCLUDE ./base-before
 INCLUDE ./php
 COPY --from=step0 /usr/local/lib/php/extensions/no-debug-non-zts-20220829/swoole.so /usr/local/lib/php/extensions/no-debug-non-zts-20220829/yasd.so* /usr/local/lib/php/extensions/no-debug-non-zts-20220829/

--- a/runtimes/php/versions/8.3/Dockerfile
+++ b/runtimes/php/versions/8.3/Dockerfile
@@ -1,12 +1,12 @@
 # syntax = devthefuture/dockerfile-x:1.4.2
 
-FROM php:8.3-cli-alpine3.20 as step0
+FROM php:8.3.12-cli-alpine3.20 as step0
 RUN apk update && apk add --no-cache linux-headers
 ARG PHP_SWOOLE_VERSION=v5.1.2
 ENV PHP_SWOOLE_VERSION=$PHP_SWOOLE_VERSION
 INCLUDE ./build
 
-FROM php:8.3-cli-alpine3.20 as final
+FROM php:8.3.12-cli-alpine3.20 as final
 INCLUDE ./base-before
 INCLUDE ./php
 COPY --from=step0 /usr/local/lib/php/extensions/no-debug-non-zts-20230831/swoole.so /usr/local/lib/php/extensions/no-debug-non-zts-20230831/yasd.so* /usr/local/lib/php/extensions/no-debug-non-zts-20230831/

--- a/runtimes/python/versions/3.10/Dockerfile
+++ b/runtimes/python/versions/3.10/Dockerfile
@@ -1,5 +1,5 @@
 # syntax = devthefuture/dockerfile-x:1.4.2
-FROM python:3.10-alpine3.20
+FROM python:3.10.15-alpine3.20
 
 INCLUDE ./base-before
 INCLUDE ./python

--- a/runtimes/python/versions/3.11/Dockerfile
+++ b/runtimes/python/versions/3.11/Dockerfile
@@ -1,5 +1,5 @@
 # syntax = devthefuture/dockerfile-x:1.4.2
-FROM python:3.11-alpine3.20
+FROM python:3.11.10-alpine3.20
 
 INCLUDE ./base-before
 INCLUDE ./python

--- a/runtimes/python/versions/3.12/Dockerfile
+++ b/runtimes/python/versions/3.12/Dockerfile
@@ -1,5 +1,5 @@
 # syntax = devthefuture/dockerfile-x:1.4.2
-FROM python:3.12-alpine3.20
+FROM python:3.12.6-alpine3.20
 
 INCLUDE ./base-before
 INCLUDE ./python

--- a/runtimes/python/versions/3.8/Dockerfile
+++ b/runtimes/python/versions/3.8/Dockerfile
@@ -1,5 +1,5 @@
 # syntax = devthefuture/dockerfile-x:1.4.2
-FROM python:3.8-alpine3.20
+FROM python:3.8.20-alpine3.20
 
 INCLUDE ./base-before
 INCLUDE ./python

--- a/runtimes/python/versions/3.9/Dockerfile
+++ b/runtimes/python/versions/3.9/Dockerfile
@@ -1,5 +1,5 @@
 # syntax = devthefuture/dockerfile-x:1.4.2
-FROM python:3.9-alpine3.20
+FROM python:3.9.20-alpine3.20
 
 INCLUDE ./base-before
 INCLUDE ./python

--- a/runtimes/python/versions/ml-3.11/Dockerfile
+++ b/runtimes/python/versions/ml-3.11/Dockerfile
@@ -1,5 +1,5 @@
 # syntax = devthefuture/dockerfile-x:1.4.2
-FROM python:3.11-bookworm
+FROM python:3.11.10-bookworm
 
 RUN apt-get update && apt-get install -y gcc pkg-config libhdf5-dev
 

--- a/runtimes/ruby/versions/3.0/Dockerfile
+++ b/runtimes/ruby/versions/3.0/Dockerfile
@@ -1,5 +1,5 @@
 # syntax = devthefuture/dockerfile-x:1.4.2
-FROM ruby:3.0-alpine3.16
+FROM ruby:3.0.7-alpine3.16
 ENV OPEN_RUNTIMES_ENTRYPOINT=index.rb
 
 INCLUDE ./base-before

--- a/runtimes/ruby/versions/3.1/Dockerfile
+++ b/runtimes/ruby/versions/3.1/Dockerfile
@@ -1,5 +1,5 @@
 # syntax = devthefuture/dockerfile-x:1.4.2
-FROM ruby:3.1-alpine3.20
+FROM ruby:3.1.6-alpine3.20
 ENV OPEN_RUNTIMES_ENTRYPOINT=index.rb
 
 INCLUDE ./base-before

--- a/runtimes/ruby/versions/3.2/Dockerfile
+++ b/runtimes/ruby/versions/3.2/Dockerfile
@@ -1,5 +1,5 @@
 # syntax = devthefuture/dockerfile-x:1.4.2
-FROM ruby:3.2-alpine3.20
+FROM ruby:3.2.5-alpine3.20
 ENV OPEN_RUNTIMES_ENTRYPOINT=index.rb
 
 INCLUDE ./base-before

--- a/runtimes/ruby/versions/3.3/Dockerfile
+++ b/runtimes/ruby/versions/3.3/Dockerfile
@@ -1,5 +1,5 @@
 # syntax = devthefuture/dockerfile-x:1.4.2
-FROM ruby:3.3-alpine3.20
+FROM ruby:3.3.5-alpine3.20
 ENV OPEN_RUNTIMES_ENTRYPOINT=index.rb
 
 INCLUDE ./base-before


### PR DESCRIPTION
- Deno used 1.41 instead of 1.40, fixed
- Lock Go, PHP, Python, Ruby, Node to specific patch versions