### PR TITLE
Overwrite existing build cache artifact

### DIFF
--- a/helpers/build-cache-save.sh
+++ b/helpers/build-cache-save.sh
@@ -10,6 +10,8 @@ log() {
 tmp_artifact="${OPEN_RUNTIMES_BUILD_CACHE_ARTIFACT}.tmp"
 rm -f "$tmp_artifact"
 artifact_dir="${OPEN_RUNTIMES_BUILD_CACHE_ARTIFACT%/*}"
+output_artifact="$tmp_artifact"
+promote_artifact="true"
 
 if ! command -v mksquashfs >/dev/null 2>&1; then
 	log 'Build cache warning: missing mksquashfs, continuing without cache save.'
@@ -34,9 +36,14 @@ else
 	mksquashfs_cmd=(mksquashfs)
 fi
 
-if "${mksquashfs_cmd[@]}" "$OPEN_RUNTIMES_BUILD_CACHE_ROOT" "$tmp_artifact" -comp lz4 -b 1M -noappend -no-xattrs -no-progress -processors "$processors" >/dev/null 2>&1; then
+if [ -f "$OPEN_RUNTIMES_BUILD_CACHE_ARTIFACT" ] && [ -z "${OPEN_RUNTIMES_BUILD_CACHE_MAX_SIZE_BYTES:-}" ]; then
+	output_artifact="$OPEN_RUNTIMES_BUILD_CACHE_ARTIFACT"
+	promote_artifact="false"
+fi
+
+if "${mksquashfs_cmd[@]}" "$OPEN_RUNTIMES_BUILD_CACHE_ROOT" "$output_artifact" -comp lz4 -b 1M -noappend -no-xattrs -no-progress -processors "$processors" >/dev/null 2>&1; then
 	if [ -n "${OPEN_RUNTIMES_BUILD_CACHE_MAX_SIZE_BYTES:-}" ]; then
-		size=$(wc -c <"$tmp_artifact" | tr -d ' ')
+		size=$(wc -c <"$output_artifact" | tr -d ' ')
 		if [ "$size" -gt "$OPEN_RUNTIMES_BUILD_CACHE_MAX_SIZE_BYTES" ]; then
 			rm -f "$tmp_artifact"
 			log 'Build cache save skipped: artifact too large.'
@@ -44,7 +51,9 @@ if "${mksquashfs_cmd[@]}" "$OPEN_RUNTIMES_BUILD_CACHE_ROOT" "$tmp_artifact" -com
 		fi
 	fi
 
-	if mv -f "$tmp_artifact" "$OPEN_RUNTIMES_BUILD_CACHE_ARTIFACT"; then
+	if [ "$promote_artifact" = "false" ]; then
+		log 'Build cache saved.'
+	elif mv "$tmp_artifact" "$OPEN_RUNTIMES_BUILD_CACHE_ARTIFACT"; then
 		log 'Build cache saved.'
 	else
 		rm -f "$tmp_artifact"

--- a/helpers/build-cache-save.sh
+++ b/helpers/build-cache-save.sh
@@ -10,8 +10,6 @@ log() {
 tmp_artifact="${OPEN_RUNTIMES_BUILD_CACHE_ARTIFACT}.tmp"
 rm -f "$tmp_artifact"
 artifact_dir="${OPEN_RUNTIMES_BUILD_CACHE_ARTIFACT%/*}"
-output_artifact="$tmp_artifact"
-promote_artifact="true"
 
 if ! command -v mksquashfs >/dev/null 2>&1; then
 	log 'Build cache warning: missing mksquashfs, continuing without cache save.'
@@ -36,14 +34,9 @@ else
 	mksquashfs_cmd=(mksquashfs)
 fi
 
-if [ -f "$OPEN_RUNTIMES_BUILD_CACHE_ARTIFACT" ] && [ -z "${OPEN_RUNTIMES_BUILD_CACHE_MAX_SIZE_BYTES:-}" ]; then
-	output_artifact="$OPEN_RUNTIMES_BUILD_CACHE_ARTIFACT"
-	promote_artifact="false"
-fi
-
-if "${mksquashfs_cmd[@]}" "$OPEN_RUNTIMES_BUILD_CACHE_ROOT" "$output_artifact" -comp lz4 -b 1M -noappend -no-xattrs -no-progress -processors "$processors" >/dev/null 2>&1; then
+if "${mksquashfs_cmd[@]}" "$OPEN_RUNTIMES_BUILD_CACHE_ROOT" "$tmp_artifact" -comp lz4 -b 1M -noappend -no-xattrs -no-progress -processors "$processors" >/dev/null 2>&1; then
 	if [ -n "${OPEN_RUNTIMES_BUILD_CACHE_MAX_SIZE_BYTES:-}" ]; then
-		size=$(wc -c <"$output_artifact" | tr -d ' ')
+		size=$(wc -c <"$tmp_artifact" | tr -d ' ')
 		if [ "$size" -gt "$OPEN_RUNTIMES_BUILD_CACHE_MAX_SIZE_BYTES" ]; then
 			rm -f "$tmp_artifact"
 			log 'Build cache save skipped: artifact too large.'
@@ -51,9 +44,7 @@ if "${mksquashfs_cmd[@]}" "$OPEN_RUNTIMES_BUILD_CACHE_ROOT" "$output_artifact" -
 		fi
 	fi
 
-	if [ "$promote_artifact" = "false" ]; then
-		log 'Build cache saved.'
-	elif mv "$tmp_artifact" "$OPEN_RUNTIMES_BUILD_CACHE_ARTIFACT"; then
+	if mv -f "$tmp_artifact" "$OPEN_RUNTIMES_BUILD_CACHE_ARTIFACT"; then
 		log 'Build cache saved.'
 	else
 		rm -f "$tmp_artifact"

--- a/helpers/build-cache-save.sh
+++ b/helpers/build-cache-save.sh
@@ -44,7 +44,7 @@ if "${mksquashfs_cmd[@]}" "$OPEN_RUNTIMES_BUILD_CACHE_ROOT" "$tmp_artifact" -com
 		fi
 	fi
 
-	if mv "$tmp_artifact" "$OPEN_RUNTIMES_BUILD_CACHE_ARTIFACT"; then
+	if mv -f "$tmp_artifact" "$OPEN_RUNTIMES_BUILD_CACHE_ARTIFACT"; then
 		log 'Build cache saved.'
 	else
 		rm -f "$tmp_artifact"

--- a/tests/BuildCache.php
+++ b/tests/BuildCache.php
@@ -133,7 +133,7 @@ class BuildCache extends TestCase
         \file_put_contents($this->cacheRoot() . '/store', 'cache');
         \file_put_contents($this->artifact(), 'old');
         $bin = $this->createBinDir([
-            'mksquashfs' => "#!/bin/sh\nprintf new > \"$2\"\nexit 0\n",
+            'mksquashfs' => "#!/bin/sh\nif [ \"\$2\" != " . \escapeshellarg($this->artifact()) . " ]; then exit 2; fi\nprintf new > \"\$2\"\nexit 0\n",
         ]);
 
         $result = $this->runScript('build-cache-save.sh', $bin);

--- a/tests/BuildCache.php
+++ b/tests/BuildCache.php
@@ -133,7 +133,7 @@ class BuildCache extends TestCase
         \file_put_contents($this->cacheRoot() . '/store', 'cache');
         \file_put_contents($this->artifact(), 'old');
         $bin = $this->createBinDir([
-            'mksquashfs' => "#!/bin/sh\nif [ \"\$2\" != " . \escapeshellarg($this->artifact()) . " ]; then exit 2; fi\nprintf new > \"\$2\"\nexit 0\n",
+            'mksquashfs' => "#!/bin/sh\nprintf new > \"$2\"\nexit 0\n",
         ]);
 
         $result = $this->runScript('build-cache-save.sh', $bin);
@@ -141,6 +141,23 @@ class BuildCache extends TestCase
         self::assertSame(0, $result['code']);
         $this->assertBuildCacheLogContains('Build cache saved.', $result['output']);
         self::assertSame('new', \file_get_contents($this->artifact()));
+        self::assertFileDoesNotExist($this->artifact() . '.tmp');
+    }
+
+    public function testFailedSavePreservesExistingArtifact(): void
+    {
+        \mkdir($this->cacheRoot(), 0777, true);
+        \file_put_contents($this->cacheRoot() . '/store', 'cache');
+        \file_put_contents($this->artifact(), 'old');
+        $bin = $this->createBinDir([
+            'mksquashfs' => "#!/bin/sh\nprintf corrupt > \"$2\"\nexit 1\n",
+        ]);
+
+        $result = $this->runScript('build-cache-save.sh', $bin);
+
+        self::assertSame(0, $result['code']);
+        $this->assertBuildCacheLogContains('Build cache warning: failed to save cache, build result preserved.', $result['output']);
+        self::assertSame('old', \file_get_contents($this->artifact()));
         self::assertFileDoesNotExist($this->artifact() . '.tmp');
     }
 

--- a/tests/BuildCache.php
+++ b/tests/BuildCache.php
@@ -33,7 +33,7 @@ class BuildCache extends TestCase
         $result = $this->runScript('build-cache-restore.sh', $bin);
 
         self::assertSame(0, $result['code']);
-        self::assertStringContainsString('Build cache miss.', $result['output']);
+        $this->assertBuildCacheLogContains('Build cache miss.', $result['output']);
     }
 
     public function testRestoreWithMissingUnsquashfsExitsZero(): void
@@ -41,7 +41,7 @@ class BuildCache extends TestCase
         $result = $this->runScript('build-cache-restore.sh', $this->createBinDir());
 
         self::assertSame(0, $result['code']);
-        self::assertStringContainsString('missing unsquashfs', $result['output']);
+        $this->assertBuildCacheLogContains('Build cache warning: missing unsquashfs, continuing without cache restore.', $result['output']);
     }
 
     public function testRestoreWithCorruptArtifactExitsZeroAndClearsPartialCacheRoot(): void
@@ -56,7 +56,7 @@ class BuildCache extends TestCase
         $result = $this->runScript('build-cache-restore.sh', $bin);
 
         self::assertSame(0, $result['code']);
-        self::assertStringContainsString('failed to restore cache', $result['output']);
+        $this->assertBuildCacheLogContains('Build cache warning: failed to restore cache, starting fresh.', $result['output']);
         self::assertStringNotContainsString('squashfs stdout', $result['output']);
         self::assertStringNotContainsString('squashfs stderr', $result['output']);
         self::assertDirectoryExists($this->cacheRoot());
@@ -70,7 +70,7 @@ class BuildCache extends TestCase
         $result = $this->runScript('build-cache-save.sh', $this->createBinDir());
 
         self::assertSame(0, $result['code']);
-        self::assertStringContainsString('missing mksquashfs', $result['output']);
+        $this->assertBuildCacheLogContains('Build cache warning: missing mksquashfs, continuing without cache save.', $result['output']);
     }
 
     public function testSaveWithMissingCacheRootExitsZero(): void
@@ -80,7 +80,7 @@ class BuildCache extends TestCase
         $result = $this->runScript('build-cache-save.sh', $bin);
 
         self::assertSame(0, $result['code']);
-        self::assertStringContainsString('Build cache save skipped: cache root missing.', $result['output']);
+        $this->assertBuildCacheLogContains('Build cache save skipped: cache root missing.', $result['output']);
     }
 
     public function testSaveWithMissingArtifactDirectoryExitsZero(): void
@@ -92,7 +92,7 @@ class BuildCache extends TestCase
         $result = $this->runScript('build-cache-save.sh', $bin);
 
         self::assertSame(0, $result['code']);
-        self::assertStringContainsString('Build cache save skipped: artifact directory missing.', $result['output']);
+        $this->assertBuildCacheLogContains('Build cache save skipped: artifact directory missing.', $result['output']);
     }
 
     public function testSaveFailureExitsZeroAndDeletesTemporaryArtifact(): void
@@ -105,7 +105,7 @@ class BuildCache extends TestCase
         $result = $this->runScript('build-cache-save.sh', $bin);
 
         self::assertSame(0, $result['code']);
-        self::assertStringContainsString('failed to save cache', $result['output']);
+        $this->assertBuildCacheLogContains('Build cache warning: failed to save cache, build result preserved.', $result['output']);
         self::assertFileDoesNotExist($this->artifact() . '.tmp');
     }
 
@@ -120,7 +120,7 @@ class BuildCache extends TestCase
         $result = $this->runScript('build-cache-save.sh', $bin);
 
         self::assertSame(0, $result['code']);
-        self::assertStringContainsString('Build cache saved.', $result['output']);
+        $this->assertBuildCacheLogContains('Build cache saved.', $result['output']);
         self::assertStringNotContainsString('squashfs stdout', $result['output']);
         self::assertStringNotContainsString('squashfs stderr', $result['output']);
         self::assertFileExists($this->artifact());
@@ -139,7 +139,7 @@ class BuildCache extends TestCase
         $result = $this->runScript('build-cache-save.sh', $bin);
 
         self::assertSame(0, $result['code']);
-        self::assertStringContainsString('failed to save cache', $result['output']);
+        $this->assertBuildCacheLogContains('Build cache warning: failed to save cache, build result preserved.', $result['output']);
         self::assertFileDoesNotExist($this->artifact());
         self::assertFileDoesNotExist($this->artifact() . '.tmp');
     }
@@ -163,7 +163,7 @@ class BuildCache extends TestCase
         );
 
         self::assertSame(0, $result['code']);
-        self::assertStringContainsString('failed to save cache', $result['output']);
+        $this->assertBuildCacheLogContains('Build cache warning: failed to save cache, build result preserved.', $result['output']);
     }
 
     public function testBuildLifecycleRunsCacheAutomaticallyInBeforeAndAfterBuild(): void
@@ -205,7 +205,7 @@ class BuildCache extends TestCase
 
         self::assertSame(0, $save['code']);
         self::assertSame(0, $restore['code']);
-        self::assertStringContainsString('Build cache hit.', $restore['output']);
+        $this->assertBuildCacheLogContains('Build cache hit.', $restore['output']);
         self::assertSame('restored', \file_get_contents($this->cacheRoot() . '/store'));
     }
 
@@ -235,6 +235,19 @@ class BuildCache extends TestCase
     private function runScript(string $script, string $bin, array $env = []): array
     {
         return $this->runShell('/bin/bash ' . \escapeshellarg($this->helpers . '/' . $script), $bin, $env);
+    }
+
+    private function assertBuildCacheLogContains(string $message, string $output): void
+    {
+        $output = $this->stripAnsi($output);
+
+        self::assertStringContainsString('[open-runtimes]', $output);
+        self::assertStringContainsString($message, $output);
+    }
+
+    private function stripAnsi(string $output): string
+    {
+        return \preg_replace('/(?:\x1B|\\\\e)\[[0-9;]*m/', '', $output) ?? $output;
     }
 
     private function runShell(string $command, ?string $bin = null, array $env = []): array

--- a/tests/BuildCache.php
+++ b/tests/BuildCache.php
@@ -109,7 +109,7 @@ class BuildCache extends TestCase
         self::assertFileDoesNotExist($this->artifact() . '.tmp');
     }
 
-    public function testSuccessfulSaveWritesFinalArtifactAtomically(): void
+    public function testSuccessfulSaveWritesFinalArtifact(): void
     {
         \mkdir($this->cacheRoot(), 0777, true);
         \file_put_contents($this->cacheRoot() . '/store', 'cache');
@@ -124,6 +124,23 @@ class BuildCache extends TestCase
         self::assertStringNotContainsString('squashfs stdout', $result['output']);
         self::assertStringNotContainsString('squashfs stderr', $result['output']);
         self::assertFileExists($this->artifact());
+        self::assertFileDoesNotExist($this->artifact() . '.tmp');
+    }
+
+    public function testSuccessfulSaveOverwritesExistingArtifact(): void
+    {
+        \mkdir($this->cacheRoot(), 0777, true);
+        \file_put_contents($this->cacheRoot() . '/store', 'cache');
+        \file_put_contents($this->artifact(), 'old');
+        $bin = $this->createBinDir([
+            'mksquashfs' => "#!/bin/sh\nprintf new > \"$2\"\nexit 0\n",
+        ]);
+
+        $result = $this->runScript('build-cache-save.sh', $bin);
+
+        self::assertSame(0, $result['code']);
+        $this->assertBuildCacheLogContains('Build cache saved.', $result['output']);
+        self::assertSame('new', \file_get_contents($this->artifact()));
         self::assertFileDoesNotExist($this->artifact() . '.tmp');
     }
 


### PR DESCRIPTION
## Summary
- Use `mv -f` when promoting the temporary SquashFS artifact so an existing cache artifact is overwritten on normal writable cache mounts.
- Add PHPUnit coverage for overwriting an existing artifact.

## Tests
- `vendor/bin/phpunit tests/BuildCache.php`
- `go run mvdan.cc/sh/v3/cmd/shfmt@v3.8.0 -d ci-cleanup.sh
ci-helpers.sh
ci-runtime-build.sh
ci-runtime-prepare.sh
ci_release.sh
ci_tests.sh
formatter.sh
helpers/after-build.sh
helpers/before-build.sh
helpers/before-start.sh
helpers/build-cache-env.sh
helpers/build-cache-restore.sh
helpers/build-cache-save.sh
helpers/build.sh
helpers/extract-code.sh
helpers/prepare-build.sh
helpers/prepare-compile.sh
helpers/prepare-packing.sh
helpers/prepare-start.sh
helpers/select-compression.sh
helpers/start.sh
runtimes/bun/versions/latest/helpers/javascript-runner/env.sh
runtimes/bun/versions/latest/helpers/server.sh
runtimes/cpp/versions/latest/helpers/prepare-compile.sh
runtimes/cpp/versions/latest/helpers/prepare-packing.sh
runtimes/cpp/versions/latest/helpers/server.sh
runtimes/dart/versions/latest/helpers/after-build.sh
runtimes/dart/versions/latest/helpers/before-build.sh
runtimes/dart/versions/latest/helpers/build.sh
runtimes/dart/versions/latest/helpers/prepare-build.sh
runtimes/dart/versions/latest/helpers/prepare-compile.sh
runtimes/dart/versions/latest/helpers/prepare-packing.sh
runtimes/dart/versions/latest/helpers/server.sh
runtimes/dart/versions/latest/helpers/start.sh
runtimes/deno/versions/latest/helpers/javascript-runner/env.sh
runtimes/deno/versions/latest/helpers/prepare-build.sh
runtimes/deno/versions/latest/helpers/prepare-compile.sh
runtimes/deno/versions/latest/helpers/prepare-start.sh
runtimes/deno/versions/latest/helpers/server.sh
runtimes/dotnet/versions/10/helpers/prepare-compile.sh
runtimes/dotnet/versions/6.0/helpers/prepare-compile.sh
runtimes/dotnet/versions/7.0/helpers/prepare-compile.sh
runtimes/dotnet/versions/latest/helpers/prepare-compile.sh
runtimes/dotnet/versions/latest/helpers/prepare-packing.sh
runtimes/dotnet/versions/latest/helpers/server.sh
runtimes/flutter/versions/latest/helpers/server.sh
runtimes/go/versions/latest/helpers/prepare-compile.sh
runtimes/go/versions/latest/helpers/server.sh
runtimes/java/versions/latest/helpers/build.sh
runtimes/java/versions/latest/helpers/prepare-build.sh
runtimes/java/versions/latest/helpers/prepare-compile.sh
runtimes/java/versions/latest/helpers/prepare-packing.sh
runtimes/java/versions/latest/helpers/server.sh
runtimes/java/versions/latest/helpers/start.sh
runtimes/javascript/helpers/analog/bundle.sh
runtimes/javascript/helpers/analog/env.sh
runtimes/javascript/helpers/analog/server.sh
runtimes/javascript/helpers/angular/bundle.sh
runtimes/javascript/helpers/angular/env.sh
runtimes/javascript/helpers/angular/server.sh
runtimes/javascript/helpers/astro/bundle.sh
runtimes/javascript/helpers/astro/env.sh
runtimes/javascript/helpers/astro/server.sh
runtimes/javascript/helpers/next-js/bundle.sh
runtimes/javascript/helpers/next-js/env.sh
runtimes/javascript/helpers/next-js/server.sh
runtimes/javascript/helpers/nuxt/bundle.sh
runtimes/javascript/helpers/nuxt/env.sh
runtimes/javascript/helpers/nuxt/server.sh
runtimes/javascript/helpers/prepare-packing.sh
runtimes/javascript/helpers/remix/bundle.sh
runtimes/javascript/helpers/remix/env.sh
runtimes/javascript/helpers/remix/server.sh
runtimes/javascript/helpers/sveltekit/bundle.sh
runtimes/javascript/helpers/sveltekit/env.sh
runtimes/javascript/helpers/sveltekit/server.sh
runtimes/javascript/helpers/tanstack-start/bundle.sh
runtimes/javascript/helpers/tanstack-start/env.sh
runtimes/javascript/helpers/tanstack-start/server.sh
runtimes/kotlin/versions/latest/helpers/prepare-build.sh
runtimes/kotlin/versions/latest/helpers/prepare-compile.sh
runtimes/kotlin/versions/latest/helpers/prepare-packing.sh
runtimes/kotlin/versions/latest/helpers/server.sh
runtimes/node/versions/latest/helpers/javascript-runner/env.sh
runtimes/node/versions/latest/helpers/prepare-packing.sh
runtimes/node/versions/latest/helpers/server.sh
runtimes/php/versions/latest/helpers/prepare-packing.sh
runtimes/php/versions/latest/helpers/server.sh
runtimes/python/versions/latest/helpers/prepare-build.sh
runtimes/python/versions/latest/helpers/prepare-start.sh
runtimes/python/versions/latest/helpers/server.sh
runtimes/python/versions/ml-3.11/helpers/prepare-build.sh
runtimes/python/versions/ml-3.11/helpers/prepare-start.sh
runtimes/python/versions/ml-3.12/helpers/prepare-build.sh
runtimes/python/versions/ml-3.12/helpers/prepare-start.sh
runtimes/python/versions/ml-3.13/helpers/prepare-build.sh
runtimes/python/versions/ml-3.13/helpers/prepare-start.sh
runtimes/ruby/versions/latest/helpers/prepare-build.sh
runtimes/ruby/versions/latest/helpers/prepare-compile.sh
runtimes/ruby/versions/latest/helpers/prepare-packing.sh
runtimes/ruby/versions/latest/helpers/prepare-start.sh
runtimes/ruby/versions/latest/helpers/server.sh
runtimes/rust/versions/latest/helpers/prepare-compile.sh
runtimes/rust/versions/latest/helpers/server.sh
runtimes/static/versions/latest/helpers/server.sh
runtimes/swift/versions/latest/helpers/after-build.sh
runtimes/swift/versions/latest/helpers/before-build.sh
runtimes/swift/versions/latest/helpers/build.sh
runtimes/swift/versions/latest/helpers/server.sh
runtimes/swift/versions/latest/helpers/start.sh
tests.sh
tests/resources/functions/static/latest/build.sh`