### PR TITLE
Fix: SSR runtime restarts

### DIFF
--- a/runtimes/ssr/versions/latest/helpers/analog/server.sh
+++ b/runtimes/ssr/versions/latest/helpers/analog/server.sh
@@ -2,8 +2,8 @@ set -e
 
 cd /usr/local/server/src/function/
 
-mv ../server-analog.js ./server.js
-mv ../helpers.js ./helpers.js
-mv ../logger.js ./logger.js
+cp ../server-analog.js ./server.js
+cp ../helpers.js ./helpers.js
+cp ../logger.js ./logger.js
 
 HOST=0.0.0.0 PORT=3000 node ./server.js

--- a/runtimes/ssr/versions/latest/helpers/angular/server.sh
+++ b/runtimes/ssr/versions/latest/helpers/angular/server.sh
@@ -2,8 +2,8 @@ set -e
 
 cd /usr/local/server/src/function/
 
-mv ../server-angular.js ./server.js
-mv ../helpers.js ./helpers.js
-mv ../logger.js ./logger.js
+cp ../server-angular.js ./server.js
+cp ../helpers.js ./helpers.js
+cp ../logger.js ./logger.js
 
 HOST=0.0.0.0 PORT=3000 node ./server.js

--- a/runtimes/ssr/versions/latest/helpers/astro/server.sh
+++ b/runtimes/ssr/versions/latest/helpers/astro/server.sh
@@ -2,8 +2,8 @@ set -e
 
 cd /usr/local/server/src/function/
 
-mv ../server-astro.js ./server.js
-mv ../helpers.js ./helpers.js
-mv ../logger.js ./logger.js
+cp ../server-astro.js ./server.js
+cp ../helpers.js ./helpers.js
+cp ../logger.js ./logger.js
 
 HOST=0.0.0.0 PORT=3000 node ./server.js

--- a/runtimes/ssr/versions/latest/helpers/next-js/server.sh
+++ b/runtimes/ssr/versions/latest/helpers/next-js/server.sh
@@ -2,8 +2,8 @@ set -e
 
 cd /usr/local/server/src/function
 
-mv ../server-next-js.js ./server.js
-mv ../helpers.js ./helpers.js
-mv ../logger.js ./logger.js
+cp ../server-next-js.js ./server.js
+cp ../helpers.js ./helpers.js
+cp ../logger.js ./logger.js
 
 HOST=0.0.0.0 PORT=3000 node ./server.js

--- a/runtimes/ssr/versions/latest/helpers/nuxt/server.sh
+++ b/runtimes/ssr/versions/latest/helpers/nuxt/server.sh
@@ -2,8 +2,8 @@ set -e
 
 cd /usr/local/server/src/function/
 
-mv ../server-nuxt.js ./server.js
-mv ../helpers.js ./helpers.js
-mv ../logger.js ./logger.js
+cp ../server-nuxt.js ./server.js
+cp ../helpers.js ./helpers.js
+cp ../logger.js ./logger.js
 
 HOST=0.0.0.0 PORT=3000 node ./server.js

--- a/runtimes/ssr/versions/latest/helpers/remix/server.sh
+++ b/runtimes/ssr/versions/latest/helpers/remix/server.sh
@@ -2,8 +2,8 @@ set -e
 
 cd /usr/local/server/src/function
 
-mv ../server-remix.js ./server.js
-mv ../helpers.js ./helpers.js
-mv ../logger.js ./logger.js
+cp ../server-remix.js ./server.js
+cp ../helpers.js ./helpers.js
+cp ../logger.js ./logger.js
 
 HOST=0.0.0.0 PORT=3000 node ./server.js

--- a/runtimes/ssr/versions/latest/helpers/sveltekit/server.sh
+++ b/runtimes/ssr/versions/latest/helpers/sveltekit/server.sh
@@ -2,8 +2,8 @@ set -e
 
 cd /usr/local/server/src/function/
 
-mv ../server-sveltekit.js ./server.js
-mv ../helpers.js ./helpers.js
-mv ../logger.js ./logger.js
+cp ../server-sveltekit.js ./server.js
+cp ../helpers.js ./helpers.js
+cp ../logger.js ./logger.js
 
 HOST=0.0.0.0 PORT=3000 node ./server.js


### PR DESCRIPTION
`mv` command doesnt work well when restarting after crash. Using `cp` instead solves this problem.