### PR TITLE
Hide SquashFS build output on success

### DIFF
--- a/helpers/lifecycle/build.sh
+++ b/helpers/lifecycle/build.sh
@@ -88,12 +88,13 @@ if [ "$COMPRESSION_METHOD" = "none" ]; then
 elif [ "$COMPRESSION_METHOD" = "squashfs" ]; then
 	processors=$(nproc 2>/dev/null || echo 1)
 	squashfs_log=$(mktemp)
+	trap 'rm -f "$squashfs_log"' EXIT
 	if mksquashfs . "$OUTPUT_DIR/code.sqfs" -comp lz4 -b 1M -noappend -no-xattrs -no-progress -processors "$processors" -wildcards -e code.sqfs code.tar code.tar.gz code.gz >"$squashfs_log" 2>&1; then
 		rm -f "$squashfs_log"
+		trap - EXIT
 	else
 		status=$?
-		cat "$squashfs_log"
-		rm -f "$squashfs_log"
+		cat "$squashfs_log" >&2
 		exit "$status"
 	fi
 elif [ "$COMPRESSION_METHOD" = "zstd" ]; then

--- a/helpers/lifecycle/build.sh
+++ b/helpers/lifecycle/build.sh
@@ -87,7 +87,15 @@ if [ "$COMPRESSION_METHOD" = "none" ]; then
 	tar --exclude code.sqfs --exclude code.tar --exclude code.tar.gz --exclude code.gz -cf "$OUTPUT_DIR/code.tar.gz" .
 elif [ "$COMPRESSION_METHOD" = "squashfs" ]; then
 	processors=$(nproc 2>/dev/null || echo 1)
-	mksquashfs . "$OUTPUT_DIR/code.sqfs" -comp lz4 -b 1M -noappend -no-xattrs -no-progress -processors "$processors" -wildcards -e code.sqfs code.tar code.tar.gz code.gz
+	squashfs_log=$(mktemp)
+	if mksquashfs . "$OUTPUT_DIR/code.sqfs" -comp lz4 -b 1M -noappend -no-xattrs -no-progress -processors "$processors" -wildcards -e code.sqfs code.tar code.tar.gz code.gz >"$squashfs_log" 2>&1; then
+		rm -f "$squashfs_log"
+	else
+		status=$?
+		cat "$squashfs_log"
+		rm -f "$squashfs_log"
+		exit "$status"
+	fi
 elif [ "$COMPRESSION_METHOD" = "zstd" ]; then
 	tar --exclude code.sqfs --exclude code.tar --exclude code.tar.gz --exclude code.gz -cf - . | zstd -qf -o "$OUTPUT_DIR/code.tar.gz"
 else


### PR DESCRIPTION
## Summary
- capture build-output `mksquashfs` logs during packaging
- replay the logs only when compression fails
- preserve the original failure status

## Testing
- `bash -n helpers/lifecycle/build.sh`
- `shellcheck helpers/lifecycle/build.sh`
- `git diff --check origin/main...HEAD`