### PR TITLE
Support SquashFS build outputs

### DIFF
--- a/docs/add-runtime.md
+++ b/docs/add-runtime.md
@@ -110,13 +110,13 @@ phases see (e.g. activating a virtualenv, or setting `OPEN_RUNTIMES_CLEANUP`).
 | Install | run the user/install command in `/usr/local/build` | — |
 | Compile | (compiled langs) build the binary | `compile` |
 | Pack | prune/clean build output | `pack` |
-| Archive | tar `/usr/local/build` → `/mnt/code/code.tar.gz`, write `.open-runtimes` metadata, save build cache | — |
+| Archive | package `/usr/local/build` → `/mnt/code/code.tar.gz` by default, or `/mnt/code/code.sqfs` when `OPEN_RUNTIMES_BUILD_COMPRESSION=auto`/`squashfs`; write `.open-runtimes` metadata, save build cache | — |
 
 **Start** (`helpers/lifecycle/start.sh`, invoked as `helpers/start.sh "<start command>"`):
 
 | Phase | What happens | Hook |
 |---|---|---|
-| Extract | unpack `code.tar.gz` | — |
+| Extract | unpack `code.sqfs` when present, otherwise unpack legacy `code.tar.gz`, `code.tar`, or `code.gz` | — |
 | Prepare | move deps/binaries into place, activate envs | `start-prepare` |
 | Serve | run the start command and watch for the server-ready line | — |
 
@@ -126,9 +126,15 @@ copies user code into `src/function/`, runs `cargo build --release`, and moves
 the binary into `/usr/local/build`. An **interpreted** runtime usually needs no
 hooks beyond what its shared family already provides.
 
-> Useful paths: `/mnt/code` (mounted user code + the output `code.tar.gz`),
+> Useful paths: `/mnt/code` (mounted user code + the output `code.tar.gz` or `code.sqfs`),
 > `/usr/local/build` (build working dir), `/usr/local/server` (the runtime
 > itself), `/mnt/telemetry` (timing files), `/mnt/logs`.
+
+Build output compression is controlled by `OPEN_RUNTIMES_BUILD_COMPRESSION`.
+The default remains `gzip` for downloadable artifact compatibility. `auto` uses
+SquashFS with LZ4 for faster packaging and extraction, and explicit values
+`squashfs`, `gzip`, `zstd`, and `none` are supported. Downloaded SquashFS
+outputs can be extracted with `unsquashfs -d output code.sqfs`.
 
 ## 4. Writing the runtime server
 

--- a/helpers/lifecycle/build.sh
+++ b/helpers/lifecycle/build.sh
@@ -82,11 +82,14 @@ echo "OPEN_RUNTIMES_COMPRESSION=$COMPRESSION_METHOD" >>.open-runtimes
 
 OUTPUT_DIR="${OPEN_RUNTIMES_BUILD_OUTPUT_DIR:-/mnt/code}"
 if [ "$COMPRESSION_METHOD" = "none" ]; then
-	tar --exclude code.tar --exclude code.tar.gz -cf "$OUTPUT_DIR/code.tar.gz" .
+	tar --exclude code.sqfs --exclude code.tar --exclude code.tar.gz --exclude code.gz -cf "$OUTPUT_DIR/code.tar.gz" .
+elif [ "$COMPRESSION_METHOD" = "squashfs" ]; then
+	processors=$(nproc 2>/dev/null || echo 1)
+	mksquashfs . "$OUTPUT_DIR/code.sqfs" -comp lz4 -b 1M -noappend -no-xattrs -no-progress -processors "$processors" -wildcards -e code.sqfs code.tar code.tar.gz code.gz
 elif [ "$COMPRESSION_METHOD" = "zstd" ]; then
-	tar --exclude code.tar --exclude code.tar.gz -cf - . | zstd -qf -o "$OUTPUT_DIR/code.tar.gz"
+	tar --exclude code.sqfs --exclude code.tar --exclude code.tar.gz --exclude code.gz -cf - . | zstd -qf -o "$OUTPUT_DIR/code.tar.gz"
 else
-	tar --exclude code.tar --exclude code.tar.gz -zcf "$OUTPUT_DIR/code.tar.gz" .
+	tar --exclude code.sqfs --exclude code.tar --exclude code.tar.gz --exclude code.gz -zcf "$OUTPUT_DIR/code.tar.gz" .
 fi
 
 opr_log "Build packaging finished."

--- a/helpers/lifecycle/compression.sh
+++ b/helpers/lifecycle/compression.sh
@@ -4,6 +4,8 @@
 
 if [ "$OPEN_RUNTIMES_BUILD_COMPRESSION" = "none" ]; then
 	COMPRESSION_METHOD="none"
+elif [ "$OPEN_RUNTIMES_BUILD_COMPRESSION" = "squashfs" ]; then
+	COMPRESSION_METHOD="squashfs"
 elif [ "$OPEN_RUNTIMES_BUILD_COMPRESSION" = "zstd" ]; then
 	COMPRESSION_METHOD="zstd"
 elif [ "$OPEN_RUNTIMES_BUILD_COMPRESSION" = "gzip" ]; then
@@ -12,13 +14,7 @@ elif [ "$OPEN_RUNTIMES_BUILD_COMPRESSION" = "auto" ]; then
 	TOTAL_SIZE_KB=$(du -sk . 2>/dev/null | cut -f1)
 	TOTAL_SIZE_KB=${TOTAL_SIZE_KB:-0}
 
-	if [ "$TOTAL_SIZE_KB" -lt 5120 ]; then
-		# < 5MB: no compression
-		COMPRESSION_METHOD="none"
-	else
-		# >= 5MB: gzip (edge decompresses with igzip)
-		COMPRESSION_METHOD="gzip"
-	fi
+	COMPRESSION_METHOD="squashfs"
 
 	echo -e "\e[90m$(date +[%H:%M:%S]) \e[31m[\e[0mopen-runtimes\e[31m]\e[97m Auto compression: ${COMPRESSION_METHOD} (size=${TOTAL_SIZE_KB}KB) \e[0m"
 else

--- a/helpers/lifecycle/compression.sh
+++ b/helpers/lifecycle/compression.sh
@@ -11,12 +11,9 @@ elif [ "$OPEN_RUNTIMES_BUILD_COMPRESSION" = "zstd" ]; then
 elif [ "$OPEN_RUNTIMES_BUILD_COMPRESSION" = "gzip" ]; then
 	COMPRESSION_METHOD="gzip"
 elif [ "$OPEN_RUNTIMES_BUILD_COMPRESSION" = "auto" ]; then
-	TOTAL_SIZE_KB=$(du -sk . 2>/dev/null | cut -f1)
-	TOTAL_SIZE_KB=${TOTAL_SIZE_KB:-0}
-
 	COMPRESSION_METHOD="squashfs"
 
-	echo -e "\e[90m$(date +[%H:%M:%S]) \e[31m[\e[0mopen-runtimes\e[31m]\e[97m Auto compression: ${COMPRESSION_METHOD} (size=${TOTAL_SIZE_KB}KB) \e[0m"
+	echo -e "\e[90m$(date +[%H:%M:%S]) \e[31m[\e[0mopen-runtimes\e[31m]\e[97m Auto compression: ${COMPRESSION_METHOD} \e[0m"
 else
 	# Default: gzip (backward compatible)
 	COMPRESSION_METHOD="gzip"

--- a/helpers/lifecycle/extract.sh
+++ b/helpers/lifecycle/extract.sh
@@ -5,14 +5,14 @@
 # Prepare telemetry
 mkdir -p /mnt/telemetry
 
-# Detect archive compression by reading the first 4 magic bytes. The build
-# packs as code.tar.gz regardless of actual compression (helpers/select-
-# compression.sh picks gzip/zstd/none by build size), so the filename can't
-# be trusted.
+# Detect archive compression by reading the first 4 magic bytes. Legacy tar
+# builds pack as code.tar.gz regardless of actual compression, so the filename
+# can't be trusted.
 detect_archive_format() {
 	local magic
 	magic=$(head -c4 "$1" 2>/dev/null | od -An -vtx1 2>/dev/null | tr -d ' \n')
 	case "$magic" in
+	68737173) echo "squashfs" ;;
 	1f8b*) echo "gzip" ;;
 	28b52ffd) echo "zstd" ;;
 	*) echo "tar" ;;
@@ -27,6 +27,7 @@ extract_archive() {
 	local format
 	format=$(detect_archive_format "$archive")
 	case "$format" in
+	squashfs) unsquashfs -q -f -d "$dest" "$archive" ;;
 	gzip) tar -xzf "$archive" -C "$dest" ;;
 	# Subshell with pipefail so a zstd error (corrupt archive, missing
 	# binary) surfaces as a non-zero exit instead of being masked by tar
@@ -36,13 +37,13 @@ extract_archive() {
 	esac
 }
 
-# Locate the build archive in /mnt/code and extract it to dest. The build
-# always writes /mnt/code/code.tar.gz; code.tar and code.gz are accepted as
-# legacy fallbacks. Each branch passes the file that actually exists rather
-# than a hardcoded name.
+# Locate the build archive in /mnt/code and extract it to dest. Squashfs is
+# preferred for auto compression, while legacy tar artifacts remain supported.
 extract_code_archive() {
 	local dest="$1"
-	if [ -f /mnt/code/code.tar ]; then
+	if [ -f /mnt/code/code.sqfs ]; then
+		extract_archive /mnt/code/code.sqfs "$dest"
+	elif [ -f /mnt/code/code.tar ]; then
 		extract_archive /mnt/code/code.tar "$dest"
 	elif [ -f /mnt/code/code.tar.gz ]; then
 		extract_archive /mnt/code/code.tar.gz "$dest"
@@ -71,7 +72,7 @@ if [ -f "/mnt/code/.extracted" ]; then
 	for item in /mnt/code/*; do
 		# Skip archive files and marker
 		case "$(basename "$item")" in
-		code.tar | code.tar.gz | code.gz | .extracted) continue ;;
+		code.sqfs | code.tar | code.tar.gz | code.gz | .extracted) continue ;;
 		esac
 		ln -s "$item" /usr/local/server/src/function/ || symlink_failed=true
 	done

--- a/tests/BuildCache.php
+++ b/tests/BuildCache.php
@@ -264,14 +264,12 @@ class BuildCache extends TestCase
         self::assertLessThan(\strpos($build, 'Build finished'), \strpos($build, 'build-cache-save.sh'));
     }
 
-    public function testBuildCacheEnvUsesFixedPaths(): void
+    public function testBuildCacheEnvUsesDefaultPaths(): void
     {
         $env = \file_get_contents($this->repoHelpers . '/build-cache-env.sh');
 
-        self::assertStringContainsString('OPEN_RUNTIMES_BUILD_CACHE_ROOT="/usr/local/cache/build"', $env);
-        self::assertStringContainsString('OPEN_RUNTIMES_BUILD_CACHE_ARTIFACT="/cache/stores.sqfs"', $env);
-        self::assertStringNotContainsString('${OPEN_RUNTIMES_BUILD_CACHE_ROOT:-', $env);
-        self::assertStringNotContainsString('${OPEN_RUNTIMES_BUILD_CACHE_ARTIFACT:-', $env);
+        self::assertStringContainsString('OPEN_RUNTIMES_BUILD_CACHE_ROOT="${OPEN_RUNTIMES_BUILD_CACHE_ROOT:-/usr/local/cache/build}"', $env);
+        self::assertStringContainsString('OPEN_RUNTIMES_BUILD_CACHE_ARTIFACT="${OPEN_RUNTIMES_BUILD_CACHE_ARTIFACT:-/cache/stores.sqfs}"', $env);
     }
 
     public function testCacheHitStillWorksOnSecondBuild(): void
@@ -398,8 +396,8 @@ class BuildCache extends TestCase
     private function writeTestCachePaths(string $cacheRoot, string $artifact): void
     {
         $env = \file_get_contents($this->repoHelpers . '/build-cache-env.sh');
-        $env = \str_replace('OPEN_RUNTIMES_BUILD_CACHE_ROOT="/usr/local/cache/build"', 'OPEN_RUNTIMES_BUILD_CACHE_ROOT="' . $cacheRoot . '"', $env);
-        $env = \str_replace('OPEN_RUNTIMES_BUILD_CACHE_ARTIFACT="/cache/stores.sqfs"', 'OPEN_RUNTIMES_BUILD_CACHE_ARTIFACT="' . $artifact . '"', $env);
+        $env = \str_replace('OPEN_RUNTIMES_BUILD_CACHE_ROOT="${OPEN_RUNTIMES_BUILD_CACHE_ROOT:-/usr/local/cache/build}"', 'OPEN_RUNTIMES_BUILD_CACHE_ROOT="' . $cacheRoot . '"', $env);
+        $env = \str_replace('OPEN_RUNTIMES_BUILD_CACHE_ARTIFACT="${OPEN_RUNTIMES_BUILD_CACHE_ARTIFACT:-/cache/stores.sqfs}"', 'OPEN_RUNTIMES_BUILD_CACHE_ARTIFACT="' . $artifact . '"', $env);
         \file_put_contents($this->helpers . '/build-cache-env.sh', $env);
     }
 

--- a/tests/BuildCompression.php
+++ b/tests/BuildCompression.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace Tests;
+
+use PHPUnit\Framework\TestCase;
+
+class BuildCompression extends TestCase
+{
+    private string $root;
+
+    protected function setUp(): void
+    {
+        $this->root = \sys_get_temp_dir() . '/open-runtimes-build-compression-' . \bin2hex(\random_bytes(6));
+        \mkdir($this->root, 0777, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removePath($this->root);
+    }
+
+    public function testDefaultCompressionRemainsGzip(): void
+    {
+        $result = $this->runCompressionSelection([]);
+
+        self::assertSame(0, $result['code']);
+        self::assertStringContainsString('METHOD=gzip', $result['output']);
+    }
+
+    public function testAutoCompressionUsesSquashfs(): void
+    {
+        $result = $this->runCompressionSelection([
+            'OPEN_RUNTIMES_BUILD_COMPRESSION' => 'auto',
+        ]);
+
+        self::assertSame(0, $result['code']);
+        self::assertStringContainsString('Auto compression: squashfs', $this->stripAnsi($result['output']));
+        self::assertStringContainsString('METHOD=squashfs', $result['output']);
+    }
+
+    public function testExplicitSquashfsCompressionIsSupported(): void
+    {
+        $result = $this->runCompressionSelection([
+            'OPEN_RUNTIMES_BUILD_COMPRESSION' => 'squashfs',
+        ]);
+
+        self::assertSame(0, $result['code']);
+        self::assertStringContainsString('METHOD=squashfs', $result['output']);
+    }
+
+    public function testBuildLifecyclePackagesSquashfsAndKeepsLegacyTarBranches(): void
+    {
+        $build = \file_get_contents(\dirname(__DIR__) . '/helpers/lifecycle/build.sh');
+
+        self::assertStringContainsString('"$COMPRESSION_METHOD" = "squashfs"', $build);
+        self::assertStringContainsString('mksquashfs . "$OUTPUT_DIR/code.sqfs"', $build);
+        self::assertStringContainsString('-comp lz4 -b 1M -noappend -no-xattrs -no-progress', $build);
+        self::assertStringContainsString('"$COMPRESSION_METHOD" = "none"', $build);
+        self::assertStringContainsString('"$COMPRESSION_METHOD" = "zstd"', $build);
+        self::assertStringContainsString('"$OUTPUT_DIR/code.tar.gz"', $build);
+    }
+
+    public function testExtractionPrefersSquashfsAndKeepsLegacyTarFallbacks(): void
+    {
+        $extract = \file_get_contents(\dirname(__DIR__) . '/helpers/lifecycle/extract.sh');
+
+        self::assertStringContainsString('68737173) echo "squashfs"', $extract);
+        self::assertStringContainsString('squashfs) unsquashfs -q -f -d "$dest" "$archive"', $extract);
+        self::assertLessThan(\strpos($extract, '/mnt/code/code.tar'), \strpos($extract, '/mnt/code/code.sqfs'));
+        self::assertStringContainsString('code.sqfs | code.tar | code.tar.gz | code.gz | .extracted', $extract);
+    }
+
+    private function runCompressionSelection(array $env): array
+    {
+        $script = \dirname(__DIR__) . '/helpers/lifecycle/compression.sh';
+        \file_put_contents($this->root . '/file.txt', 'contents');
+
+        $command = 'cd ' . \escapeshellarg($this->root) . ' && . ' . \escapeshellarg($script) . ' && printf "METHOD=%s\n" "$COMPRESSION_METHOD"';
+
+        return $this->runShell($command, $env);
+    }
+
+    private function runShell(string $command, array $env): array
+    {
+        $descriptorSpec = [
+            1 => ['pipe', 'w'],
+            2 => ['pipe', 'w'],
+        ];
+
+        $process = \proc_open(['/bin/bash', '-c', $command], $descriptorSpec, $pipes, null, $env + [
+            'PATH' => '/bin:/usr/bin',
+        ]);
+
+        if (!\is_resource($process)) {
+            self::fail('Failed to start process.');
+        }
+
+        $output = \stream_get_contents($pipes[1]) . \stream_get_contents($pipes[2]);
+        \fclose($pipes[1]);
+        \fclose($pipes[2]);
+
+        return [
+            'code' => \proc_close($process),
+            'output' => $output,
+        ];
+    }
+
+    private function stripAnsi(string $output): string
+    {
+        return \preg_replace('/(?:\x1B|\\e)\[[0-9;]*m/', '', $output) ?? $output;
+    }
+
+    private function removePath(string $path): void
+    {
+        if (!\file_exists($path) && !\is_link($path)) {
+            return;
+        }
+
+        if (\is_file($path) || \is_link($path)) {
+            \unlink($path);
+            return;
+        }
+
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($path, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST
+        );
+
+        foreach ($iterator as $file) {
+            $file->isDir() ? \rmdir($file->getPathname()) : \unlink($file->getPathname());
+        }
+
+        \rmdir($path);
+    }
+}

--- a/tests/SSR.php
+++ b/tests/SSR.php
@@ -205,28 +205,39 @@ class SSR extends CSR
     public function testModclean(): void
     {
         // Main build has modclean enabled (default behavior)
-        $archive = '/app/tests/.runtime/code.tar.gz';
-        $result = \shell_exec("tar -tzf {$archive} 2>/dev/null | grep 'node_modules/.*\\.md$' | head -1");
-        self::assertEmpty(\trim($result ?? ''), 'Expected no .md files in node_modules when modclean is enabled');
+        $entries = $this->listBuildArchiveEntries('/app/tests/.runtime');
+        self::assertSame(0, \preg_match('/node_modules\/.*\.md$/m', $entries), 'Expected no .md files in node_modules when modclean is enabled');
 
         // Baseline build has all cleanup disabled
-        $archive = '/app/tests/.runtime/modclean-disabled-build/src/code.tar.gz';
-        $result = \shell_exec("tar -tzf {$archive} 2>/dev/null | grep 'node_modules/.*\\.md$' | head -1");
-        self::assertNotEmpty(\trim($result ?? ''), 'Expected .md files in node_modules when modclean is disabled');
+        $entries = $this->listBuildArchiveEntries('/app/tests/.runtime/modclean-disabled-build/src');
+        self::assertSame(1, \preg_match('/node_modules\/.*\.md$/m', $entries), 'Expected .md files in node_modules when modclean is disabled');
     }
 
     public function testNft(): void
     {
         // NFT build has NFT enabled, modclean disabled
-        $archive = '/app/tests/.runtime/nft-build/src/code.tar.gz';
-        $nftCount = (int)\shell_exec("tar -tzf {$archive} 2>/dev/null | grep -c 'node_modules/'");
+        $nftCount = \substr_count($this->listBuildArchiveEntries('/app/tests/.runtime/nft-build/src'), 'node_modules/');
 
         // Baseline build has all cleanup disabled
-        $archive = '/app/tests/.runtime/modclean-disabled-build/src/code.tar.gz';
-        $fullCount = (int)\shell_exec("tar -tzf {$archive} 2>/dev/null | grep -c 'node_modules/'");
+        $fullCount = \substr_count($this->listBuildArchiveEntries('/app/tests/.runtime/modclean-disabled-build/src'), 'node_modules/');
 
         self::assertGreaterThan(0, $fullCount, 'Expected files in node_modules when cleanup is disabled');
         self::assertLessThan($fullCount, $nftCount, 'Expected fewer files in node_modules after NFT pruning');
+    }
+
+    protected function listBuildArchiveEntries(string $directory): string
+    {
+        $squashfs = $directory . '/code.sqfs';
+        if (\is_file($squashfs) && \filesize($squashfs) > 0) {
+            return \shell_exec('unsquashfs -ll ' . \escapeshellarg($squashfs) . ' 2>/dev/null') ?? '';
+        }
+
+        $tar = $directory . '/code.tar.gz';
+        if (\is_file($tar) && \filesize($tar) > 0) {
+            return \shell_exec('tar -tzf ' . \escapeshellarg($tar) . ' 2>/dev/null') ?? '';
+        }
+
+        self::fail('Build archive not found in ' . $directory);
     }
 
     public function testStaticCache(): void

--- a/tests/SSR.php
+++ b/tests/SSR.php
@@ -229,7 +229,7 @@ class SSR extends CSR
     {
         $squashfs = $directory . '/code.sqfs';
         if (\is_file($squashfs) && \filesize($squashfs) > 0) {
-            return \shell_exec('unsquashfs -ll ' . \escapeshellarg($squashfs) . ' 2>/dev/null') ?? '';
+            return \shell_exec('unsquashfs -l ' . \escapeshellarg($squashfs) . ' 2>/dev/null') ?? '';
         }
 
         $tar = $directory . '/code.tar.gz';

--- a/tests/SSR/NextJS.php
+++ b/tests/SSR/NextJS.php
@@ -15,11 +15,9 @@ class NextJS extends SSR
     // server-wrapper and next.config imports, so we fall back to modclean.
     public function testNft(): void
     {
-        $archive = '/app/tests/.runtime/nft-build/src/code.tar.gz';
-        $nftCount = (int)\shell_exec("tar -tzf {$archive} 2>/dev/null | grep -c 'node_modules/'");
+        $nftCount = \substr_count($this->listBuildArchiveEntries('/app/tests/.runtime/nft-build/src'), 'node_modules/');
 
-        $archive = '/app/tests/.runtime/modclean-disabled-build/src/code.tar.gz';
-        $fullCount = (int)\shell_exec("tar -tzf {$archive} 2>/dev/null | grep -c 'node_modules/'");
+        $fullCount = \substr_count($this->listBuildArchiveEntries('/app/tests/.runtime/modclean-disabled-build/src'), 'node_modules/');
 
         self::assertGreaterThan(0, $fullCount, 'Expected files in node_modules when cleanup is disabled');
         self::assertEquals($fullCount, $nftCount, 'Expected NFT to be skipped for Next.js (counts should be equal)');

--- a/tests/compose.yaml
+++ b/tests/compose.yaml
@@ -164,7 +164,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
       - ..:/app
       - /tmp:/tmp
-    command: ['sh', '-c', 'apk update && apk add docker-cli && vendor/bin/phpunit --configuration phpunit.xml "tests/$$TEST_CLASS"']
+    command: ['sh', '-c', 'apk update && apk add docker-cli squashfs-tools && vendor/bin/phpunit --configuration phpunit.xml "tests/$$TEST_CLASS"']
 
   formatter:
     <<: *runtime


### PR DESCRIPTION
## Summary
- add `OPEN_RUNTIMES_BUILD_COMPRESSION=squashfs`
- make `OPEN_RUNTIMES_BUILD_COMPRESSION=auto` package build outputs as `code.sqfs` using SquashFS + LZ4
- keep the default as gzip for downloadable artifact compatibility
- preserve legacy extraction support for `code.tar`, `code.tar.gz`, and `code.gz`
- update SSR archive inspection tests to support both SquashFS and tar artifacts
- document SquashFS extraction with `unsquashfs -d output code.sqfs`

## Benchmark Results
Benchmarks were run inside `openruntimes/node:v5-22` using the runtime toolchain.

### Node-style project with assets
Synthetic project: `67,601` files, `327,446,076` bytes source size.

| Format | Package | Extract | Artifact size |
|---|---:|---:|---:|
| raw tar | `4.06s` | `3.49s` | `361.3MB` |
| gzip tar | `8.46s` | `3.47s` | `190.2MB` |
| zstd tar | `4.07s` | `1.97s` | `189.3MB` |
| squashfs lz4 | `2.20s` | `1.11s` | `190.0MB` |

### node_modules-style tiny files
Synthetic `node_modules`-heavy project: `305,602` files, `31,675,265` bytes source size.

| Format | Package | Extract | Artifact size |
|---|---:|---:|---:|
| raw tar | `24.45s` | `8.38s` | `315.4MB` |
| gzip tar | `27.49s` | `8.26s` | `3.9MB` |
| zstd tar | `28.07s` | `8.08s` | `1.9MB` |
| squashfs lz4 | `16.58s` | `5.19s` | `6.2MB` |

SquashFS + LZ4 is consistently faster for packaging and extraction. For many tiny files, it trades a larger artifact than gzip/zstd for much faster build/start handling.

## Tests
- `vendor/bin/phpunit --configuration phpunit.xml tests/BuildCompression.php`
- `vendor/bin/phpunit --configuration phpunit.xml tests/BuildCache.php`
- `bash -n helpers/lifecycle/build.sh`
- `bash -n helpers/lifecycle/compression.sh`
- `bash -n helpers/lifecycle/extract.sh`
