### PR TITLE
feat: opt-in JSON build manifest of the output file listing

### DIFF
--- a/helpers/build-manifest.sh
+++ b/helpers/build-manifest.sh
@@ -16,7 +16,7 @@ if [ -z "${OPEN_RUNTIMES_BUILD_MANIFEST:-}" ]; then
 	exit 0
 fi
 
-manifest_dir="${OPEN_RUNTIMES_BUILD_MANIFEST%/*}"
+manifest_dir=$(dirname "$OPEN_RUNTIMES_BUILD_MANIFEST")
 if [ ! -d "$manifest_dir" ] && ! mkdir -p "$manifest_dir"; then
 	log 'Build manifest skipped: manifest directory could not be created.'
 	exit 0
@@ -33,7 +33,9 @@ max_files="${OPEN_RUNTIMES_BUILD_MANIFEST_MAX_FILES:-10000}"
 files=$(find . -name node_modules -prune -o -type f ! -name code.sqfs ! -name code.tar ! -name code.tar.gz ! -name code.gz -print 2>/dev/null | head -n "$max_files" | sed 's|^\./||')
 
 # jq guarantees correct JSON string escaping; the fallback covers the common
-# cases (backslash, double quote) for images without jq.
+# cases (backslash, double quote, tab, carriage return) for images without
+# jq — remaining control characters are rare enough in file names that the
+# consumer's tolerance for an unparseable manifest is the backstop.
 if command -v jq >/dev/null 2>&1; then
 	if ! printf '%s\n' "$files" | jq -R . | jq -s '{version: 1, files: [.[] | select(length > 0)]}' >"$tmp_manifest" 2>/dev/null; then
 		log 'Build manifest warning: failed to encode manifest, continuing without it.'
@@ -47,7 +49,7 @@ else
 			if [ -z "$file" ]; then
 				continue
 			fi
-			escaped=$(printf '%s' "$file" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g')
+			escaped=$(printf '%s' "$file" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g' -e $'s/\t/\\\\t/g' -e $'s/\r/\\\\r/g')
 			if [ "$first" -eq 1 ]; then
 				first=0
 			else

--- a/helpers/build-manifest.sh
+++ b/helpers/build-manifest.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+# Writes a JSON build manifest describing the build output (the current
+# working directory) to $OPEN_RUNTIMES_BUILD_MANIFEST, for orchestrators that
+# inspect the output post-job (e.g. rendering detection over the file
+# listing). Opt-in: a no-op when the variable is unset. Best-effort: never
+# fails the build.
+#
+# Manifest shape (v1) — future fields become sibling keys:
+#   {"version":1,"files":["index.html","server/entry.mjs"]}
+
+log() {
+	echo -e "\e[90m$(date +[%H:%M:%S]) \e[31m[\e[0mopen-runtimes\e[31m]\e[97m $1 \e[0m"
+}
+
+if [ -z "${OPEN_RUNTIMES_BUILD_MANIFEST:-}" ]; then
+	exit 0
+fi
+
+manifest_dir="${OPEN_RUNTIMES_BUILD_MANIFEST%/*}"
+if [ ! -d "$manifest_dir" ] && ! mkdir -p "$manifest_dir"; then
+	log 'Build manifest skipped: manifest directory could not be created.'
+	exit 0
+fi
+
+tmp_manifest="${OPEN_RUNTIMES_BUILD_MANIFEST}.tmp"
+rm -f "$tmp_manifest"
+trap 'rm -f "$tmp_manifest"' EXIT
+
+# The output file listing: dependency directories pruned, archive artifacts
+# excluded (mirroring the archive step's excludes), leading ./ stripped, and
+# capped so a pathological output can't produce an unbounded manifest.
+max_files="${OPEN_RUNTIMES_BUILD_MANIFEST_MAX_FILES:-10000}"
+files=$(find . -name node_modules -prune -o -type f ! -name code.sqfs ! -name code.tar ! -name code.tar.gz ! -name code.gz -print 2>/dev/null | head -n "$max_files" | sed 's|^\./||')
+
+# jq guarantees correct JSON string escaping; the fallback covers the common
+# cases (backslash, double quote) for images without jq.
+if command -v jq >/dev/null 2>&1; then
+	if ! printf '%s\n' "$files" | jq -R . | jq -s '{version: 1, files: [.[] | select(length > 0)]}' >"$tmp_manifest" 2>/dev/null; then
+		log 'Build manifest warning: failed to encode manifest, continuing without it.'
+		exit 0
+	fi
+else
+	{
+		printf '{"version":1,"files":['
+		first=1
+		while IFS= read -r file; do
+			if [ -z "$file" ]; then
+				continue
+			fi
+			escaped=$(printf '%s' "$file" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g')
+			if [ "$first" -eq 1 ]; then
+				first=0
+			else
+				printf ','
+			fi
+			printf '"%s"' "$escaped"
+		done <<<"$files"
+		printf ']}'
+	} >"$tmp_manifest"
+fi
+
+if mv -f "$tmp_manifest" "$OPEN_RUNTIMES_BUILD_MANIFEST"; then
+	count=$(printf '%s' "$files" | grep -c . || true)
+	log "Build manifest written. ($count files)"
+else
+	log 'Build manifest warning: failed to write manifest, continuing without it.'
+fi
+
+exit 0

--- a/helpers/lifecycle/build.sh
+++ b/helpers/lifecycle/build.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # Build lifecycle: stage -> build-prepare hook -> install command -> compile
-# hook -> pack hook -> archive. Per-runtime steps live in /usr/local/server/hooks/.
+# hook -> pack hook -> archive -> manifest. Per-runtime steps live in
+# /usr/local/server/hooks/.
 # Fail build if any command fails
 set -e
 shopt -s dotglob
@@ -94,6 +95,10 @@ else
 fi
 
 opr_log "Build packaging finished."
+
+# --- Manifest: describe the build output for the orchestrator (opt-in) ---
+
+bash /usr/local/server/helpers/build-manifest.sh || true
 
 # --- Build cache: persist package-manager caches for the next build ---
 

--- a/tests/BuildManifest.php
+++ b/tests/BuildManifest.php
@@ -72,13 +72,27 @@ class BuildManifest extends TestCase
 
     public function testEscapesSpecialCharactersInFileNames(): void
     {
-        $name = 'we"ird\\name.html';
+        $name = "we\"ird\\na\tme\r.html";
         \file_put_contents($this->output . '/' . $name, 'html');
 
         $result = $this->runManifest();
 
         self::assertSame(0, $result['code']);
         self::assertSame([$name], $this->readManifest()['files']);
+    }
+
+    public function testRelativeManifestPathWritesFileNotDirectory(): void
+    {
+        \file_put_contents($this->output . '/index.html', 'html');
+
+        $result = $this->runManifest(['OPEN_RUNTIMES_BUILD_MANIFEST' => 'manifest.json']);
+
+        self::assertSame(0, $result['code']);
+        $path = $this->output . '/manifest.json';
+        self::assertFileExists($path);
+        self::assertDirectoryDoesNotExist($path);
+        $manifest = \json_decode((string) \file_get_contents($path), true);
+        self::assertSame(['index.html'], $manifest['files']);
     }
 
     public function testCapsFileCount(): void

--- a/tests/BuildManifest.php
+++ b/tests/BuildManifest.php
@@ -1,0 +1,190 @@
+<?php
+
+namespace Tests;
+
+use PHPUnit\Framework\TestCase;
+
+class BuildManifest extends TestCase
+{
+    private string $root;
+    private string $helpers;
+    private string $repoHelpers;
+    private string $output;
+
+    protected function setUp(): void
+    {
+        $this->root = \sys_get_temp_dir() . '/open-runtimes-build-manifest-' . \bin2hex(\random_bytes(6));
+        $this->output = $this->root . '/output';
+        \mkdir($this->output, 0777, true);
+        $this->repoHelpers = \dirname(__DIR__) . '/helpers';
+        $this->helpers = $this->root . '/helpers';
+        \mkdir($this->helpers, 0777, true);
+        \copy($this->repoHelpers . '/build-manifest.sh', $this->helpers . '/build-manifest.sh');
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removePath($this->root);
+    }
+
+    public function testNoOpWhenManifestPathUnset(): void
+    {
+        \file_put_contents($this->output . '/index.html', 'html');
+
+        $result = $this->runManifest([]);
+
+        self::assertSame(0, $result['code']);
+        self::assertSame('', $result['output']);
+        self::assertSame([], \glob($this->root . '/*.json'));
+    }
+
+    public function testWritesVersionedManifestOfOutputFiles(): void
+    {
+        \file_put_contents($this->output . '/index.html', 'html');
+        \mkdir($this->output . '/server', 0777, true);
+        \file_put_contents($this->output . '/server/entry.mjs', 'mjs');
+
+        $result = $this->runManifest();
+
+        self::assertSame(0, $result['code']);
+        $manifest = $this->readManifest();
+        self::assertSame(1, $manifest['version']);
+        $files = $manifest['files'];
+        \sort($files);
+        self::assertSame(['index.html', 'server/entry.mjs'], $files);
+        self::assertStringContainsString('Build manifest written. (2 files)', $result['output']);
+        self::assertFileDoesNotExist($this->manifestPath() . '.tmp');
+    }
+
+    public function testPrunesNodeModulesAndExcludesArchiveArtifacts(): void
+    {
+        \file_put_contents($this->output . '/index.html', 'html');
+        \mkdir($this->output . '/node_modules/pkg', 0777, true);
+        \file_put_contents($this->output . '/node_modules/pkg/index.js', 'js');
+        \file_put_contents($this->output . '/code.tar.gz', 'tar');
+        \file_put_contents($this->output . '/code.sqfs', 'sqfs');
+
+        $result = $this->runManifest();
+
+        self::assertSame(0, $result['code']);
+        self::assertSame(['index.html'], $this->readManifest()['files']);
+    }
+
+    public function testEscapesSpecialCharactersInFileNames(): void
+    {
+        $name = 'we"ird\\name.html';
+        \file_put_contents($this->output . '/' . $name, 'html');
+
+        $result = $this->runManifest();
+
+        self::assertSame(0, $result['code']);
+        self::assertSame([$name], $this->readManifest()['files']);
+    }
+
+    public function testCapsFileCount(): void
+    {
+        foreach (\range(1, 5) as $i) {
+            \file_put_contents($this->output . '/file-' . $i . '.html', 'html');
+        }
+
+        $result = $this->runManifest([
+            'OPEN_RUNTIMES_BUILD_MANIFEST' => $this->manifestPath(),
+            'OPEN_RUNTIMES_BUILD_MANIFEST_MAX_FILES' => '2',
+        ]);
+
+        self::assertSame(0, $result['code']);
+        self::assertCount(2, $this->readManifest()['files']);
+    }
+
+    public function testEmptyOutputWritesEmptyFileList(): void
+    {
+        $result = $this->runManifest();
+
+        self::assertSame(0, $result['code']);
+        $manifest = $this->readManifest();
+        self::assertSame(1, $manifest['version']);
+        self::assertSame([], $manifest['files']);
+        self::assertStringContainsString('Build manifest written. (0 files)', $result['output']);
+    }
+
+    public function testBuildLifecycleWritesManifestAfterPackaging(): void
+    {
+        $build = \file_get_contents($this->repoHelpers . '/lifecycle/build.sh');
+
+        self::assertStringContainsString('build-manifest.sh', $build);
+        self::assertLessThan(\strpos($build, 'build-manifest.sh'), \strpos($build, 'Build packaging finished'));
+        self::assertLessThan(\strpos($build, 'Build finished'), \strpos($build, 'build-manifest.sh'));
+    }
+
+    private function manifestPath(): string
+    {
+        return $this->root . '/manifest.json';
+    }
+
+    private function readManifest(): array
+    {
+        self::assertFileExists($this->manifestPath());
+        $manifest = \json_decode((string) \file_get_contents($this->manifestPath()), true);
+        self::assertIsArray($manifest);
+
+        return $manifest;
+    }
+
+    /**
+     * Runs build-manifest.sh with the output directory as the working
+     * directory, mirroring how lifecycle/build.sh invokes it. Passing null
+     * for OPEN_RUNTIMES_BUILD_MANIFEST leaves it unset.
+     */
+    private function runManifest(?array $env = null): array
+    {
+        $env ??= ['OPEN_RUNTIMES_BUILD_MANIFEST' => $this->manifestPath()];
+
+        $command = 'cd ' . \escapeshellarg($this->output) . ' && /bin/bash ' . \escapeshellarg($this->helpers . '/build-manifest.sh');
+
+        $descriptorSpec = [
+            1 => ['pipe', 'w'],
+            2 => ['pipe', 'w'],
+        ];
+
+        $process = \proc_open(['/bin/bash', '-c', $command], $descriptorSpec, $pipes, null, $env + [
+            'PATH' => '/bin:/usr/bin',
+        ]);
+
+        if (!\is_resource($process)) {
+            self::fail('Failed to start process.');
+        }
+
+        $output = \stream_get_contents($pipes[1]) . \stream_get_contents($pipes[2]);
+        \fclose($pipes[1]);
+        \fclose($pipes[2]);
+
+        return [
+            'code' => \proc_close($process),
+            'output' => $this->stripAnsi($output),
+        ];
+    }
+
+    private function stripAnsi(string $output): string
+    {
+        return \preg_replace('/(?:\x1B|\\\\e)\[[0-9;]*m/', '', $output) ?? $output;
+    }
+
+    private function removePath(string $path): void
+    {
+        if (\is_dir($path)) {
+            foreach (\scandir($path) ?: [] as $entry) {
+                if ($entry === '.' || $entry === '..') {
+                    continue;
+                }
+                $this->removePath($path . '/' . $entry);
+            }
+            \rmdir($path);
+
+            return;
+        }
+
+        if (\file_exists($path)) {
+            \unlink($path);
+        }
+    }
+}


### PR DESCRIPTION
## What does this PR do?

Adds an opt-in build manifest step to the build lifecycle: when `OPEN_RUNTIMES_BUILD_MANIFEST` is set (e.g. `/mnt/code/manifest.json`), `build.sh` writes a versioned JSON manifest of the build output's file listing after packaging:

```json
{"version": 1, "files": ["index.html", "server/entry.mjs"]}
```

This lets orchestrators inspect the build output post-job — Appwrite reads it back through the jobs-service artifact system (`ReadArtifact` + artifact callback) to run SSR/static rendering detection for site builds, replacing the log-separator parsing (`{APPWRITE_DETECTION_SEPARATOR_*}`) the executor path uses today. A structured document keeps it extensible: future fields (sizes, framework hints, timings) become sibling keys with no format break.

Implementation notes:
- New standalone `helpers/build-manifest.sh`, invoked from `lifecycle/build.sh` after `Build packaging finished.` with the output directory as the working directory. Best-effort like the build-cache helpers: unset variable is a no-op, and no failure mode fails the build.
- Listing prunes `node_modules`, excludes the archive artifacts (`code.tar.gz` / `code.sqfs` / …, mirroring the archive step's excludes), strips the leading `./`, and caps at `OPEN_RUNTIMES_BUILD_MANIFEST_MAX_FILES` (default 10000).
- JSON encoding via `jq` when available, with a printf/sed escaper fallback for images without it.
- Atomic write (`.tmp` + `mv`) so a consumer never reads a half-written manifest.

## Test Plan

`tests/BuildManifest.php` (same harness pattern as `tests/BuildCache.php`): no-op when unset, versioned manifest with correct listing, node_modules/archive exclusion, special-character escaping (validated by decoding), file-count cap, empty output, and lifecycle ordering.

## Related PRs and Issues

Companion to appwrite/appwrite `feat/sites-on-orchestrator` (sites builds on the jobs-service backend); Appwrite's Jobs worker joins build readiness on this manifest's artifact callback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)