### PR TITLE
chore: update python deployment target architectures

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -87,27 +87,27 @@ jobs:
             RUNTIME: python
             VERSION: "3.12"
             IMAGE: openruntimes/python:v4-3.12
-            ARCH: "linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64"
+            ARCH: "linux/amd64,linux/arm64"
           - ID: python-3.11
             RUNTIME: python
             VERSION: "3.11"
             IMAGE: openruntimes/python:v4-3.11
-            ARCH: "linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64"
+            ARCH: "linux/amd64,linux/arm64"
           - ID: python-3.10
             RUNTIME: python
             VERSION: "3.10"
             IMAGE: openruntimes/python:v4-3.10
-            ARCH: "linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64"
+            ARCH: "linux/amd64,linux/arm64"
           - ID: python-3.9
             RUNTIME: python
             VERSION: "3.9"
             IMAGE: openruntimes/python:v4-3.9
-            ARCH: "linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64"
+            ARCH: "linux/amd64,linux/arm64"
           - ID: python-3.8
             RUNTIME: python
             VERSION: "3.8"
             IMAGE: openruntimes/python:v4-3.8
-            ARCH: "linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64"
+            ARCH: "linux/amd64,linux/arm64"
 
           # Python ML
           - ID: python-ml-3.11


### PR DESCRIPTION
With the addition of gunicorn and aiohttp, we are no longer able to install them on arm/v6 and arm/v6 platforms since gcc is not readily available and needs to be compiled from source for those platforms. 