### PR TITLE
Harden Python ML dependency installs

### DIFF
--- a/ci/runtimes.toml
+++ b/ci/runtimes.toml
@@ -47,7 +47,7 @@ test = "Serverless/Python.php"
 [python-ml]
 entry = "tests.py"
 versions = ["3.13", "3.12", "3.11"]
-commands = { install = "pip install --no-cache-dir -r requirements.txt", start = "bash helpers/server.sh" }
+commands = { install = "pip install --no-cache-dir --timeout 120 -r requirements.txt", start = "bash helpers/server.sh" }
 formatter = { prepare = "pip install ruff", check = "ruff format --check", write = "ruff format" }
 tools = "python --version && pip --version && poetry --version"
 test = "Serverless/PythonML.php"

--- a/tests/resources/functions/python/ml-3.11/requirements.txt
+++ b/tests/resources/functions/python/ml-3.11/requirements.txt
@@ -1,2 +1,2 @@
 requests==2.27.1
-tensorflow
+tensorflow==2.21.0

--- a/tests/resources/functions/python/ml-3.12/requirements.txt
+++ b/tests/resources/functions/python/ml-3.12/requirements.txt
@@ -1,2 +1,2 @@
 requests==2.27.1
-tensorflow
+tensorflow==2.21.0

--- a/tests/resources/functions/python/ml-3.13/requirements.txt
+++ b/tests/resources/functions/python/ml-3.13/requirements.txt
@@ -1,2 +1,2 @@
 requests==2.27.1
-tensorflow
+tensorflow==2.21.0


### PR DESCRIPTION
## Summary

- Pin Python ML test fixtures to `tensorflow==2.21.0`, matching the existing asserted TensorFlow version.
- Add a longer pip network timeout for the Python ML install path, where TensorFlow downloads a large wheel.
- Keep the install command as a single `pip install` invocation without a retry loop.

## Context

The flaky `python-ml-3.13` job failed while downloading the TensorFlow 2.21.0 wheel from PyPI with:

```text
ssl.SSLError: [SSL: DECRYPTION_FAILED_OR_BAD_RECORD_MAC]
```

The failure happened during build-time dependency installation before the runtime test suite started.

## Testing

- `ALL_CHANGED_FILES='ci/runtimes.toml' GITHUB_OUTPUT=/tmp/open-runtimes-matrix.out bun ./ci/index.ts`
- `git diff --check`

Full Python ML Docker tests were left to CI because they require rebuilding the runtime and downloading TensorFlow.
