### PR TITLE
Add SquashFS build cache support

### DIFF
--- a/base-before.dockerfile
+++ b/base-before.dockerfile
@@ -7,9 +7,9 @@ ENV OPEN_RUNTIMES_HEADERS="{}"
 
 RUN <<EOR
     if [ -f /etc/alpine-release ]; then
-        apk add util-linux zstd
+        apk add util-linux zstd squashfs-tools
     else
-        apt-get update && apt-get install -y util-linux zstd
+        apt-get update && apt-get install -y util-linux zstd squashfs-tools
     fi
 EOR
 

--- a/ci_tests.sh
+++ b/ci_tests.sh
@@ -149,7 +149,7 @@ fi
 
 # Tools test
 echo "Testing tools ..."
-REQUIRED_TOOLS="tar --help && unzip --help"
+REQUIRED_TOOLS="tar --help && unzip --help && command -v mksquashfs && command -v unsquashfs"
 docker run \
 	--platform linux/x86_64 \
 	--name open-runtimes-test-tools \

--- a/ci_tests.sh
+++ b/ci_tests.sh
@@ -149,7 +149,7 @@ fi
 
 # Tools test
 echo "Testing tools ..."
-REQUIRED_TOOLS="tar --help && unzip --help && mksquashfs -help && unsquashfs -help"
+REQUIRED_TOOLS="tar --help && unzip --help && tmp=\$(mktemp -d) && mkdir -p \"\$tmp/src\" && mksquashfs \"\$tmp/src\" \"\$tmp/test.sqfs\" -noappend -quiet -no-progress && unsquashfs -s \"\$tmp/test.sqfs\" && rm -rf \"\$tmp\""
 docker run \
 	--platform linux/x86_64 \
 	--name open-runtimes-test-tools \

--- a/ci_tests.sh
+++ b/ci_tests.sh
@@ -149,7 +149,7 @@ fi
 
 # Tools test
 echo "Testing tools ..."
-REQUIRED_TOOLS="tar --help && unzip --help && command -v mksquashfs && command -v unsquashfs"
+REQUIRED_TOOLS="tar --help && unzip --help && mksquashfs -help && unsquashfs -help"
 docker run \
 	--platform linux/x86_64 \
 	--name open-runtimes-test-tools \

--- a/ci_tests.sh
+++ b/ci_tests.sh
@@ -149,7 +149,7 @@ fi
 
 # Tools test
 echo "Testing tools ..."
-REQUIRED_TOOLS="tar --help && unzip --help && tmp=\$(mktemp -d) && mkdir -p \"\$tmp/src\" && mksquashfs \"\$tmp/src\" \"\$tmp/test.sqfs\" -noappend -quiet -no-progress && unsquashfs -s \"\$tmp/test.sqfs\" && rm -rf \"\$tmp\""
+REQUIRED_TOOLS="tar --help && unzip --help && command -v mksquashfs && command -v unsquashfs"
 docker run \
 	--platform linux/x86_64 \
 	--name open-runtimes-test-tools \

--- a/ci_tests.sh
+++ b/ci_tests.sh
@@ -149,7 +149,7 @@ fi
 
 # Tools test
 echo "Testing tools ..."
-REQUIRED_TOOLS="tar --help && unzip --help && command -v mksquashfs && command -v unsquashfs"
+REQUIRED_TOOLS="command -v tar && command -v unzip && command -v mksquashfs && command -v unsquashfs"
 docker run \
 	--platform linux/x86_64 \
 	--name open-runtimes-test-tools \

--- a/helpers/build-cache.sh
+++ b/helpers/build-cache.sh
@@ -34,8 +34,11 @@ set -e
 
 if [ "$status" -eq 0 ] && [ -d "$CACHE_ROOT" ]; then
 	processors=$(nproc 2>/dev/null || echo 1)
-	mksquashfs "$CACHE_ROOT" /cache/stores.sqfs -comp lz4 -b 1M -noappend -no-xattrs -no-progress -processors "$processors"
-	echo '[build cache] Saved.'
+	if mksquashfs "$CACHE_ROOT" /cache/stores.sqfs -comp lz4 -b 1M -noappend -no-xattrs -no-progress -processors "$processors"; then
+		echo '[build cache] Saved.'
+	else
+		echo '[build cache] Warning: failed to save cache, build result preserved.'
+	fi
 fi
 
 exit "$status"

--- a/helpers/build-cache.sh
+++ b/helpers/build-cache.sh
@@ -22,7 +22,11 @@ if [ -f /cache/stores.sqfs ]; then
 	echo '[build cache] Hit.'
 	rm -rf "$CACHE_ROOT"
 	mkdir -p "$CACHE_ROOT"
-	unsquashfs -q -f -d "$CACHE_ROOT" /cache/stores.sqfs
+	if ! unsquashfs -q -f -d "$CACHE_ROOT" /cache/stores.sqfs; then
+		echo '[build cache] Warning: failed to restore cache, starting fresh.'
+		rm -rf "$CACHE_ROOT"
+		mkdir -p "$CACHE_ROOT"
+	fi
 else
 	echo '[build cache] Miss.'
 fi

--- a/helpers/build-cache.sh
+++ b/helpers/build-cache.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# Fail build if any command fails
+set -e
+shopt -s dotglob
+
+if ! command -v unsquashfs >/dev/null 2>&1 || ! command -v mksquashfs >/dev/null 2>&1; then
+	echo '[build cache] Missing squashfs-tools in runtime image.'
+	exit 1
+fi
+
+CACHE_ROOT=/usr/local/cache/build
+mkdir -p "$CACHE_ROOT"
+
+export npm_config_cache="$CACHE_ROOT/npm"
+export YARN_CACHE_FOLDER="$CACHE_ROOT/yarn"
+export npm_config_store_dir="$CACHE_ROOT/pnpm"
+export XDG_CACHE_HOME="$CACHE_ROOT/xdg-cache"
+export XDG_STATE_HOME="$CACHE_ROOT/xdg-state"
+export BUN_INSTALL_CACHE_DIR="$CACHE_ROOT/bun"
+
+if [ -f /cache/stores.sqfs ]; then
+	echo '[build cache] Hit.'
+	rm -rf "$CACHE_ROOT"
+	mkdir -p "$CACHE_ROOT"
+	unsquashfs -q -f -d "$CACHE_ROOT" /cache/stores.sqfs
+else
+	echo '[build cache] Miss.'
+fi
+
+set +e
+bash /cache/build-command.sh
+status=$?
+set -e
+
+if [ "$status" -eq 0 ] && [ -d "$CACHE_ROOT" ]; then
+	processors=$(nproc 2>/dev/null || echo 1)
+	mksquashfs "$CACHE_ROOT" /cache/stores.sqfs -comp lz4 -b 1M -noappend -no-xattrs -no-progress -processors "$processors"
+	echo '[build cache] Saved.'
+fi
+
+exit "$status"

--- a/helpers/build-cache.sh
+++ b/helpers/build-cache.sh
@@ -27,8 +27,6 @@ if [ -f /cache/stores.sqfs ]; then
 		rm -rf "$CACHE_ROOT"
 		mkdir -p "$CACHE_ROOT"
 	fi
-else
-	echo '[build cache] Miss.'
 fi
 
 set +e


### PR DESCRIPTION
## Summary
- install squashfs-tools in the shared runtime base for Alpine and Debian/Ubuntu images
- verify tar, unzip, mksquashfs, and unsquashfs are present in the global tools smoke test
- add helpers/build-cache.sh so executor can invoke build cache restore/save from runtime images
- restore /cache/stores.sqfs into /usr/local/cache/build when available, then run /cache/build-command.sh
- save package manager caches back to /cache/stores.sqfs after successful builds
- treat cache restore/save failures as cache failures, not build command failures

## Testing
- bash -n helpers/build-cache.sh
- confirmed helpers/build-cache.sh contains no apk/apt install commands
- confirmed base-before.dockerfile installs squashfs-tools for both apk and apt-get branches
- bash -n ci_tests.sh
- bash tests.sh node: tools smoke test passed; full suite later failed at unrelated Tests\Serverless\Node::testHeadlessBrowser with 500 vs 200
- focused Dart image build confirmed Debian/Ubuntu branch installs squashfs-tools and exposes mksquashfs/unsquashfs