### PR TITLE
Fix: Hidden files (attept 2)

### DIFF
--- a/ci-runtime-prepare.sh
+++ b/ci-runtime-prepare.sh
@@ -4,16 +4,16 @@ mkdir -p ./runtimes/.test
 
 # Global files (for all runtimes)
 mkdir -p ./runtimes/.test/helpers
-cp -R ./helpers/* ./runtimes/.test/helpers
+cp -R ./helpers/. ./runtimes/.test/helpers
 
 # Runtime base dockerfile
 cp -R ./runtimes/$RUNTIME_FOLDER/$RUNTIME_FOLDER.dockerfile ./runtimes/.test
 
 # Runtime-specific files (most)
-cp -R ./runtimes/$RUNTIME_FOLDER/versions/latest/* ./runtimes/.test
+cp -R ./runtimes/$RUNTIME_FOLDER/versions/latest/. ./runtimes/.test
 
 # Version-specific files
-cp -R ./runtimes/$RUNTIME_FOLDER/versions/$VERSION_FOLDER/* ./runtimes/.test
+cp -R ./runtimes/$RUNTIME_FOLDER/versions/$VERSION_FOLDER/. ./runtimes/.test
 
 # Global Docker configuration
 cp ./base-before.dockerfile ./runtimes/.test/base-before.dockerfile

--- a/ci_tests.sh
+++ b/ci_tests.sh
@@ -32,11 +32,11 @@ echo "Running tests ..."
 mkdir -p ./tests/.runtime
 
 if ! [ -z "$ENFORCED_RUNTIME" ]; then
-    cp -R ./tests/resources/functions/$RUNTIME/* ./tests/.runtime
+    cp -R ./tests/resources/functions/$RUNTIME/. ./tests/.runtime
 else
-    cp -R ./tests/resources/functions/$RUNTIME_FOLDER/latest/* ./tests/.runtime
+    cp -R ./tests/resources/functions/$RUNTIME_FOLDER/latest/. ./tests/.runtime
         if [ -d "./tests/resources/functions/$RUNTIME_FOLDER/$VERSION_FOLDER/" ]; then
-        cp -R ./tests/resources/functions/$RUNTIME_FOLDER/$VERSION_FOLDER/* ./tests/.runtime
+        cp -R ./tests/resources/functions/$RUNTIME_FOLDER/$VERSION_FOLDER/. ./tests/.runtime
     fi
 fi
 

--- a/helpers/before-build.sh
+++ b/helpers/before-build.sh
@@ -5,7 +5,7 @@ set -e
 echo "Preparing for build ..."
 
 # Copy from mounted volume to temporary folder
-cp -R /mnt/code/* /usr/local/build
+cp -R /mnt/code/. /usr/local/build
 
 # Enter build folder
 cd /usr/local/build

--- a/runtimes/cpp/versions/latest/helpers/prepare-compile.sh
+++ b/runtimes/cpp/versions/latest/helpers/prepare-compile.sh
@@ -6,7 +6,7 @@ if [ -f "/usr/local/build/CMakeLists.txt" ]; then
 fi
 
 # Copy user code into server code
-cp -R --no-clobber /usr/local/build/* /usr/local/server/src
+cp -R --no-clobber /usr/local/build/. /usr/local/server/src
 
 # Update dynamic placeholder to import user code
 ESCAPED_OPEN_RUNTIMES_ENTRYPOINT="$(echo "$OPEN_RUNTIMES_ENTRYPOINT" | sed -e 's/[\/&]/\\&/g')"

--- a/runtimes/cpp/versions/latest/helpers/prepare-packing.sh
+++ b/runtimes/cpp/versions/latest/helpers/prepare-packing.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 mkdir -p /tmp/compiled
-mv /usr/local/build/compiled/* /tmp/compiled
-rm -rf /usr/local/build/*
-mv /tmp/compiled/* /usr/local/build/
+mv /usr/local/build/compiled/{.*,*} /tmp/compiled
+rm -rf /usr/local/build
+mkdir -p /usr/local/build
+mv /tmp/compiled/{.*,*} /usr/local/build/

--- a/runtimes/cpp/versions/latest/helpers/prepare-packing.sh
+++ b/runtimes/cpp/versions/latest/helpers/prepare-packing.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 mkdir -p /tmp/compiled
-mv /usr/local/build/compiled/{.*,*} /tmp/compiled
+cp -R /usr/local/build/compiled/. /tmp/compiled
 rm -rf /usr/local/build
 mkdir -p /usr/local/build
-mv /tmp/compiled/{.*,*} /usr/local/build/
+cp -R /tmp/compiled/. /usr/local/build/

--- a/runtimes/dart/versions/latest/helpers/before-build.sh
+++ b/runtimes/dart/versions/latest/helpers/before-build.sh
@@ -5,7 +5,7 @@ set -e
 echo "Preparing for build ..."
 
 # Copy from mounted volume to temporary folder
-cp -R /mnt/code/* /usr/local/build
+cp -R /mnt/code/. /usr/local/build
 
 # Add a pubspec.yaml if one doesn't already exist.
 cd /usr/local/build

--- a/runtimes/dart/versions/latest/helpers/prepare-packing.sh
+++ b/runtimes/dart/versions/latest/helpers/prepare-packing.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 mkdir -p /tmp/compiled
-mv /usr/local/build/compiled/* /tmp/compiled
-rm -rf /usr/local/build/*
-mv /tmp/compiled/* /usr/local/build/
+mv /usr/local/build/compiled/{.*,*} /tmp/compiled
+rm -rf /usr/local/build
+mkdir -p /usr/local/build
+mv /tmp/compiled/{.*,*} /usr/local/build/

--- a/runtimes/dart/versions/latest/helpers/prepare-packing.sh
+++ b/runtimes/dart/versions/latest/helpers/prepare-packing.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 mkdir -p /tmp/compiled
-mv /usr/local/build/compiled/{.*,*} /tmp/compiled
+cp -R /usr/local/build/compiled/. /tmp/compiled
 rm -rf /usr/local/build
 mkdir -p /usr/local/build
-mv /tmp/compiled/{.*,*} /usr/local/build/
+cp -R /tmp/compiled/. /usr/local/build/

--- a/runtimes/dotnet/versions/6.0/helpers/prepare-compile.sh
+++ b/runtimes/dotnet/versions/6.0/helpers/prepare-compile.sh
@@ -31,4 +31,4 @@ cd /usr/local/server
 dotnet publish DotNetRuntime.csproj -c Release
 
 # Copy output files
-cp -R /usr/local/server/bin/Release/net6.0/publish/* /usr/local/build/compiled
+cp -R /usr/local/server/bin/Release/net6.0/publish/. /usr/local/build/compiled

--- a/runtimes/dotnet/versions/7.0/helpers/prepare-compile.sh
+++ b/runtimes/dotnet/versions/7.0/helpers/prepare-compile.sh
@@ -31,4 +31,4 @@ cd /usr/local/server
 dotnet publish DotNetRuntime.csproj -c Release
 
 # Copy output files
-cp -R /usr/local/server/bin/Release/net7.0/publish/* /usr/local/build/compiled
+cp -R /usr/local/server/bin/Release/net7.0/publish/. /usr/local/build/compiled

--- a/runtimes/dotnet/versions/latest/helpers/prepare-compile.sh
+++ b/runtimes/dotnet/versions/latest/helpers/prepare-compile.sh
@@ -31,4 +31,4 @@ cd /usr/local/server
 dotnet publish DotNetRuntime.csproj -c Release
 
 # Copy output files
-cp -R /usr/local/server/bin/Release/net8.0/publish/* /usr/local/build/compiled
+cp -R /usr/local/server/bin/Release/net8.0/publish/. /usr/local/build/compiled

--- a/runtimes/dotnet/versions/latest/helpers/prepare-packing.sh
+++ b/runtimes/dotnet/versions/latest/helpers/prepare-packing.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 mkdir -p /tmp/compiled
-mv /usr/local/build/compiled/* /tmp/compiled
-rm -rf /usr/local/build/*
-mv /tmp/compiled/* /usr/local/build/
+mv /usr/local/build/compiled/{.*,*} /tmp/compiled
+rm -rf /usr/local/build
+mkdir -p /usr/local/build
+mv /tmp/compiled/{.*,*} /usr/local/build/

--- a/runtimes/dotnet/versions/latest/helpers/prepare-packing.sh
+++ b/runtimes/dotnet/versions/latest/helpers/prepare-packing.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 mkdir -p /tmp/compiled
-mv /usr/local/build/compiled/{.*,*} /tmp/compiled
+cp -R /usr/local/build/compiled/. /tmp/compiled
 rm -rf /usr/local/build
 mkdir -p /usr/local/build
-mv /tmp/compiled/{.*,*} /usr/local/build/
+cp -R /tmp/compiled/. /usr/local/build/

--- a/runtimes/java/versions/latest/helpers/prepare-compile.sh
+++ b/runtimes/java/versions/latest/helpers/prepare-compile.sh
@@ -8,4 +8,4 @@ mkdir /usr/local/build/compiled
 sh gradlew buildJar
 
 # Copy output files
-cp -R /usr/local/server/build/libs/* /usr/local/build/compiled
+cp -R /usr/local/server/build/libs/. /usr/local/build/compiled

--- a/runtimes/java/versions/latest/helpers/prepare-packing.sh
+++ b/runtimes/java/versions/latest/helpers/prepare-packing.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 mkdir -p /tmp/compiled
-mv /usr/local/build/compiled/* /tmp/compiled
-rm -rf /usr/local/build/*
-mv /tmp/compiled/* /usr/local/build/
+mv /usr/local/build/compiled/{.*,*} /tmp/compiled
+rm -rf /usr/local/build
+mkdir -p /usr/local/build
+mv /tmp/compiled/{.*,*} /usr/local/build/

--- a/runtimes/java/versions/latest/helpers/prepare-packing.sh
+++ b/runtimes/java/versions/latest/helpers/prepare-packing.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 mkdir -p /tmp/compiled
-mv /usr/local/build/compiled/{.*,*} /tmp/compiled
+cp -R /usr/local/build/compiled/. /tmp/compiled
 rm -rf /usr/local/build
 mkdir -p /usr/local/build
-mv /tmp/compiled/{.*,*} /usr/local/build/
+cp -R /tmp/compiled/. /usr/local/build/

--- a/runtimes/kotlin/versions/latest/helpers/prepare-compile.sh
+++ b/runtimes/kotlin/versions/latest/helpers/prepare-compile.sh
@@ -10,4 +10,4 @@ cd /usr/local/server
 sh gradlew buildJar
 
 # Copy output files
-cp -R /usr/local/server/build/libs/* /usr/local/build/compiled
+cp -R /usr/local/server/build/libs/. /usr/local/build/compiled

--- a/runtimes/kotlin/versions/latest/helpers/prepare-packing.sh
+++ b/runtimes/kotlin/versions/latest/helpers/prepare-packing.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 mkdir -p /tmp/compiled
-mv /usr/local/build/compiled/* /tmp/compiled
-rm -rf /usr/local/build/*
-mv /tmp/compiled/* /usr/local/build/
+mv /usr/local/build/compiled/{.*,*} /tmp/compiled
+rm -rf /usr/local/build
+mkdir -p /usr/local/build
+mv /tmp/compiled/{.*,*} /usr/local/build/

--- a/runtimes/kotlin/versions/latest/helpers/prepare-packing.sh
+++ b/runtimes/kotlin/versions/latest/helpers/prepare-packing.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 mkdir -p /tmp/compiled
-mv /usr/local/build/compiled/{.*,*} /tmp/compiled
+cp -R /usr/local/build/compiled/. /tmp/compiled
 rm -rf /usr/local/build
 mkdir -p /usr/local/build
-mv /tmp/compiled/{.*,*} /usr/local/build/
+cp -R /tmp/compiled/. /usr/local/build/

--- a/runtimes/node/versions/latest/helpers/analog/server.sh
+++ b/runtimes/node/versions/latest/helpers/analog/server.sh
@@ -6,6 +6,6 @@ source /usr/local/server/helpers/analog/env.sh
 
 cp ../server-analog.mjs ./server.mjs
 mkdir -p ./ssr
-cp -R ../ssr/* ./ssr/
+cp -R ../ssr/. ./ssr/
 
 HOST=0.0.0.0 PORT=3000 node ./server.mjs

--- a/runtimes/node/versions/latest/helpers/angular/server.sh
+++ b/runtimes/node/versions/latest/helpers/angular/server.sh
@@ -6,6 +6,6 @@ source /usr/local/server/helpers/angular/env.sh
 
 cp ../server-angular.mjs ./server.mjs
 mkdir -p ./ssr
-cp -R ../ssr/* ./ssr/
+cp -R ../ssr/. ./ssr/
 
 HOST=0.0.0.0 PORT=3000 node ./server.mjs

--- a/runtimes/node/versions/latest/helpers/astro/server.sh
+++ b/runtimes/node/versions/latest/helpers/astro/server.sh
@@ -6,6 +6,6 @@ source /usr/local/server/helpers/astro/env.sh
 
 cp ../server-astro.mjs ./server.mjs
 mkdir -p ./ssr
-cp -R ../ssr/* ./ssr/
+cp -R ../ssr/. ./ssr/
 
 HOST=0.0.0.0 PORT=3000 node ./server.mjs

--- a/runtimes/node/versions/latest/helpers/next-js/bundle.sh
+++ b/runtimes/node/versions/latest/helpers/next-js/bundle.sh
@@ -7,7 +7,7 @@ fi
 ENTRYPOINT="./server/webpack-runtime.js"
 if [ -e "$ENTRYPOINT" ]; then
     mkdir -p .next
-    mv ./{.*,*} .next/
+    cp -R ./. .next/
 
     if [ -d "/usr/local/build/public/" ]; then
         mv /usr/local/build/public/ ./public/

--- a/runtimes/node/versions/latest/helpers/next-js/bundle.sh
+++ b/runtimes/node/versions/latest/helpers/next-js/bundle.sh
@@ -7,7 +7,7 @@ fi
 ENTRYPOINT="./server/webpack-runtime.js"
 if [ -e "$ENTRYPOINT" ]; then
     mkdir -p .next
-    mv ./* .next/
+    mv ./{.*,*} .next/
 
     if [ -d "/usr/local/build/public/" ]; then
         mv /usr/local/build/public/ ./public/

--- a/runtimes/node/versions/latest/helpers/next-js/server.sh
+++ b/runtimes/node/versions/latest/helpers/next-js/server.sh
@@ -6,6 +6,6 @@ source /usr/local/server/helpers/next-js/env.sh
 
 cp ../server-next-js.mjs ./server.mjs
 mkdir -p ./ssr
-cp -R ../ssr/* ./ssr/
+cp -R ../ssr/. ./ssr/
 
 HOST=0.0.0.0 PORT=3000 node ./server.mjs

--- a/runtimes/node/versions/latest/helpers/nuxt/server.sh
+++ b/runtimes/node/versions/latest/helpers/nuxt/server.sh
@@ -6,6 +6,6 @@ source /usr/local/server/helpers/nuxt/env.sh
 
 cp ../server-nuxt.mjs ./server.mjs
 mkdir -p ./ssr
-cp -R ../ssr/* ./ssr/
+cp -R ../ssr/. ./ssr/
 
 HOST=0.0.0.0 PORT=3000 node ./server.mjs

--- a/runtimes/node/versions/latest/helpers/remix/bundle.sh
+++ b/runtimes/node/versions/latest/helpers/remix/bundle.sh
@@ -7,7 +7,7 @@ fi
 ENTRYPOINT="./server/index.js"
 if [ -e "$ENTRYPOINT" ]; then
     mkdir -p .build
-    mv ./* .build/
+    mv ./{.*,*} .build/
 
     mv .build/ build/
 

--- a/runtimes/node/versions/latest/helpers/remix/bundle.sh
+++ b/runtimes/node/versions/latest/helpers/remix/bundle.sh
@@ -7,7 +7,7 @@ fi
 ENTRYPOINT="./server/index.js"
 if [ -e "$ENTRYPOINT" ]; then
     mkdir -p .build
-    mv ./{.*,*} .build/
+    cp -R ./. .build/
 
     mv .build/ build/
 

--- a/runtimes/node/versions/latest/helpers/remix/server.sh
+++ b/runtimes/node/versions/latest/helpers/remix/server.sh
@@ -6,6 +6,6 @@ source /usr/local/server/helpers/remix/env.sh
 
 cp ../server-remix.mjs ./server.mjs
 mkdir -p ./ssr
-cp -R ../ssr/* ./ssr/
+cp -R ../ssr/. ./ssr/
 
 HOST=0.0.0.0 PORT=3000 node ./server.mjs

--- a/runtimes/node/versions/latest/helpers/sveltekit/server.sh
+++ b/runtimes/node/versions/latest/helpers/sveltekit/server.sh
@@ -6,6 +6,6 @@ source /usr/local/server/helpers/sveltekit/env.sh
 
 cp ../server-sveltekit.mjs ./server.mjs
 mkdir -p ./ssr
-cp -R ../ssr/* ./ssr/
+cp -R ../ssr/. ./ssr/
 
 HOST=0.0.0.0 PORT=3000 node ./server.mjs

--- a/runtimes/python/versions/latest/helpers/prepare-start.sh
+++ b/runtimes/python/versions/latest/helpers/prepare-start.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # Copy contents of the server-env virtual env to the runtime-env virtual env
-cp -r /usr/local/server/server-env/* /usr/local/server/src/function/runtime-env
+cp -r /usr/local/server/server-env/. /usr/local/server/src/function/runtime-env
 
 # Activate virtual env
 source /usr/local/server/src/function/runtime-env/bin/activate

--- a/runtimes/python/versions/ml-3.11/helpers/prepare-start.sh
+++ b/runtimes/python/versions/ml-3.11/helpers/prepare-start.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # Copy contents of the server-env virtual env to the runtime-env virtual env
-cp -r /usr/local/server/server-env/* /usr/local/server/src/function/runtime-env
+cp -r /usr/local/server/server-env/. /usr/local/server/src/function/runtime-env
 
 # Activate virtual env
 . /usr/local/server/src/function/runtime-env/bin/activate # OVERRIDE: Cant use source here

--- a/runtimes/python/versions/ml-3.12/helpers/prepare-start.sh
+++ b/runtimes/python/versions/ml-3.12/helpers/prepare-start.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # Copy contents of the server-env virtual env to the runtime-env virtual env
-cp -r /usr/local/server/server-env/* /usr/local/server/src/function/runtime-env
+cp -r /usr/local/server/server-env/. /usr/local/server/src/function/runtime-env
 
 # Activate virtual env
 . /usr/local/server/src/function/runtime-env/bin/activate # OVERRIDE: Cant use source here

--- a/runtimes/ruby/versions/latest/helpers/prepare-packing.sh
+++ b/runtimes/ruby/versions/latest/helpers/prepare-packing.sh
@@ -6,4 +6,4 @@ set -e
 mkdir -p /usr/local/build/vendor
 
 # Copy dependencies
-cp -R /usr/local/server/vendor/* /usr/local/build/vendor
+cp -R /usr/local/server/vendor/. /usr/local/build/vendor

--- a/runtimes/swift/versions/latest/helpers/before-build.sh
+++ b/runtimes/swift/versions/latest/helpers/before-build.sh
@@ -5,7 +5,7 @@ set -e
 echo "Preparing for build ..."
 
 # Copy from mounted volume to temporary folder
-cp -R /mnt/code/* /usr/local/build
+cp -R /mnt/code/. /usr/local/build
 
 # Enter build folder
 cd /usr/local/build


### PR DESCRIPTION
Removing `*` allows hidden  files (like .vitepress) to be copied during build.

It's okay to copy hidden files. They are not private, just meant to be hidden from user. Good example is `.prettierrc.json` - perfectly fine to copy, and even required in some CI/CD scenarios.