### PR TITLE
fix: dirname for build cache artifact directory

### DIFF
--- a/helpers/build-cache-save.sh
+++ b/helpers/build-cache-save.sh
@@ -9,7 +9,7 @@ log() {
 
 tmp_artifact="${OPEN_RUNTIMES_BUILD_CACHE_ARTIFACT}.tmp"
 rm -f "$tmp_artifact"
-artifact_dir="${OPEN_RUNTIMES_BUILD_CACHE_ARTIFACT%/*}"
+artifact_dir=$(dirname "$OPEN_RUNTIMES_BUILD_CACHE_ARTIFACT")
 
 file_size() {
 	wc -c <"$1" | tr -d ' '

--- a/tests/BuildCache.php
+++ b/tests/BuildCache.php
@@ -83,16 +83,17 @@ class BuildCache extends TestCase
         $this->assertBuildCacheLogContains('Build cache save skipped: cache root missing.', $result['output']);
     }
 
-    public function testSaveWithMissingArtifactDirectoryExitsZero(): void
+    public function testSaveWithUncreatableArtifactDirectoryExitsZero(): void
     {
         \mkdir($this->cacheRoot(), 0777, true);
-        $this->writeTestCachePaths($this->cacheRoot(), $this->root . '/missing/stores.sqfs');
+        \file_put_contents($this->root . '/blocker', 'file');
+        $this->writeTestCachePaths($this->cacheRoot(), $this->root . '/blocker/stores.sqfs');
         $bin = $this->createBinDir(['mksquashfs' => "#!/bin/sh\nexit 1\n"]);
 
         $result = $this->runScript('build-cache-save.sh', $bin);
 
         self::assertSame(0, $result['code']);
-        $this->assertBuildCacheLogContains('Build cache save skipped: artifact directory missing.', $result['output']);
+        $this->assertBuildCacheLogContains('Build cache save skipped: artifact directory could not be created.', $result['output']);
     }
 
     public function testSaveFailureExitsZeroAndDeletesTemporaryArtifact(): void
@@ -141,6 +142,28 @@ class BuildCache extends TestCase
         self::assertStringNotContainsString('squashfs stderr', $result['output']);
         self::assertFileExists($this->artifact());
         self::assertFileDoesNotExist($this->artifact() . '.tmp');
+    }
+
+    public function testRelativeArtifactPathWritesFileNotDirectory(): void
+    {
+        \mkdir($this->cacheRoot(), 0777, true);
+        \file_put_contents($this->cacheRoot() . '/store', 'cache');
+        $this->writeTestCachePaths($this->cacheRoot(), 'stores.sqfs');
+        $bin = $this->createBinDir([
+            'mksquashfs' => "#!/bin/sh\nprintf saved > \"$2\"\nexit 0\n",
+        ]);
+
+        $result = $this->runShell(
+            'cd ' . \escapeshellarg($this->root) . ' && /bin/bash ' . \escapeshellarg($this->helpers . '/build-cache-save.sh'),
+            $bin
+        );
+
+        self::assertSame(0, $result['code']);
+        $this->assertBuildCacheLogContains('Build cache saved.', $result['output']);
+        $path = $this->root . '/stores.sqfs';
+        self::assertFileExists($path);
+        self::assertDirectoryDoesNotExist($path);
+        self::assertSame('saved', \file_get_contents($path));
     }
 
     public function testSuccessfulSaveOverwritesExistingArtifact(): void


### PR DESCRIPTION
## What does this PR do?

Replaces the `${VAR%/*}` dirname pattern in `helpers/build-cache-save.sh` with `dirname`, fixing the same two edge cases as the build-manifest fix in #515 (where this was flagged during review but left out of scope):

- A separator-less artifact path (e.g. `stores.sqfs`) resolved to itself, so the script created a *directory* named like the file and `mv` buried the artifact inside it.
- A root-level path (e.g. `/stores.sqfs`) stripped to an empty string, skipping the save despite a writable `/`.

Also repairs the stale `testSaveWithMissingArtifactDirectoryExitsZero` test, which predates the script gaining `mkdir -p`: with a creatable parent the save no longer skips, so the test now blocks creation with a file and asserts the current `could not be created` message.

## Test Plan

`tests/BuildCache.php` — new `testRelativeArtifactPathWritesFileNotDirectory` mirrors the #515 manifest test; full suite passes (21 tests, 90 assertions).

## Related PRs and Issues

Follow-up to #515.

🤖 Generated with [Claude Code](https://claude.com/claude-code)