### PR TITLE
Fix: Deno release cpu archs

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -55,17 +55,17 @@ jobs:
             RUNTIME: deno
             VERSION: "2.0"
             IMAGE: openruntimes/deno:v4-2.0
-            ARCH: "linux/amd64"
+            ARCH: "linux/amd64,linux/arm64"
           - ID: deno-1.46
             RUNTIME: deno
             VERSION: "1.46"
             IMAGE: openruntimes/deno:v4-1.46
-            ARCH: "linux/amd64"
+            ARCH: "linux/amd64,linux/arm64"
           - ID: deno-1.40
             RUNTIME: deno
             VERSION: "1.40"
             IMAGE: openruntimes/deno:v4-1.40
-            ARCH: "linux/amd64"
+            ARCH: "linux/amd64,linux/arm64"
           - ID: deno-1.35
             RUNTIME: deno
             VERSION: "1.35"


### PR DESCRIPTION
Add newly supported archs (1.35 doesnt support it).

This adds support for MacOS (Appwrite CLI)

Proof 1.35 doesn't have it:

![CleanShot 2024-10-09 at 20 01 25@2x](https://github.com/user-attachments/assets/cc8ce600-3113-42ec-a8e2-8119f07feaf2)

Proof 1.40 has it:


![CleanShot 2024-10-09 at 20 01 46@2x](https://github.com/user-attachments/assets/0fc69775-bcd9-4c90-af1d-1d2f6fbaafdc)

I also checked each 3 versions
