### PR TITLE
Hide mksquashfs output on success

### DIFF
--- a/helpers/build-cache.sh
+++ b/helpers/build-cache.sh
@@ -36,9 +36,13 @@ set -e
 
 if [ "$status" -eq 0 ] && [ -d "$CACHE_ROOT" ]; then
 	processors=$(nproc 2>/dev/null || echo 1)
-	if mksquashfs "$CACHE_ROOT" /cache/stores.sqfs -comp lz4 -b 1M -noappend -no-xattrs -no-progress -processors "$processors" >/dev/null 2>&1; then
+	mksquashfs_log=$(mktemp)
+	if mksquashfs "$CACHE_ROOT" /cache/stores.sqfs -comp lz4 -b 1M -noappend -no-xattrs -no-progress -processors "$processors" >"$mksquashfs_log" 2>&1; then
+		rm -f "$mksquashfs_log"
 		echo '[build cache] Saved.'
 	else
+		cat "$mksquashfs_log"
+		rm -f "$mksquashfs_log"
 		echo '[build cache] Warning: failed to save cache, build result preserved.'
 	fi
 fi

--- a/helpers/build-cache.sh
+++ b/helpers/build-cache.sh
@@ -36,7 +36,7 @@ set -e
 
 if [ "$status" -eq 0 ] && [ -d "$CACHE_ROOT" ]; then
 	processors=$(nproc 2>/dev/null || echo 1)
-	if mksquashfs "$CACHE_ROOT" /cache/stores.sqfs -comp lz4 -b 1M -noappend -no-xattrs -no-progress -processors "$processors"; then
+	if mksquashfs "$CACHE_ROOT" /cache/stores.sqfs -comp lz4 -b 1M -noappend -no-xattrs -no-progress -processors "$processors" >/dev/null 2>&1; then
 		echo '[build cache] Saved.'
 	else
 		echo '[build cache] Warning: failed to save cache, build result preserved.'

--- a/helpers/build-cache.sh
+++ b/helpers/build-cache.sh
@@ -36,13 +36,10 @@ set -e
 
 if [ "$status" -eq 0 ] && [ -d "$CACHE_ROOT" ]; then
 	processors=$(nproc 2>/dev/null || echo 1)
-	mksquashfs_log=$(mktemp)
-	if mksquashfs "$CACHE_ROOT" /cache/stores.sqfs -comp lz4 -b 1M -noappend -no-xattrs -no-progress -processors "$processors" >"$mksquashfs_log" 2>&1; then
-		rm -f "$mksquashfs_log"
+	if mksquashfs_output=$(mksquashfs "$CACHE_ROOT" /cache/stores.sqfs -comp lz4 -b 1M -noappend -no-xattrs -no-progress -processors "$processors" 2>&1); then
 		echo '[build cache] Saved.'
 	else
-		cat "$mksquashfs_log"
-		rm -f "$mksquashfs_log"
+		printf '%s\n' "$mksquashfs_output"
 		echo '[build cache] Warning: failed to save cache, build result preserved.'
 	fi
 fi


### PR DESCRIPTION
## Summary
- Capture mksquashfs output while saving the build cache
- Keep successful cache saves quiet except for the existing saved message
- Print captured mksquashfs output when cache saving fails

## Testing
- bash -n helpers/build-cache.sh