### PR TITLE
Fix: Angular tests

### DIFF
--- a/tests/SSR/Angular.php
+++ b/tests/SSR/Angular.php
@@ -11,11 +11,4 @@ error_reporting(E_ALL);
 
 class Angular extends SSR
 {
-    // TODO: Remove override when we find way to disable Angular SSR cache for /date path
-    public function testServerAction(): void
-    {
-        $response = Client::execute(url: '/date', method: 'GET');
-        self::assertEquals(200, $response['code']);
-        self::assertNotEmpty($response['body']);
-    }
 }

--- a/tests/resources/functions/angular/src/app/app.routes.server.ts
+++ b/tests/resources/functions/angular/src/app/app.routes.server.ts
@@ -3,6 +3,6 @@ import { RenderMode, ServerRoute } from '@angular/ssr';
 export const serverRoutes: ServerRoute[] = [
   {
     path: '**',
-    renderMode: RenderMode.Prerender
+    renderMode: RenderMode.Server
   }
 ];


### PR DESCRIPTION
Remove Angular test override due to pre-rendering cache issues