### PR TITLE
Feat: add Dart 3.12 runtime

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -82,6 +82,7 @@ jobs:
                 { ID: "python-ml-3.11", RUNTIME: "python", VERSION: "ml-3.11", IMAGE: "openruntimes/python-ml:v5-3.11", ARCH: "linux/amd64,linux/arm64" },
 
                 // Dart
+                { ID: "dart-3.12", RUNTIME: "dart", VERSION: "3.12", IMAGE: "openruntimes/dart:v5-3.12", ARCH: "linux/amd64,linux/arm64" },
                 { ID: "dart-3.11", RUNTIME: "dart", VERSION: "3.11", IMAGE: "openruntimes/dart:v5-3.11", ARCH: "linux/amd64,linux/arm64" },
                 { ID: "dart-3.10", RUNTIME: "dart", VERSION: "3.10", IMAGE: "openruntimes/dart:v5-3.10", ARCH: "linux/amd64,linux/arm64" },
                 { ID: "dart-3.9", RUNTIME: "dart", VERSION: "3.9", IMAGE: "openruntimes/dart:v5-3.9", ARCH: "linux/amd64,linux/arm64" },

--- a/ci/runtimes.toml
+++ b/ci/runtimes.toml
@@ -56,6 +56,7 @@ test = "Serverless/PythonML.php"
 [dart]
 entry = "lib/tests.dart"
 versions = [
+    "3.12",
     "3.11",
     "3.10",
     "3.9",

--- a/runtimes/dart/versions/3.12/Dockerfile
+++ b/runtimes/dart/versions/3.12/Dockerfile
@@ -1,0 +1,6 @@
+# syntax = devthefuture/dockerfile-x:1.4.2
+FROM dart:3.12.0
+
+INCLUDE ./base-before
+INCLUDE ./dart
+INCLUDE ./base-after

--- a/runtimes/dart/versions/3.12/prepare/pubspec.yaml
+++ b/runtimes/dart/versions/3.12/prepare/pubspec.yaml
@@ -1,0 +1,11 @@
+name: prepare
+description: Prepare runtime with package details and import fixes
+version: 1.0.0
+publish_to: none
+# homepage: https://www.example.com
+
+environment:
+  sdk: '>=3.0.0 <4.0.0'
+
+dependencies:
+  pubspec: ^2.3.0


### PR DESCRIPTION
Adds Dart 3.12.0 (stable, released 2026-05-18) as a new runtime version.

Mirrors the structure of the existing Dart 3.11 runtime:
- New `runtimes/dart/versions/3.12/` (Dockerfile pinned to `dart:3.12.0`, prepare/pubspec.yaml copied from 3.11)
- New matrix entry in `.github/workflows/publish.yaml`
- New version in `ci/runtimes.toml`