### PR TITLE
refactor: move SSR logger + http-injection core to runtimes/javascript

### DIFF
--- a/runtimes/javascript/src/ssr/http-injection.mjs
+++ b/runtimes/javascript/src/ssr/http-injection.mjs
@@ -1,0 +1,118 @@
+// Shared HTTP server wrappers used by both the node and bun SSR injection
+// entrypoints. Contains the per-request logic (Open Runtimes endpoints, secret
+// auth, per-request log id, safe execution timeout, error capture) plus the
+// constructor wrappers that install it. Runtime entrypoints decide *how* these
+// get applied (node: import-in-the-middle + require-in-the-middle; bun: direct
+// Server.prototype.emit patch at preload time).
+
+import {
+  addOprEndpoints,
+  addAuthenticationCheck,
+  addSafeTimeout,
+} from "./system.mjs";
+import { Logger, loggingNamespace } from "./logger.mjs";
+
+// Core: replace an http.Server's `emit` so "request" events flow through the
+// Open Runtimes contract before hitting the user-owned listener.
+export function overrideEmit(originalEmit) {
+  return function (event, ...emitArgs) {
+    if (event !== "request") {
+      return originalEmit.call(this, event, ...emitArgs);
+    }
+
+    const [req, res] = emitArgs;
+
+    if (addOprEndpoints(req, res)) {
+      return;
+    }
+
+    if (addAuthenticationCheck(req, res)) {
+      return;
+    }
+
+    req.loggerId = Logger.start(
+      req.headers["x-open-runtimes-logging"],
+      req.headers["x-open-runtimes-log-id"],
+    );
+    res.setHeader("x-open-runtimes-log-id", req.loggerId);
+
+    if (addSafeTimeout(req, res)) {
+      return;
+    }
+
+    const self = this;
+
+    loggingNamespace.run({ id: req.loggerId }, () => {
+      Logger.overrideNativeLogs(loggingNamespace, req.loggerId);
+
+      const dispatch = () => {
+        try {
+          originalEmit.call(self, event, ...emitArgs);
+        } catch (error) {
+          if (!res.headersSent) {
+            Logger.write(req.loggerId, [error], Logger.TYPE_ERROR);
+            res.writeHead(500, { "Content-Type": "text/plain" });
+            res.end("");
+          }
+        }
+      };
+
+      if (req.safeTimeout !== null && req.safeTimeout !== undefined) {
+        setTimeout(() => {
+          if (!res.headersSent) {
+            console.error("Execution timed out.");
+            res.statusCode = 500;
+            res.setHeader("Content-Type", "text/plain");
+            res.setHeader("Content-Length", 0);
+            res.end("");
+          }
+        }, req.safeTimeout * 1000);
+      }
+
+      dispatch();
+    });
+  };
+}
+
+// Wrap a Server constructor (used by Nitro's `new Server()` path).
+export function wrapServer(originalServer) {
+  return function (...args) {
+    const server = originalServer.apply(this, args);
+    server.emit = overrideEmit(server.emit);
+    return server;
+  };
+}
+
+// Wrap createServer (used by native http, express, koa, ...).
+export function wrapCreateServer(originalCreateServer) {
+  return function (...args) {
+    const server = new originalCreateServer(...args);
+    server.emit = overrideEmit(server.emit);
+    return server;
+  };
+}
+
+// Apply wrapServer/wrapCreateServer to a loaded http/https module's exports.
+// Handles both CJS and ESM shapes. Used by node's import-in-the-middle hook.
+export function wrapHttp(moduleExports) {
+  if (moduleExports.Server) {
+    moduleExports.Server = wrapServer(moduleExports.Server);
+  }
+  if (moduleExports.createServer) {
+    moduleExports.createServer = wrapCreateServer(moduleExports.createServer);
+  }
+
+  const isESM = moduleExports[Symbol.toStringTag] === "Module";
+  if (isESM) {
+    if (moduleExports.default.Server) {
+      moduleExports.default.Server = wrapServer(moduleExports.default.Server);
+    }
+    if (moduleExports.default.createServer) {
+      moduleExports.default.createServer = wrapCreateServer(
+        moduleExports.default.createServer,
+      );
+    }
+  }
+
+  return moduleExports;
+}

--- a/runtimes/javascript/src/ssr/logger.mjs
+++ b/runtimes/javascript/src/ssr/logger.mjs
@@ -1,8 +1,10 @@
-import { appendFileSync } from "fs";
-import { createNamespace } from "cls-hooked";
+import { appendFileSync } from "node:fs";
+import { AsyncLocalStorage } from "node:async_hooks";
 import superjson from "superjson";
 
-export const loggingNamespace = createNamespace("logging");
+// Shared between node and bun. Uses AsyncLocalStorage (built into Node 16+
+// and Bun) instead of cls-hooked so both runtimes can consume the same file.
+export const loggingNamespace = new AsyncLocalStorage();
 
 export const nativeLog = console.log.bind(console);
 
@@ -47,26 +49,23 @@ export class Logger {
     const path = `/mnt/logs/${id}_${type === Logger.TYPE_ERROR ? "errors" : "logs"}.log`;
     try {
       appendFileSync(path, stringLog + "\n");
-    } catch (err) {
-      // Silently ignore write failures to prevent runtime crashes
-      // The logging system should not cause the main execution to fail
+    } catch {
+      // Silently ignore write failures to prevent runtime crashes.
     }
   }
 
-  static overrideNativeLogs(namespace, rid) {
+  static overrideNativeLogs(namespace, _rid) {
+    const forward = (type) => (...args) => {
+      const requestId = namespace.getStore()?.id ?? "";
+      Logger.write(requestId, args, type);
+    };
+
     console.log =
       console.info =
       console.debug =
       console.warn =
-        (...args) => {
-          const requestId = namespace.get("id");
-          Logger.write(requestId, args, Logger.TYPE_LOG, true);
-        };
-
-    console.error = (...args) => {
-      const requestId = namespace.get("id");
-      Logger.write(requestId, args, Logger.TYPE_ERROR, true);
-    };
+        forward(Logger.TYPE_LOG);
+    console.error = forward(Logger.TYPE_ERROR);
   }
 
   // Recreated from https://www.php.net/manual/en/function.uniqid.php

--- a/runtimes/node/versions/latest/package-lock.json
+++ b/runtimes/node/versions/latest/package-lock.json
@@ -10,7 +10,6 @@
       "license": "ISC",
       "dependencies": {
         "@vercel/nft": "^0.29.2",
-        "cls-hooked": "^4.2.2",
         "express": "^4.21.2",
         "import-in-the-middle": "^1.14.4",
         "micro": "^9.3.4",
@@ -172,7 +171,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -232,18 +230,6 @@
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
       "license": "MIT"
-    },
-    "node_modules/async-hook-jl": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/async-hook-jl/-/async-hook-jl-1.7.6.tgz",
-      "integrity": "sha512-gFaHkFfSxTjvoxDMYqDuGHlcRyUuamF8s+ZTtJdDzqjws4mCt7v0vuV79/E2Wr2/riMQgtG4/yUtXWs1gZ7JMg==",
-      "license": "MIT",
-      "dependencies": {
-        "stack-chain": "^1.3.7"
-      },
-      "engines": {
-        "node": "^4.7 || >=6.9 || >=7.3"
-      }
     },
     "node_modules/async-sema": {
       "version": "3.1.1",
@@ -442,20 +428,6 @@
       "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
       "license": "MIT"
     },
-    "node_modules/cls-hooked": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/cls-hooked/-/cls-hooked-4.2.2.tgz",
-      "integrity": "sha512-J4Xj5f5wq/4jAvcdgoGsL3G103BtWpZrMo8NEinRltN+xpTZdI+M38pyQqhuFU/P792xkMFvnKSf+Lm81U1bxw==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "async-hook-jl": "^1.7.6",
-        "emitter-listener": "^1.0.1",
-        "semver": "^5.4.1"
-      },
-      "engines": {
-        "node": "^4.7 || >=6.9 || >=7.3 || >=8.2.1"
-      }
-    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -608,15 +580,6 @@
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
       "license": "MIT"
-    },
-    "node_modules/emitter-listener": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/emitter-listener/-/emitter-listener-1.1.2.tgz",
-      "integrity": "sha512-Bt1sBAGFHY9DKY+4/2cV6izcKJUf5T7/gkdmkxzX/qv9CcGH8xSwVRW5mtX03SWJtRTWSOpzCuWN9rBFYZepZQ==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "shimmer": "^1.2.0"
-      }
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
@@ -1485,15 +1448,6 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
     },
-    "node_modules/semver": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
     "node_modules/send": {
       "version": "0.19.0",
       "resolved": "https://registry.npmjs.org/send/-/send-0.19.0.tgz",
@@ -1620,12 +1574,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/shimmer": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
-      "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw==",
-      "license": "BSD-2-Clause"
-    },
     "node_modules/side-channel": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
@@ -1721,12 +1669,6 @@
       "engines": {
         "node": ">=20.16.0"
       }
-    },
-    "node_modules/stack-chain": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/stack-chain/-/stack-chain-1.3.7.tgz",
-      "integrity": "sha512-D8cWtWVdIe/jBA7v5p5Hwl5yOSOrmZPWDPe2KxQ5UAGD+nxbxU0lKXA4h85Ta6+qgdKVL3vUxsbIZjc1kBG7ug==",
-      "license": "MIT"
     },
     "node_modules/statuses": {
       "version": "1.5.0",

--- a/runtimes/node/versions/latest/package.json
+++ b/runtimes/node/versions/latest/package.json
@@ -12,7 +12,6 @@
   "license": "ISC",
   "dependencies": {
     "@vercel/nft": "^0.29.2",
-    "cls-hooked": "^4.2.2",
     "express": "^4.21.2",
     "import-in-the-middle": "^1.14.4",
     "micro": "^9.3.4",

--- a/runtimes/node/versions/latest/src/ssr/injections.mjs
+++ b/runtimes/node/versions/latest/src/ssr/injections.mjs
@@ -1,146 +1,23 @@
+// Node's SSR injection entrypoint — loaded via NODE_OPTIONS='--import ...'.
+// All per-request logic lives in the shared http-injection.mjs; this file only
+// wires the wrappers up using node-specific hook mechanisms (import-in-the-
+// middle for ESM, require-in-the-middle for CJS) so every load of http/https
+// receives the wrapped Server / createServer.
+
 import { Hook, createAddHookMessageChannel } from "import-in-the-middle";
 import ritm from "require-in-the-middle";
 import { register } from "node:module";
-import {
-  addOprEndpoints,
-  addAuthenticationCheck,
-  addSafeTimeout,
-} from "./system.mjs";
-import { Logger, loggingNamespace } from "./logger.mjs";
+import { wrapHttp } from "./http-injection.mjs";
 
-console.log(`Preparing SSR runtime ...`);
+console.log("Preparing SSR runtime ...");
 
 const { registerOptions, waitForAllMessagesAcknowledged } =
   createAddHookMessageChannel();
 register("import-in-the-middle/hook.mjs", import.meta.url, registerOptions);
 
-// Main logic to override HTTP and HTTPS libraries
-function wrapHttp(moduleExports) {
-  if (moduleExports.Server) {
-    moduleExports.Server = wrapServer(moduleExports.Server);
-  }
-  if (moduleExports.createServer) {
-    moduleExports.createServer = wrapCreateServer(moduleExports.createServer);
-  }
-
-  const isESM = moduleExports[Symbol.toStringTag] === "Module";
-  if (isESM) {
-    if (moduleExports.default.Server) {
-      moduleExports.default.Server = wrapServer(moduleExports.default.Server);
-    }
-    if (moduleExports.default.createServer) {
-      moduleExports.default.createServer = wrapCreateServer(
-        moduleExports.default.createServer,
-      );
-    }
-  }
-
-  return moduleExports;
-}
-
-// Override for methods used by Nitro
-function wrapServer(originalServer) {
-  return function (...args) {
-    const server = originalServer.apply(this, args);
-    server.emit = overrideEmit(server.emit);
-    return server;
-  };
-}
-
-// Override for methods used by native http, express.js, koa.js, ...
-function wrapCreateServer(originalCreateServer) {
-  return function (...args) {
-    const server = new originalCreateServer(...args);
-    server.emit = overrideEmit(server.emit);
-    return server;
-  };
-}
-
-// Request handler overrides (code here is main purpose of injection)
-function overrideEmit(originalEmit) {
-  return function (event, ...emitArgs) {
-    if (event !== "request") {
-      return originalEmit.call(this, event, ...emitArgs);
-    }
-
-    const [req, res] = emitArgs;
-    let handled = false;
-
-    // internal health check, telemetry, etc.
-    handled = addOprEndpoints(req, res);
-    if (handled) {
-      return;
-    }
-
-    // Ensure auth headers
-    handled = addAuthenticationCheck(req, res);
-    if (handled) {
-      return;
-    }
-
-    // Enable per-request logging
-    req.loggerId = Logger.start(
-      req.headers[`x-open-runtimes-logging`],
-      req.headers[`x-open-runtimes-log-id`],
-    );
-    res.setHeader("x-open-runtimes-log-id", req.loggerId);
-
-    // Validate and prepare safe timeout duration
-    handled = addSafeTimeout(req, res);
-    if (handled) {
-      return;
-    }
-
-    // Wrap rest of the logic in namespace for proper log reporting
-    loggingNamespace.run(async () => {
-      loggingNamespace.set("id", req.loggerId);
-      Logger.overrideNativeLogs(loggingNamespace, req.loggerId);
-
-      // Apply safe timeout, when relevant
-      if (req.safeTimeout !== null) {
-        setTimeout(() => {
-          if (!res.headersSent) {
-            console.error("Execution timed out.");
-            res.statusCode = 500;
-            res.setHeader("Content-Type", "text/plain");
-            res.setHeader("Content-Length", 0);
-            res.end("");
-          }
-        }, req.safeTimeout * 1000);
-
-        try {
-          // Forward to original handler
-          originalEmit.call(this, event, ...emitArgs);
-        } catch (error) {
-          // Write errors into logger
-          if (!res.headersSent) {
-            Logger.write(req.loggerId, [error], Logger.TYPE_ERROR);
-            res.writeHead(500, { "Content-Type": "text/plain" });
-            res.end("");
-          }
-        }
-      } else {
-        try {
-          // Forward to original handler
-          originalEmit.call(this, event, ...emitArgs);
-        } catch (error) {
-          // Write errors into logger
-          if (!res.headersSent) {
-            Logger.write(req.loggerId, [error], Logger.TYPE_ERROR);
-            res.writeHead(500, { "Content-Type": "text/plain" });
-            res.end("");
-          }
-        }
-      }
-    });
-  };
-}
-
-// ESM and CommonJS override for HTTP servers
 new Hook(["http", "https"], wrapHttp);
 ritm(["http", "https"], wrapHttp);
 
-// Ensures injections are complete
 await waitForAllMessagesAcknowledged();
 
 console.log(


### PR DESCRIPTION
## Summary

Follow-up to #486. Pulls two more pieces out of the node runtime and into `runtimes/javascript/` so bun (and any future JS runtime) can consume them verbatim. Requested on [#485](https://github.com/open-runtimes/open-runtimes/pull/485#discussion_r_on_injections).

## What moves

### `runtimes/javascript/src/ssr/logger.mjs`

Node's `logger.mjs` used `cls-hooked`; the bun port used `AsyncLocalStorage`. The two implementations were byte-equivalent aside from the namespace library. Converging on `AsyncLocalStorage` (stable in Node 16+ and supported by Bun) lets a single file serve both runtimes.

Changes:
- New file at `runtimes/javascript/src/ssr/logger.mjs`.
- Deleted `runtimes/node/versions/latest/src/ssr/logger.mjs`.
- Dropped `cls-hooked` from node's `package.json` and refreshed `package-lock.json`.
- Node's `injections.mjs` now calls `loggingNamespace.run({ id }, fn)` instead of `loggingNamespace.run(fn)` + `loggingNamespace.set("id", id)` (AsyncLocalStorage shape).

### `runtimes/javascript/src/ssr/http-injection.mjs`

`overrideEmit`, `wrapServer`, `wrapCreateServer`, and `wrapHttp` were the same in node and bun — only the **registration** (how the wrappers get installed onto `http`/`https`) differs:

- Node: `import-in-the-middle` (ESM) + `require-in-the-middle` (CJS), loaded via `NODE_OPTIONS='--import ...'`.
- Bun: direct `Server.prototype.emit` patch at `--preload` time (arrives next in #485).

Both now import the shared helpers from `./http-injection.mjs`. Node's `injections.mjs` is down to ~25 lines — just the hook registration.

## Behaviour

No contract changes. The per-request flow is identical:

1. Short-circuit `/__opr/health` and `/__opr/timings`.
2. `x-open-runtimes-secret` auth check.
3. Per-request `x-open-runtimes-log-id` header + logger namespace.
4. `x-open-runtimes-timeout` validation + safe-timeout timer.
5. Original handler dispatch with error capture.

## Test plan

- [ ] `bash tests.sh node-24` with every SSR framework (astro, angular, analog, next-js, next-js-turbopack, nuxt, remix, sveltekit, tanstack_start_native, tanstack_start_nitro_v2, tanstack_start_nitro_v3). All existing SSR tests must pass — the refactor changes nothing a test can see.
- [ ] Confirm `cls-hooked` is gone from node's `node_modules` after `npm ci`.
- [ ] CI: node matrix stays green.

## Follow-ups

- [#485](https://github.com/open-runtimes/open-runtimes/pull/485) rebases on this and removes its own duplicate `logger.ts` + `injections.ts` wrappers, consuming the shared file.
- Deno SSR is out of scope here — `runtimes/deno` has no SSR support yet, so there's nothing to dedupe. Once Deno gains SSR it can opt into the same `runtimes/javascript/` overlay via `shared = "javascript"`.