### PR TITLE
chore: disable gunicorn timeout

### DIFF
--- a/runtimes/python/versions/latest/helpers/server.sh
+++ b/runtimes/python/versions/latest/helpers/server.sh
@@ -18,4 +18,5 @@ python3 /usr/local/server/src/function/runtime-env/bin/gunicorn \
   --chdir "$(pwd)/src" \
   --worker-class aiohttp.GunicornWebWorker \
   --preload \
+  --timeout 0 \
   'server:app'


### PR DESCRIPTION
While investigating https://github.com/appwrite/appwrite/issues/8907, we noticed logs like:

```
Preparing for start ...
Starting ...
HTTP server successfully started!
[2024-11-05 09:25:59 +0000] [16] [CRITICAL] WORKER TIMEOUT (pid:17)
[2024-11-05 09:26:00 +0000] [16] [ERROR] Worker (pid:17) was sent SIGKILL! Perhaps out of memory?
```

So, the worker probably timed out since the default [timeout](https://docs.gunicorn.org/en/stable/settings.html#timeout) is 30 seconds and then there was no reply sent back to Appwrite.

This PR changes the timeout in gunicorn to prevent the workers from being killed and Appwrite will handle the timeout.
