### PR TITLE
Feat: add Flutter 3.44 runtime

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -35,6 +35,7 @@ jobs:
             const matrix = {
               include: [
                 // Flutter
+                { ID: "flutter-3.44", RUNTIME: "flutter", VERSION: "3.44", IMAGE: "openruntimes/flutter:v5-3.44", ARCH: "linux/amd64,linux/arm64" },
                 { ID: "flutter-3.41", RUNTIME: "flutter", VERSION: "3.41", IMAGE: "openruntimes/flutter:v5-3.41", ARCH: "linux/amd64,linux/arm64" },
                 { ID: "flutter-3.24", RUNTIME: "flutter", VERSION: "3.24", IMAGE: "openruntimes/flutter:v5-3.24", ARCH: "linux/amd64,linux/arm64" },
                 { ID: "flutter-3.27", RUNTIME: "flutter", VERSION: "3.27", IMAGE: "openruntimes/flutter:v5-3.27", ARCH: "linux/amd64,linux/arm64" },

--- a/ci/runtimes.toml
+++ b/ci/runtimes.toml
@@ -76,7 +76,7 @@ test = "Serverless/Dart.php"
 
 [flutter]
 report_size = false
-versions = ["3.41", "3.38", "3.35", "3.32", "3.29", "3.27", "3.24"]
+versions = ["3.44", "3.41", "3.38", "3.35", "3.32", "3.29", "3.27", "3.24"]
 commands = { install = "flutter build web", start = "bash helpers/server.sh" }
 formatter = { prepare = "echo \"Using native formatter\"", check = "dart format -o none --set-exit-if-changed .", write = "dart format ." }
 test = "CSR/Flutter.php"

--- a/runtimes/flutter/versions/3.44/Dockerfile
+++ b/runtimes/flutter/versions/3.44/Dockerfile
@@ -1,0 +1,9 @@
+# syntax = devthefuture/dockerfile-x:1.4.2
+FROM ghcr.io/adrianjagielak/flutter:3.44.0
+
+INCLUDE ./base-before
+INCLUDE ./flutter
+INCLUDE ./base-after
+
+# Enable web platform
+RUN flutter config --enable-web


### PR DESCRIPTION
Adds Flutter 3.44.0 (stable) as a new runtime version.

## Docker registry change

The Flutter image registry this repo has been using, `ghcr.io/cirruslabs/flutter` (from [`cirruslabs/docker-images-flutter`](https://github.com/cirruslabs/docker-images-flutter)), is now deprecated — Cirrus Labs wound down image hosting in May 2026 following an acquisition, and their last published image is `3.41.9`. No new Flutter versions will be released there.

This PR pins the new 3.44 runtime to `ghcr.io/adrianjagielak/flutter:3.44.0`, sourced from [`adrianjagielak/docker-images-flutter`](https://github.com/adrianjagielak/docker-images-flutter) — the recommended community continuation of the cirruslabs project. The upstream README positions it as drop-in compatible (same tag scheme, same `linux/amd64` + `linux/arm64` architectures), so the new Dockerfile follows the exact same pattern as the existing 3.41 runtime — only the registry prefix changes.

The existing Flutter version directories (3.24 → 3.41) continue to use the cirruslabs registry and are intentionally left untouched in this PR. A follow-up can migrate them in bulk if desired.

## Changes

- New `runtimes/flutter/versions/3.44/Dockerfile` (web platform enabled, same INCLUDE pattern as 3.41)
- New `flutter-3.44` matrix entry in `.github/workflows/publish.yaml`
- New `"3.44"` version in `ci/runtimes.toml`
