### PR TITLE
feat(rust): add Rust 1.96 runtime

### DIFF
--- a/ci/runtimes.toml
+++ b/ci/runtimes.toml
@@ -95,7 +95,7 @@ test = "Serverless/Ruby.php"
 
 [rust]
 entry = "tests.rs"
-versions = ["1.83"]
+versions = ["1.96", "1.83"]
 commands = { install = "", start = "bash helpers/server.sh" }
 formatter = { prepare = "echo \"Using native formatter\"", check = "find ./ -name '*.rs' -type f -print | xargs rustfmt --check --edition 2021", write = "find ./ -name '*.rs' -type f -print | xargs rustfmt --edition 2021" }
 tools = "rustc --version && cargo --version"

--- a/runtimes/rust/versions/1.96/Dockerfile
+++ b/runtimes/rust/versions/1.96/Dockerfile
@@ -1,0 +1,6 @@
+# syntax = devthefuture/dockerfile-x:1.4.2
+FROM rust:1.96-alpine
+
+INCLUDE ./base-before
+INCLUDE ./rust
+INCLUDE ./base-after


### PR DESCRIPTION
## What
Adds a **Rust 1.96** runtime (latest stable, released 2026-05-28) alongside the existing `rust-1.83`.

## Why
`rust-1.83` is currently the only Rust version, and cargo 1.83 has no MSRV-aware resolver and can't parse `edition2024` manifests — so functions depending on modern crates (e.g. `lopdf 0.40`, MSRV 1.85) fail to build. A 1.96 runtime unblocks them. (Raised on Discord — thanks for the invite to PR! 🙏)

## Changes
- `runtimes/rust/versions/1.96/Dockerfile` — `FROM rust:1.96-alpine` + the standard `base-before` / `rust` / `base-after` includes (identical shape to `1.83`).
- `ci/runtimes.toml` — add `"1.96"` to `[rust].versions` (newest first, so it becomes the primary tested + formatted version).

## Testing (local)
- Built the runtime image and ran the example Rust function → **`200 OK`** with the expected JSON body.
- Built a real workload depending on **`lopdf 0.40`** (the exact crate that fails on `rust-1.83`) → compiles clean and runs end-to-end.
- Image size is on par with `v5-1.83` (toolchain-dominated; nothing added).

Happy to adjust anything — version ordering in `runtimes.toml`, or replacing `1.83` instead of adding, whatever you prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
