### PR TITLE
fix: create build output and cache artifact dirs before use

### DIFF
--- a/helpers/build-cache-save.sh
+++ b/helpers/build-cache-save.sh
@@ -45,8 +45,8 @@ if [ ! -d "$OPEN_RUNTIMES_BUILD_CACHE_ROOT" ]; then
 	exit 0
 fi
 
-if [ ! -d "$artifact_dir" ]; then
-	log 'Build cache save skipped: artifact directory missing.'
+if [ ! -d "$artifact_dir" ] && ! mkdir -p "$artifact_dir"; then
+	log 'Build cache save skipped: artifact directory could not be created.'
 	exit 0
 fi
 

--- a/helpers/lifecycle/build.sh
+++ b/helpers/lifecycle/build.sh
@@ -81,6 +81,7 @@ echo "OPEN_RUNTIMES_CLEANUP=${OPEN_RUNTIMES_CLEANUP:-none}" >>.open-runtimes
 echo "OPEN_RUNTIMES_COMPRESSION=$COMPRESSION_METHOD" >>.open-runtimes
 
 OUTPUT_DIR="${OPEN_RUNTIMES_BUILD_OUTPUT_DIR:-/mnt/code}"
+mkdir -p "$OUTPUT_DIR"
 if [ "$COMPRESSION_METHOD" = "none" ]; then
 	tar --exclude code.sqfs --exclude code.tar --exclude code.tar.gz --exclude code.gz -cf "$OUTPUT_DIR/code.tar.gz" .
 elif [ "$COMPRESSION_METHOD" = "squashfs" ]; then


### PR DESCRIPTION
## Summary

Two directory-creation fixes in the build lifecycle so builds don't fail (or silently stay cold) when configured directories don't exist yet:

- **`helpers/lifecycle/build.sh`** — `mkdir -p "$OUTPUT_DIR"` before archiving. With configurable output dirs (`OPEN_RUNTIMES_BUILD_OUTPUT_DIR`), the `tar`/`mksquashfs` write to `$OUTPUT_DIR/code.*` would fail if the directory didn't exist.
- **`helpers/build-cache-save.sh`** — Attempt to create the artifact directory instead of skipping the cache save when it's missing. Previously a missing dir caused an `exit 0`, silently disabling cache saves and forcing every build to run cold. The graceful-skip fallback is preserved for the case where creation genuinely fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)