### PR TITLE
Fix Bun 1.0 arm64 image build

### DIFF
--- a/runtimes/bun/bun.dockerfile
+++ b/runtimes/bun/bun.dockerfile
@@ -1,5 +1,5 @@
 ENV OPEN_RUNTIMES_ENTRYPOINT=index.ts
 COPY package* /usr/local/server/
-RUN apk update && apk add bash npm nss font-noto ca-certificates python3 make g++ gcc git
+RUN apk update && apk add bash npm nss font-noto ca-certificates python3 make gcc git
 RUN npm install pnpm yarn modclean@2.1.2 -g
 RUN bun install && npm install --no-save --prefix /usr/local/server @vercel/nft@^0.29.2


### PR DESCRIPTION
## Summary
- remove `g++` from the Bun runtime Alpine package install
- keep `gcc`, `make`, `python3`, `git`, `modclean`, `@vercel/nft`, and the shared JavaScript overlay unchanged

## Why
The Bun 1.0 publish job fails on `linux/arm64` because `g++` pulls `musl-dev` in `oven/bun:1.0.36-alpine`. That conflicts with the image's existing `glibc` package, which owns `/usr/lib/libc.so`.

## Testing
- Reproduced the failure with `apk add ... g++ ...` on `oven/bun:1.0.36-alpine` for `linux/arm64`
- Verified `apk add bash npm nss font-noto ca-certificates python3 make gcc git` succeeds on `linux/arm64`
- Verified generated Bun 1.0 runtime image builds with `RUNTIME=bun VERSION=1.0 bash ci_release.sh && docker buildx build --platform linux/arm64 --progress=plain --build-arg VERSION=openruntimes/bun:v5-1.0-local ./runtimes/.test`
