### PR TITLE
fix: drop build-only Next.js cache from SSR bundle

### DIFF
--- a/runtimes/javascript/helpers/next-js/bundle.sh
+++ b/runtimes/javascript/helpers/next-js/bundle.sh
@@ -7,6 +7,23 @@ if [ -n "$OPEN_RUNTIMES_OUTPUT_DIRECTORY" ]; then
 	cd "$OPEN_RUNTIMES_OUTPUT_DIRECTORY"
 fi
 
+# Subdirectories of .next/cache that are pure build-time artifacts and never
+# read at runtime. Safe to drop before packaging.
+#   webpack — webpack persistent build cache (often hundreds of MB)
+#   swc     — SWC compiler cache
+# Not listed (intentionally kept): fetch-cache, images, server, use-cache —
+# these are populated by `next build` for ISR / RSC / image optimization and
+# removing them changes runtime behavior.
+NEXT_BUILD_ONLY_CACHE_DIRS=("webpack" "swc")
+
+for dir in "${NEXT_BUILD_ONLY_CACHE_DIRS[@]}"; do
+	if [ -d "./cache/$dir" ]; then
+		SIZE=$(du -sh "./cache/$dir" 2>/dev/null | cut -f1)
+		rm -rf "./cache/$dir"
+		echo -e "\e[90m$(date +[%H:%M:%S]) \e[31m[\e[0mopen-runtimes\e[31m]\e[32m Pruned build-only cache .next/cache/$dir (${SIZE:-?}) \e[0m"
+	fi
+done
+
 WEBPACK_ENTRYPOINT="./server/webpack-runtime.js"
 TURBOPACK_ENTRYPOINT="./turbopack"
 STANDALONE_ENTRYPOINT="./standalone/server.js"


### PR DESCRIPTION
## Summary

- Strip `.next/cache/webpack` and `.next/cache/swc` from the SSR bundle in `runtimes/javascript/helpers/next-js/bundle.sh` before any of the existing `mv`-staging happens.
- Encoded as a `NEXT_BUILD_ONLY_CACHE_DIRS` array so the safe-to-drop list is in one place.
- Logs each removal in the existing colored runtime format, including the size reclaimed.

## Context

`.next/cache/webpack` is the webpack persistent build cache and `.next/cache/swc` is the SWC compile cache. Both are build-time only — Next.js never reads them at runtime. They were being shipped into the runtime image because `bundle.sh`'s non-standalone branch does `mv /tmp/.opr-tmp/* .next/`, which carries the cache subtree along with the rest of `.next/`. The standalone branch already implicitly drops them (it only moves `.next/standalone/*` and `.next/static/*`), so this primarily affects non-standalone Next.js sites.

This was caught in production: a Next.js site on Appwrite Sites was being killed in a tight eviction loop with `Usage of EmptyDir volume "code" exceeds the limit "2Gi"` at the kubelet. Inspection of `/mnt/code` showed:

| path | size |
|---|---|
| `node_modules` | 1.0 GB |
| `.next/cache/webpack` | 722 MB |
| `.next` (excl. cache) | ~50 MB |
| total at idle | ≈ 2.0 GB |

The ~722 MB of `.next/cache/webpack` alone was enough to put the artifact at the disk cap before the app served a single request. Stripping it brings the artifact comfortably back under the cap on the same project without any user-side change.

### Why only `webpack` and `swc`

Other subdirs of `.next/cache` are populated by `next build` and are read at runtime:

- `fetch-cache` — populated by `next build` for static pages with `fetch()`. Deleting forces refetches on first request after every pod start and breaks the revalidation guarantees the user designed for.
- `images` — runtime image optimization cache.
- `server` — server components cache.
- `use-cache` — Next.js 15 `'use cache'` directive output.

These are intentionally left in. The list is encoded as an array so a contributor can extend it later if a future Next.js version adds a clearly build-only subdir, with the comment in place explaining the criterion.

## Testing

- `bash -n runtimes/javascript/helpers/next-js/bundle.sh` — syntax OK.
- Smoke test of the loop in isolation: created mock `cache/{webpack,fetch-cache}`, ran the loop under `set -e`. `webpack` is removed with the size logged, `swc` is skipped silently, `fetch-cache` is left intact, exit 0.
- Full Docker SSR test left to CI because it requires rebuilding the runtime image.

## Out of scope (called out for follow-up)

- `prepare-packing.sh` has `if [[ "${OPEN_RUNTIMES_NFT:-}" == "enabled" ]]; then if [ -d "./.next" ]; then return 0; fi` whose comment says "Falls back to modclean," but the early `return 0` exits before reaching the modclean block. With `OPEN_RUNTIMES_NFT=enabled` on a Next.js project, neither NFT nor modclean runs. Either the comment is wrong or the early return should be a no-op so the modclean fallback runs. Happy to do this in a separate PR.