### PR TITLE
fix: clear stub files before symlink and detect compression in fallback

### DIFF
--- a/helpers/extract-code.sh
+++ b/helpers/extract-code.sh
@@ -5,12 +5,60 @@
 # Prepare telemetry
 mkdir -p /mnt/telemetry
 
+# Detect archive compression by reading the first 4 magic bytes. The build
+# packs as code.tar.gz regardless of actual compression (helpers/select-
+# compression.sh picks gzip/zstd/none by build size), so the filename can't
+# be trusted.
+detect_archive_format() {
+	local magic
+	magic=$(head -c4 "$1" 2>/dev/null | od -An -vtx1 2>/dev/null | tr -d ' \n')
+	case "$magic" in
+	1f8b*) echo "gzip" ;;
+	28b52ffd) echo "zstd" ;;
+	*) echo "tar" ;;
+	esac
+}
+
+# Extract one archive into a destination dir, picking the right decompressor
+# from detected format.
+extract_archive() {
+	local archive="$1"
+	local dest="$2"
+	local format
+	format=$(detect_archive_format "$archive")
+	case "$format" in
+	gzip) tar -xzf "$archive" -C "$dest" ;;
+	zstd) zstd -dc "$archive" | tar -xf - -C "$dest" ;;
+	*) tar -xf "$archive" -C "$dest" ;;
+	esac
+}
+
+# Locate the build archive in /mnt/code and extract it to dest.
+extract_code_archive() {
+	local dest="$1"
+	if [ -f /mnt/code/code.tar ]; then
+		extract_archive /mnt/code/code.tar "$dest"
+	elif [ -f /mnt/code/code.tar.gz ] || [ -f /mnt/code/code.gz ]; then
+		extract_archive /mnt/code/code.tar.gz "$dest"
+	else
+		echo -e "\e[90m$(date +[%H:%M:%S]) \e[31m[\e[0mopen-runtimes\e[31m]\e[97m Code archive not found. \e[0m"
+		exit 1
+	fi
+}
+
 # Check if code is pre-extracted (e.g., by sidecar)
 if [ -f "/mnt/code/.extracted" ]; then
 	echo -e "\e[90m$(date +[%H:%M:%S]) \e[31m[\e[0mopen-runtimes\e[31m]\e[97m Code already extracted, skipping extraction. \e[0m"
 
 	start=$(awk '{print $1}' /proc/uptime)
 	shopt -s dotglob
+
+	# Clear stub files baked into the runtime image at this path. Some
+	# runtimes (e.g. Rust) ship a placeholder Cargo.toml + lib.rs here so
+	# their workspace compiles. Without this, `ln -s` would collide and
+	# force a full re-extraction on every cold start.
+	rm -rf /usr/local/server/src/function/*
+
 	symlink_failed=false
 	for item in /mnt/code/*; do
 		# Skip archive files and marker
@@ -19,20 +67,13 @@ if [ -f "/mnt/code/.extracted" ]; then
 		esac
 		ln -s "$item" /usr/local/server/src/function/ || symlink_failed=true
 	done
-	shopt -u dotglob
 
 	if [ "$symlink_failed" = true ]; then
 		echo -e "\e[90m$(date +[%H:%M:%S]) \e[31m[\e[0mopen-runtimes\e[31m]\e[97m Symlink failed, falling back to extraction. \e[0m"
-		rm -f /usr/local/server/src/function/*
-		if [ -f /mnt/code/code.tar ]; then
-			tar -xf /mnt/code/code.tar -C /usr/local/server/src/function
-		elif [ -f /mnt/code/code.tar.gz ] || [ -f /mnt/code/code.gz ]; then
-			tar -zxf /mnt/code/code.tar.gz -C /usr/local/server/src/function
-		else
-			echo -e "\e[90m$(date +[%H:%M:%S]) \e[31m[\e[0mopen-runtimes\e[31m]\e[97m Code archive not found. \e[0m"
-			exit 1
-		fi
+		rm -rf /usr/local/server/src/function/*
+		extract_code_archive /usr/local/server/src/function
 	fi
+	shopt -u dotglob
 
 	end=$(awk '{print $1}' /proc/uptime)
 	elapsed=$(awk "BEGIN{printf \"%.3f\", $end - $start}")
@@ -46,14 +87,7 @@ else
 
 	# Extract code from mounted volume to function folder
 	start=$(awk '{print $1}' /proc/uptime)
-	if [ -f /mnt/code/code.tar ]; then
-		tar -xf /mnt/code/code.tar -C /usr/local/server/src/function
-	elif [ -f /mnt/code/code.tar.gz ] || [ -f /mnt/code/code.gz ]; then
-		tar -zxf /mnt/code/code.tar.gz -C /usr/local/server/src/function
-	else
-		echo -e "\e[90m$(date +[%H:%M:%S]) \e[31m[\e[0mopen-runtimes\e[31m]\e[97m Code archive not found. \e[0m"
-		exit 1
-	fi
+	extract_code_archive /usr/local/server/src/function
 
 	end=$(awk '{print $1}' /proc/uptime)
 	elapsed=$(awk "BEGIN{printf \"%.3f\", $end - $start}")

--- a/helpers/extract-code.sh
+++ b/helpers/extract-code.sh
@@ -28,18 +28,26 @@ extract_archive() {
 	format=$(detect_archive_format "$archive")
 	case "$format" in
 	gzip) tar -xzf "$archive" -C "$dest" ;;
-	zstd) zstd -dc "$archive" | tar -xf - -C "$dest" ;;
+	# Subshell with pipefail so a zstd error (corrupt archive, missing
+	# binary) surfaces as a non-zero exit instead of being masked by tar
+	# choking on a truncated stream.
+	zstd) (set -o pipefail && zstd -dc "$archive" | tar -xf - -C "$dest") ;;
 	*) tar -xf "$archive" -C "$dest" ;;
 	esac
 }
 
-# Locate the build archive in /mnt/code and extract it to dest.
+# Locate the build archive in /mnt/code and extract it to dest. The build
+# always writes /mnt/code/code.tar.gz; code.tar and code.gz are accepted as
+# legacy fallbacks. Each branch passes the file that actually exists rather
+# than a hardcoded name.
 extract_code_archive() {
 	local dest="$1"
 	if [ -f /mnt/code/code.tar ]; then
 		extract_archive /mnt/code/code.tar "$dest"
-	elif [ -f /mnt/code/code.tar.gz ] || [ -f /mnt/code/code.gz ]; then
+	elif [ -f /mnt/code/code.tar.gz ]; then
 		extract_archive /mnt/code/code.tar.gz "$dest"
+	elif [ -f /mnt/code/code.gz ]; then
+		extract_archive /mnt/code/code.gz "$dest"
 	else
 		echo -e "\e[90m$(date +[%H:%M:%S]) \e[31m[\e[0mopen-runtimes\e[31m]\e[97m Code archive not found. \e[0m"
 		exit 1


### PR DESCRIPTION
## Summary

Two latent bugs in `helpers/extract-code.sh` combine to break every Rust v5 deployment when the runtime is started under a sidecar pre-extraction flow (e.g. Appwrite edge). Both ship in the shared helpers, so they affect every runtime image, but Rust is the only runtime where they actually fire today.

## The bugs

### 1. Pre-baked files at the symlink target

The Rust runtime image ships stub source files at `/usr/local/server/src/function/` — `Cargo.toml` and `lib.rs` — so the runtime's own Cargo workspace can compile. When the sidecar pre-extracts user code into `/mnt/code/` and writes `.extracted`, the per-item `ln -s` in this script tries to symlink `/mnt/code/Cargo.toml` over the stub:

```
ln: /usr/local/server/src/function/Cargo.toml: File exists
```

`ln` refuses to overwrite, the loop sets `symlink_failed=true`, and we fall through to extraction.

This is deterministic — it fires on every Rust cold start under sidecar mode — and any future runtime that pre-bakes files at this path will hit the same wall.

### 2. Fallback hardcoded gzip

The fallback ran `tar -zxf code.tar.gz`, but `helpers/select-compression.sh` picks the format by build size:

| size | format | actual archive |
|---|---|---|
| < 5MB | `none` | plain tar |
| 5–10MB | `gzip` | gzip |
| ≥ 10MB | `zstd` | zstd |

The filename is always `code.tar.gz` regardless of what's inside. So:

- A small Rust function (plain tar inside) → `tar: invalid magic / tar: short read`
- A large Rust function (zstd inside) → same error

Combined with bug 1, every Rust deployment hits the broken fallback and the pod never starts.

## The fix

**`helpers/extract-code.sh`:**

1. **Clear the function dir once before the symlink loop** (with `dotglob` on so hidden stubs go too). This makes the symlink path work for every runtime, including any future ones that pre-bake files here. No more cascade into the fallback for Rust.

2. **Detect compression by the first four magic bytes** (`1f 8b` → gzip, `28 b5 2f fd` → zstd, anything else → plain tar) and dispatch to the right decompressor. zstd uses `zstd -dc | tar -xf -` since BusyBox tar (Alpine default) has no `--use-compress-program`.

3. Refactor the inline tar logic into `extract_archive` / `extract_code_archive` so the marker path and the no-marker path share one implementation.

## Test plan

- [x] `bash -n helpers/extract-code.sh` — syntax check
- [x] `detect_archive_format` correctly identifies plain tar / gzip / zstd archives produced by `select-compression.sh`'s three branches
- [x] `extract_archive` extracts all three formats successfully
- [ ] Build a fresh `openruntimes/rust:v5-1.83` image with this change and verify a small (<5MB) function deploys cleanly under Appwrite edge (the original failing case: `tar: invalid magic / short read`)
- [ ] Verify a >10MB Rust function (zstd path) deploys cleanly
- [ ] Verify Node/Python/Bun runtimes still cold-start cleanly (regression check — they have empty `src/function/`, so the new pre-loop `rm -rf` is a no-op)
- [ ] Verify the no-marker path (legacy / non-sidecar) still works for all three compression formats