### PR TITLE
Fix: cicd task for release

### DIFF
--- a/ci_release.sh
+++ b/ci_release.sh
@@ -1,4 +1,8 @@
 set -e
 
+export RUNTIME_FOLDER=$(echo $RUNTIME | sed 's/\(.*\)-.*/\1/') # Get first part separated by -
+export VERSION_FOLDER="$RUNTIME-$VERSION"
+export VERSION_FOLDER="${VERSION_FOLDER#*-}" # Remove runtime folder name
+
 sh ci-cleanup.sh
 sh ci-runtime-prepare.sh


### PR DESCRIPTION

Release is broken: https://github.com/open-runtimes/open-runtimes/actions/runs/12014222549
I took code from test logic: https://github.com/open-runtimes/open-runtimes/blob/3dafc49e9863a4b09c2cc2bd27f44b7389036fae/ci_tests.sh#L4-L6