### PR TITLE
(feat): add OPEN_RUNTIMES_STATIC_FOLLOW_SYMLINKS toggle for static runtime

### DIFF
--- a/runtimes/static/versions/latest/helpers/server.sh
+++ b/runtimes/static/versions/latest/helpers/server.sh
@@ -41,6 +41,15 @@ sanitize_int() {
 	esac
 }
 
+# Follow symlinks in the served dir. Off by default (path-escape defense);
+# enable when code is mounted as symlinks (e.g. sidecar), else those paths 404.
+OPEN_RUNTIMES_STATIC_FOLLOW_SYMLINKS="$(echo "${OPEN_RUNTIMES_STATIC_FOLLOW_SYMLINKS:-false}" | tr '[:upper:]' '[:lower:]')"
+if [ "$OPEN_RUNTIMES_STATIC_FOLLOW_SYMLINKS" = "true" ]; then
+	DISABLE_SYMLINKS="false"
+else
+	DISABLE_SYMLINKS="true"
+fi
+
 # Toggle the in-memory cache.
 OPEN_RUNTIMES_STATIC_MEMORY_CACHE_ENABLED="$(echo "${OPEN_RUNTIMES_STATIC_MEMORY_CACHE_ENABLED:-true}" | tr '[:upper:]' '[:lower:]')"
 
@@ -102,7 +111,7 @@ static-web-server \
 	--page404="/mnt/resources/404.html" \
 	--page-fallback="$PAGE_FALLBACK" \
 	--ignore-hidden-files false \
-	--disable-symlinks \
+	--disable-symlinks "$DISABLE_SYMLINKS" \
 	--compression false \
 	--cache-control-headers false \
 	--config-file /tmp/config.toml \


### PR DESCRIPTION
## What

Adds an opt-in `OPEN_RUNTIMES_STATIC_FOLLOW_SYMLINKS` env var to the static runtime's `server.sh`. It maps to static-web-server's `--disable-symlinks true|false`:

- **Default (`false`)** → `--disable-symlinks true` — unchanged, secure behavior.
- **`true`** → `--disable-symlinks false` — static-web-server follows symlinks in the served directory.

## Why

`helpers/extract-code.sh` was changed in #456 to **symlink** `/mnt/code/*` into `/usr/local/server/src/function/` when the sidecar pre-extracts (`.extracted` marker), instead of copying.

But the static runtime launches static-web-server with a hardcoded `--disable-symlinks`, so it refuses to serve any path that resolves through a symlink → every request 404s. The existing fallback in `extract-code.sh` doesn't help because `ln -s` itself succeeds; only static-web-server later refuses to follow the link.

This exposes a toggle so the sidecar/symlink extraction path can be served, while keeping symlinks disabled by default for the path-escape defense.

## Notes

- `--disable-symlinks` accepts `true|false` (default `true`) per the [SWS docs](https://static-web-server.net/configuration/command-line-arguments/), matching the existing `--ignore-hidden-files false` / `--compression false` style.
- `bash -n` passes.