### PR TITLE
feat(bun): add bun 1.2

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -347,6 +347,11 @@ jobs:
             ARCH: "linux/amd64,linux/arm64"
 
           # Bun
+          - ID: bun-1.2
+            RUNTIME: bun
+            VERSION: "1.2"
+            IMAGE: openruntimes/bun:v5-1.2
+            ARCH: "linux/amd64,linux/arm64"
           - ID: bun-1.1
             RUNTIME: bun
             VERSION: "1.1"

--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ Runtime environments for serverless cloud computing for multiple coding language
 | Swift | 5.10    | [openruntimes/swift:v4-5.10](https://hub.docker.com/r/openruntimes/swift)      | [Examples](/runtimes/swift-5.10/example)     | [![Docker Pulls](https://img.shields.io/docker/pulls/openruntimes/swift?color=f02e65&style=flat-square)](https://hub.docker.com/r/openruntimes/swift) |
 | Bun | 1.0     | [openruntimes/bun:v4-1.0](https://hub.docker.com/r/openruntimes/bun)           | [Examples](/runtimes/bun-1.0/example)        | [![Docker Pulls](https://img.shields.io/docker/pulls/openruntimes/bun?color=f02e65&style=flat-square)](https://hub.docker.com/r/openruntimes/bun) |
 | Bun | 1.1     | [openruntimes/bun:v4-1.1](https://hub.docker.com/r/openruntimes/bun)           | [Examples](/runtimes/bun-1.0/example)        | [![Docker Pulls](https://img.shields.io/docker/pulls/openruntimes/bun?color=f02e65&style=flat-square)](https://hub.docker.com/r/openruntimes/bun) |
+| Bun | 1.2     | [openruntimes/bun:v4-1.2](https://hub.docker.com/r/openruntimes/bun)           | [Examples](/runtimes/bun-1.0/example)        | [![Docker Pulls](https://img.shields.io/docker/pulls/openruntimes/bun?color=f02e65&style=flat-square)](https://hub.docker.com/r/openruntimes/bun) |
 
 ## Architecture
 

--- a/ci/runtimes.toml
+++ b/ci/runtimes.toml
@@ -113,7 +113,7 @@ test = "Serverless/Go.php"
 
 [bun]
 entry = "tests.ts"
-versions = ["1.1", "1.0"]
+versions = ["1.2", "1.1", "1.0"]
 commands = { install = "bun install", start = "bash helpers/server.sh" }
 formatter = { prepare = "echo \"Using bunx biome formatter\"", check = "bunx @biomejs/biome format .", write = "bunx @biomejs/biome format --write ." }
 tools = "bun --version && npm --version && npx --version && pnpm --version && yarn --version"

--- a/runtimes/bun/versions/1.2/Dockerfile
+++ b/runtimes/bun/versions/1.2/Dockerfile
@@ -1,0 +1,6 @@
+# syntax = devthefuture/dockerfile-x:1.4.2
+FROM oven/bun:1.2.15-alpine
+
+INCLUDE ./base-before
+INCLUDE ./bun
+INCLUDE ./base-after


### PR DESCRIPTION
### What

Add bun 1.2 to the runtimes.toml and the Dockerfile.

### Why

There's a particularly annoying issue with JSX that prevents the use of things like `{ h }`,  jsx-lite, and others. It basically makes bun ignore `tsconfig.json`. It was fixed here: https://github.com/oven-sh/bun/issues/3768

We have to upgrade to Bun 1.2+ to fix this

### Issues

https://github.com/oven-sh/bun/issues/3768
