### PR TITLE
Fix hidden files (attempt 3)

### DIFF
--- a/base-before.dockerfile
+++ b/base-before.dockerfile
@@ -5,6 +5,8 @@ ENV OPEN_RUNTIMES_SECRET=open_runtime_secret
 ENV OPEN_RUNTIMES_ENV=production
 ENV OPEN_RUNTIMES_HEADERS="{}"
 
+RUN shopt -s dotglob
+
 RUN <<EOR
     if [ -f /etc/alpine-release ]; then
         apk add util-linux


### PR DESCRIPTION
A fix for frameworks like Vitepress, storing build's data in dot files and folders