### PR TITLE
fix: 52 timeouts

### DIFF
--- a/runtimes/bun/versions/latest/src/server.ts
+++ b/runtimes/bun/versions/latest/src/server.ts
@@ -247,6 +247,7 @@ const action = async (logger: Logger, request: any) => {
 Bun.serve({
   port: 3000,
   maxRequestBodySize: 20 * 1024 * 1024,
+  idleTimeout: 0,
   async fetch(request) {
     const logger = new Logger(
       request.headers.get("x-open-runtimes-logging"),

--- a/runtimes/node/versions/latest/src/server.js
+++ b/runtimes/node/versions/latest/src/server.js
@@ -11,7 +11,7 @@ const server = micro(async (req, res) => {
   );
 
   try {
-    await action(logger, req, res);
+    return await action(logger, req, res);
   } catch (e) {
     logger.write([e], Logger.TYPE_ERROR);
 
@@ -273,7 +273,7 @@ const action = async (logger, req, res) => {
   res.setHeader("x-open-runtimes-log-id", logger.id);
   await logger.end();
 
-  return send(res, output.statusCode, output.body);
+  return output;
 };
 
 server.listen(3000, undefined, undefined, () => {

--- a/runtimes/node/versions/latest/src/server.js
+++ b/runtimes/node/versions/latest/src/server.js
@@ -11,7 +11,7 @@ const server = micro(async (req, res) => {
   );
 
   try {
-    return await action(logger, req, res);
+    await action(logger, req, res);
   } catch (e) {
     logger.write([e], Logger.TYPE_ERROR);
 
@@ -273,7 +273,7 @@ const action = async (logger, req, res) => {
   res.setHeader("x-open-runtimes-log-id", logger.id);
   await logger.end();
 
-  return output;
+  return send(res, output.statusCode, output.body);
 };
 
 server.listen(3000, undefined, undefined, () => {


### PR DESCRIPTION
Sets idleTimeout setting in Bun: https://bun.sh/docs/api/http#idletimeout

This may be causing worker threads to exit, and throw curl error 52 on the client.

Related:
* https://github.com/appwrite/appwrite/issues/8907