### PR TITLE
Feat: Compression algos support

### DIFF
--- a/ci_tests.sh
+++ b/ci_tests.sh
@@ -49,11 +49,11 @@ docker run --rm --name open-runtimes-test-build -v /tmp/.build:/usr/local/server
 
 # Tools test
 echo "Testing tools ..."
-docker run --name open-runtimes-test-tools open-runtimes/test-runtime sh -c "$TOOLS"
+REQUIRED_TOOLS="tar --help && unzip --help"
+docker run --name open-runtimes-test-tools open-runtimes/test-runtime sh -c "$REQUIRED_TOOLS && $TOOLS"
 OUTPUT=$(docker logs open-runtimes-test-tools)
 EXIT_CODE=$(docker inspect open-runtimes-test-tools --format='{{.State.ExitCode}}')
 docker rm --force open-runtimes-test-tools
-
 if [[ "$EXIT_CODE" == "0" ]]; then
     echo "All tools installed properly"
 else

--- a/runtimes/java/java.dockerfile
+++ b/runtimes/java/java.dockerfile
@@ -1,2 +1,3 @@
 ENV OPEN_RUNTIMES_ENTRYPOINT=Index.java
 
+RUN apt-get update && apt-get install -y zip

--- a/runtimes/swift/swift.dockerfile
+++ b/runtimes/swift/swift.dockerfile
@@ -1,1 +1,3 @@
 ENV OPEN_RUNTIMES_ENTRYPOINT=
+
+RUN apt-get update && apt-get install -y zip

--- a/runtimes/swift/versions/5.10/Dockerfile
+++ b/runtimes/swift/versions/5.10/Dockerfile
@@ -1,5 +1,5 @@
 # syntax = devthefuture/dockerfile-x:1.4.2
-FROM swiftarm/swift:5.10-ubuntu-22.04
+FROM swift:5.10.1-jammy
 
 INCLUDE ./base-before
 INCLUDE ./swift

--- a/runtimes/swift/versions/5.5/Dockerfile
+++ b/runtimes/swift/versions/5.5/Dockerfile
@@ -1,5 +1,5 @@
 # syntax = devthefuture/dockerfile-x:1.4.2
-FROM swiftarm/swift:5.5.3-ubuntu-jammy
+FROM swift:5.5.3-focal
 
 INCLUDE ./base-before
 INCLUDE ./swift

--- a/runtimes/swift/versions/5.8/Dockerfile
+++ b/runtimes/swift/versions/5.8/Dockerfile
@@ -1,5 +1,5 @@
 # syntax = devthefuture/dockerfile-x:1.4.2
-FROM swiftarm/swift:5.8.1-ubuntu-22.04
+FROM swift:5.8.1-jammy
 
 INCLUDE ./base-before
 INCLUDE ./swift

--- a/runtimes/swift/versions/5.9/Dockerfile
+++ b/runtimes/swift/versions/5.9/Dockerfile
@@ -1,5 +1,5 @@
 # syntax = devthefuture/dockerfile-x:1.4.2
-FROM swiftarm/swift:5.9.2-ubuntu-22.04
+FROM swift:5.9.2-jammy
 
 INCLUDE ./base-before
 INCLUDE ./swift


### PR DESCRIPTION
Add test to ensure `unzip` and `tar` are available in All runtimes

Swift changes are due to:

![CleanShot 2025-01-08 at 09 45 42@2x](https://github.com/user-attachments/assets/070b040e-4936-41f7-a0d1-b0950a8efade)

(swift 5.5 got different because that version didn't exist when swift 5.5 was released)