### PR TITLE
Improve build cache save diagnostics

### DIFF
--- a/helpers/build-cache-save.sh
+++ b/helpers/build-cache-save.sh
@@ -11,6 +11,30 @@ tmp_artifact="${OPEN_RUNTIMES_BUILD_CACHE_ARTIFACT}.tmp"
 rm -f "$tmp_artifact"
 artifact_dir="${OPEN_RUNTIMES_BUILD_CACHE_ARTIFACT%/*}"
 
+file_size() {
+	wc -c <"$1" | tr -d ' '
+}
+
+file_checksum() {
+	if command -v sha256sum >/dev/null 2>&1; then
+		sha256sum "$1" | cut -d ' ' -f 1
+	elif command -v shasum >/dev/null 2>&1; then
+		shasum -a 256 "$1" | cut -d ' ' -f 1
+	fi
+}
+
+log_file_output() {
+	local file="$1"
+
+	if [ ! -s "$file" ]; then
+		return
+	fi
+
+	while IFS= read -r line; do
+		log "Build cache mksquashfs output: $line"
+	done <"$file"
+}
+
 if ! command -v mksquashfs >/dev/null 2>&1; then
 	log 'Build cache warning: missing mksquashfs, continuing without cache save.'
 	exit 0
@@ -27,6 +51,24 @@ if [ ! -d "$artifact_dir" ]; then
 fi
 
 processors=$(nproc 2>/dev/null || echo 1)
+tmp_log=$(mktemp "${artifact_dir}/build-cache-save.XXXXXX" 2>/dev/null || mktemp 2>/dev/null || true)
+
+cleanup() {
+	rm -f "$tmp_artifact"
+	if [ -n "$tmp_log" ]; then
+		rm -f "$tmp_log"
+	fi
+}
+
+trap cleanup EXIT
+
+old_size=''
+old_checksum=''
+
+if [ -f "$OPEN_RUNTIMES_BUILD_CACHE_ARTIFACT" ]; then
+	old_size=$(file_size "$OPEN_RUNTIMES_BUILD_CACHE_ARTIFACT")
+	old_checksum=$(file_checksum "$OPEN_RUNTIMES_BUILD_CACHE_ARTIFACT")
+fi
 
 if [ -n "${OPEN_RUNTIMES_BUILD_CACHE_SAVE_TIMEOUT_SECONDS:-}" ] && command -v timeout >/dev/null 2>&1; then
 	mksquashfs_cmd=(timeout "$OPEN_RUNTIMES_BUILD_CACHE_SAVE_TIMEOUT_SECONDS" mksquashfs)
@@ -34,24 +76,49 @@ else
 	mksquashfs_cmd=(mksquashfs)
 fi
 
-if "${mksquashfs_cmd[@]}" "$OPEN_RUNTIMES_BUILD_CACHE_ROOT" "$tmp_artifact" -comp lz4 -b 1M -noappend -no-xattrs -no-progress -processors "$processors" >/dev/null 2>&1; then
+if [ -z "$tmp_log" ]; then
+	log 'Build cache warning: failed to create cache save log, build result preserved.'
+	exit 0
+fi
+
+if "${mksquashfs_cmd[@]}" "$OPEN_RUNTIMES_BUILD_CACHE_ROOT" "$tmp_artifact" -comp lz4 -b 1M -noappend -no-xattrs -no-progress -processors "$processors" >"$tmp_log" 2>&1; then
 	if [ -n "${OPEN_RUNTIMES_BUILD_CACHE_MAX_SIZE_BYTES:-}" ]; then
-		size=$(wc -c <"$tmp_artifact" | tr -d ' ')
+		size=$(file_size "$tmp_artifact")
 		if [ "$size" -gt "$OPEN_RUNTIMES_BUILD_CACHE_MAX_SIZE_BYTES" ]; then
-			rm -f "$tmp_artifact"
-			log 'Build cache save skipped: artifact too large.'
+			log "Build cache save skipped: artifact too large ($size bytes, max $OPEN_RUNTIMES_BUILD_CACHE_MAX_SIZE_BYTES bytes)."
 			exit 0
 		fi
 	fi
 
 	if mv -f "$tmp_artifact" "$OPEN_RUNTIMES_BUILD_CACHE_ARTIFACT"; then
-		log 'Build cache saved.'
+		if [ ! -f "$OPEN_RUNTIMES_BUILD_CACHE_ARTIFACT" ]; then
+			log 'Build cache warning: failed to verify saved cache artifact, build result preserved.'
+			exit 0
+		fi
+
+		new_size=$(file_size "$OPEN_RUNTIMES_BUILD_CACHE_ARTIFACT")
+		new_checksum=$(file_checksum "$OPEN_RUNTIMES_BUILD_CACHE_ARTIFACT")
+
+		if [ -n "$old_checksum" ] && [ "$old_checksum" = "$new_checksum" ]; then
+			log "Build cache save skipped: artifact unchanged ($new_size bytes)."
+		else
+			if [ -n "$old_size" ]; then
+				log "Build cache saved. ($old_size bytes -> $new_size bytes)"
+			else
+				log "Build cache saved. ($new_size bytes)"
+			fi
+		fi
 	else
-		rm -f "$tmp_artifact"
 		log 'Build cache warning: failed to save cache, build result preserved.'
 	fi
 else
-	rm -f "$tmp_artifact"
+	status=$?
+	if [ -n "${OPEN_RUNTIMES_BUILD_CACHE_SAVE_TIMEOUT_SECONDS:-}" ] && [ "$status" -eq 124 ]; then
+		log "Build cache warning: failed to save cache before timeout (${OPEN_RUNTIMES_BUILD_CACHE_SAVE_TIMEOUT_SECONDS}s), build result preserved."
+	else
+		log "Build cache warning: failed to save cache with exit code $status, build result preserved."
+	fi
+	log_file_output "$tmp_log"
 	log 'Build cache warning: failed to save cache, build result preserved.'
 fi
 

--- a/helpers/build-cache-save.sh
+++ b/helpers/build-cache-save.sh
@@ -30,7 +30,7 @@ log_file_output() {
 		return
 	fi
 
-	while IFS= read -r line; do
+	while IFS= read -r line || [ -n "$line" ]; do
 		log "Build cache mksquashfs output: $line"
 	done <"$file"
 }

--- a/tests/BuildCache.php
+++ b/tests/BuildCache.php
@@ -107,6 +107,22 @@ class BuildCache extends TestCase
         self::assertSame(0, $result['code']);
         $this->assertBuildCacheLogContains('Build cache warning: failed to save cache, build result preserved.', $result['output']);
         self::assertFileDoesNotExist($this->artifact() . '.tmp');
+        self::assertSame([], \glob($this->root . '/build-cache-save.*'));
+    }
+
+    public function testSaveFailureLogsMksquashfsOutput(): void
+    {
+        \mkdir($this->cacheRoot(), 0777, true);
+        $bin = $this->createBinDir([
+            'mksquashfs' => "#!/bin/sh\nprintf 'squashfs stdout\n'\nprintf 'squashfs stderr\n' >&2\nexit 1\n",
+        ]);
+
+        $result = $this->runScript('build-cache-save.sh', $bin);
+
+        self::assertSame(0, $result['code']);
+        $this->assertBuildCacheLogContains('Build cache warning: failed to save cache with exit code 1, build result preserved.', $result['output']);
+        $this->assertBuildCacheLogContains('Build cache mksquashfs output: squashfs stdout', $result['output']);
+        $this->assertBuildCacheLogContains('Build cache mksquashfs output: squashfs stderr', $result['output']);
     }
 
     public function testSuccessfulSaveWritesFinalArtifact(): void
@@ -141,6 +157,41 @@ class BuildCache extends TestCase
         self::assertSame(0, $result['code']);
         $this->assertBuildCacheLogContains('Build cache saved.', $result['output']);
         self::assertSame('new', \file_get_contents($this->artifact()));
+        self::assertFileDoesNotExist($this->artifact() . '.tmp');
+    }
+
+    public function testSuccessfulSaveLogsUnchangedArtifact(): void
+    {
+        \mkdir($this->cacheRoot(), 0777, true);
+        \file_put_contents($this->cacheRoot() . '/store', 'cache');
+        \file_put_contents($this->artifact(), 'same');
+        $bin = $this->createBinDir([
+            'mksquashfs' => "#!/bin/sh\nprintf same > \"$2\"\nexit 0\n",
+        ]);
+
+        $result = $this->runScript('build-cache-save.sh', $bin);
+
+        self::assertSame(0, $result['code']);
+        $this->assertBuildCacheLogContains('Build cache save skipped: artifact unchanged', $result['output']);
+        self::assertSame('same', \file_get_contents($this->artifact()));
+        self::assertFileDoesNotExist($this->artifact() . '.tmp');
+    }
+
+    public function testSaveSkipsTooLargeArtifactWithSizes(): void
+    {
+        \mkdir($this->cacheRoot(), 0777, true);
+        \file_put_contents($this->artifact(), 'old');
+        $bin = $this->createBinDir([
+            'mksquashfs' => "#!/bin/sh\nprintf large > \"$2\"\nexit 0\n",
+        ]);
+
+        $result = $this->runScript('build-cache-save.sh', $bin, [
+            'OPEN_RUNTIMES_BUILD_CACHE_MAX_SIZE_BYTES' => '3',
+        ]);
+
+        self::assertSame(0, $result['code']);
+        $this->assertBuildCacheLogContains('Build cache save skipped: artifact too large (5 bytes, max 3 bytes).', $result['output']);
+        self::assertSame('old', \file_get_contents($this->artifact()));
         self::assertFileDoesNotExist($this->artifact() . '.tmp');
     }
 


### PR DESCRIPTION
## Summary
- capture and log mksquashfs output when build cache saves fail
- report cache artifact size changes, unchanged artifacts, timeout failures, and max-size skips
- keep cache save atomic with temp artifact cleanup and verification
- add focused BuildCache test coverage for diagnostics and cleanup

## Tests
- vendor/bin/phpunit tests/BuildCache.php