### PR TITLE
feat: configurable build input/output dirs and cache path

### DIFF
--- a/helpers/build-cache-env.sh
+++ b/helpers/build-cache-env.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-export OPEN_RUNTIMES_BUILD_CACHE_ROOT="/usr/local/cache/build"
-export OPEN_RUNTIMES_BUILD_CACHE_ARTIFACT="/cache/stores.sqfs"
+export OPEN_RUNTIMES_BUILD_CACHE_ROOT="${OPEN_RUNTIMES_BUILD_CACHE_ROOT:-/usr/local/cache/build}"
+export OPEN_RUNTIMES_BUILD_CACHE_ARTIFACT="${OPEN_RUNTIMES_BUILD_CACHE_ARTIFACT:-/cache/stores.sqfs}"
 
 export npm_config_cache="$OPEN_RUNTIMES_BUILD_CACHE_ROOT/npm"
 export YARN_CACHE_FOLDER="$OPEN_RUNTIMES_BUILD_CACHE_ROOT/yarn"

--- a/helpers/lifecycle/build.sh
+++ b/helpers/lifecycle/build.sh
@@ -17,13 +17,14 @@ bash /usr/local/server/helpers/build-cache-restore.sh || true
 opr_log "Environment preparation started."
 
 # Check if source directory exists and has files
-if [ ! -d "/mnt/code" ] || [ -z "$(ls -A /mnt/code 2>/dev/null)" ]; then
+INPUT_DIR="${OPEN_RUNTIMES_BUILD_INPUT_DIR:-/mnt/code}"
+if [ ! -d "$INPUT_DIR" ] || [ -z "$(ls -A "$INPUT_DIR" 2>/dev/null)" ]; then
 	opr_error "Error: No source code found. Ensure your source isn't empty."
 	exit 1
 fi
 
 # Copy from mounted volume to temporary folder
-cp -R /mnt/code/* /usr/local/build
+cp -R "$INPUT_DIR"/* /usr/local/build
 
 # Enter build folder
 cd /usr/local/build
@@ -79,12 +80,13 @@ echo "OPEN_RUNTIMES_CLEANUP=${OPEN_RUNTIMES_CLEANUP:-none}" >>.open-runtimes
 
 echo "OPEN_RUNTIMES_COMPRESSION=$COMPRESSION_METHOD" >>.open-runtimes
 
+OUTPUT_DIR="${OPEN_RUNTIMES_BUILD_OUTPUT_DIR:-/mnt/code}"
 if [ "$COMPRESSION_METHOD" = "none" ]; then
-	tar --exclude code.tar --exclude code.tar.gz -cf /mnt/code/code.tar.gz .
+	tar --exclude code.tar --exclude code.tar.gz -cf "$OUTPUT_DIR/code.tar.gz" .
 elif [ "$COMPRESSION_METHOD" = "zstd" ]; then
-	tar --exclude code.tar --exclude code.tar.gz -cf - . | zstd -qf -o /mnt/code/code.tar.gz
+	tar --exclude code.tar --exclude code.tar.gz -cf - . | zstd -qf -o "$OUTPUT_DIR/code.tar.gz"
 else
-	tar --exclude code.tar --exclude code.tar.gz -zcf /mnt/code/code.tar.gz .
+	tar --exclude code.tar --exclude code.tar.gz -zcf "$OUTPUT_DIR/code.tar.gz" .
 fi
 
 opr_log "Build packaging finished."


### PR DESCRIPTION
## What

Adds optional env vars to the build lifecycle (`helpers/lifecycle/build.sh` and `helpers/build-cache-env.sh`), all backward-compatible with their existing defaults:

| Var | Purpose | Default |
| --- | --- | --- |
| `OPEN_RUNTIMES_BUILD_INPUT_DIR` | Source dir checked & copied at the start of the build | `/mnt/code` |
| `OPEN_RUNTIMES_BUILD_OUTPUT_DIR` | Destination dir for the output archive | `/mnt/code` |
| `OPEN_RUNTIMES_BUILD_CACHE_ROOT` | Package-manager cache root | `/usr/local/cache/build` |
| `OPEN_RUNTIMES_BUILD_CACHE_ARTIFACT` | Persisted cache artifact path | `/cache/stores.sqfs` |

The two cache vars were hardcoded `export`s; they now honor a caller-provided value via `${VAR:-default}`.

## Notes

- Rebased onto the post-#498 lifecycle refactor; the change now lives in the single `lifecycle/build.sh` orchestrator instead of the old per-runtime `before/after-build.sh`.
- The cache artifact lives outside the packed workspace, so no archive `--exclude` is needed.
- Scope is the **build** phase only — the start phase still reads `/mnt/code`, which matches the defaults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)