### PR TITLE
Fix Bun arm64 glibc package conflict

### DIFF
--- a/runtimes/bun/bun.dockerfile
+++ b/runtimes/bun/bun.dockerfile
@@ -5,5 +5,5 @@ RUN apk update \
   && APK_ADD_FLAGS="" \
   && if apk info -e glibc > /dev/null 2>&1; then APK_ADD_FLAGS="--force-overwrite"; fi \
   && apk add ${APK_ADD_FLAGS} bash npm nss font-noto ca-certificates python3 make g++ gcc git
-RUN npm install pnpm yarn modclean@2.1.2 -g
+RUN npm install pnpm@9.15.9 yarn modclean@2.1.2 -g
 RUN bun install && npm install --no-save --prefix /usr/local/server @vercel/nft@^0.29.2

--- a/runtimes/bun/bun.dockerfile
+++ b/runtimes/bun/bun.dockerfile
@@ -1,5 +1,9 @@
 ENV OPEN_RUNTIMES_ENTRYPOINT=index.ts
 COPY package* /usr/local/server/
-RUN apk update && apk add bash npm nss font-noto ca-certificates python3 make g++ gcc git
+# Bun 1.0 arm64 includes glibc, whose /usr/lib/libc.so conflicts with musl-dev from g++.
+RUN apk update \
+  && APK_ADD_FLAGS="" \
+  && if apk info -e glibc > /dev/null 2>&1; then APK_ADD_FLAGS="--force-overwrite"; fi \
+  && apk add ${APK_ADD_FLAGS} bash npm nss font-noto ca-certificates python3 make g++ gcc git
 RUN npm install pnpm yarn modclean@2.1.2 -g
 RUN bun install && npm install --no-save --prefix /usr/local/server @vercel/nft@^0.29.2


### PR DESCRIPTION
## What changed
- Scope `apk add --force-overwrite` to Bun images that already include the `glibc` APK.
- Pin the Bun runtime's global `pnpm` install to `9.15.9`, matching the Node runtime pin.
- Add a comment explaining the Bun 1.0 arm64 `glibc` / `musl-dev` ownership conflict for `/usr/lib/libc.so`.

## Regression from #485
This issue was introduced by https://github.com/open-runtimes/open-runtimes/pull/485.

Before #485, `runtimes/bun/bun.dockerfile` installed only the basic runtime packages:

```dockerfile
apk add bash npm nss font-noto ca-certificates
```

PR #485 added the native build toolchain needed for Bun SSR/native module installs:

```dockerfile
apk add bash npm nss font-noto ca-certificates python3 make g++ gcc git
```

That made `bun-1.0` fail on `linux/arm64`: `g++` pulls Alpine's `musl-dev`, and `musl-dev` installs `/usr/lib/libc.so`. The `oven/bun:1.0.36-alpine` arm64 base image already has the `glibc` APK installed, and that package already owns `/usr/lib/libc.so`, so APK aborted with:

```text
ERROR: musl-dev-1.2.4-r3: trying to overwrite usr/lib/libc.so owned by glibc-2.26-r1
```

This PR keeps the #485 toolchain addition, but allows the expected overwrite only when the base image already contains the conflicting `glibc` package.

## CI fix
After the APK conflict was fixed, the `bun-1.0` test pipeline exposed another issue from the same Dockerfile install step: `npm install pnpm yarn modclean@2.1.2 -g` was installing latest `pnpm`. Latest `pnpm` requires newer Node features than the `nodejs-current` package available in Alpine 3.18 for Bun 1.0 (`v20.8.1`), so the tools check failed with:

```text
Error [ERR_UNKNOWN_BUILTIN_MODULE]: No such built-in module: node:sqlite
```

Pinning `pnpm@9.15.9` keeps the tool compatible with the Node version in `bun-1.0` and matches the existing pin in `runtimes/node/node.dockerfile`.

## Testing
- `RUNTIME=bun VERSION=1.0 ENTRYPOINT=index.ts INSTALL_COMMAND= START_COMMAND= bash ./ci_release.sh`
- `docker buildx build --platform linux/arm64 --progress=plain -t open-runtimes/bun-1.0-arm64-check ./runtimes/.test`
- `docker run --rm --platform linux/arm64 open-runtimes/bun-1.0-arm64-check sh -lc 'bun --version && node --version && npm --version && npx --version && pnpm --version && yarn --version && python3 --version && make --version | head -n 1 && git --version && g++ --version | head -n 1 && gcc --version | head -n 1 && modclean --version && apk info -W /usr/lib/libc.so'`
- `docker build --platform linux/x86_64 -t open-runtimes/bun-1.0-x86-check ./runtimes/.test`
- `docker run --rm --platform linux/x86_64 open-runtimes/bun-1.0-x86-check sh -lc 'bun --version && node --version && npm --version && npx --version && pnpm --version && yarn --version && python3 --version && make --version | head -n 1 && git --version && g++ --version | head -n 1 && gcc --version | head -n 1 && modclean --version'`
