### PR TITLE
Add clock anchors and Node boot-phase timing to cold-start telemetry

### DIFF
--- a/helpers/lifecycle/start.sh
+++ b/helpers/lifecycle/start.sh
@@ -7,6 +7,16 @@ shopt -s dotglob
 
 . /usr/local/server/helpers/lifecycle/lib.sh
 
+# Wall-clock + uptime anchor pair: every other value in timings.txt is an
+# uptime-based delta, which is unmappable to the controller's timeline on its
+# own. The pair lets the controller convert any uptime reading to wall time.
+# Anchor keys are absolute stamps, never durations — the controller excludes
+# them from histograms.
+anchor_wall=$(date +%s.%N)
+[[ "$anchor_wall" == *N* ]] && anchor_wall=$(date +%s) # busybox date without %N
+echo "anchor_wall=$anchor_wall" >>/mnt/telemetry/timings.txt
+echo "anchor_uptime=$(opr_uptime)" >>/mnt/telemetry/timings.txt
+
 # Extract code (handles sidecar pre-extraction)
 . /usr/local/server/helpers/lifecycle/extract.sh
 
@@ -26,9 +36,12 @@ opr_log "Environment preparation finished."
 
 opr_success "Runtime started."
 
-# Capture start time for startup metric
+# Capture start time for startup metric. The anchor stamp marks the exact
+# server-process exec point on the shared uptime timeline, so the controller
+# can compute exec → runtime-main against the process's own timeOrigin.
 start_uptime=$(opr_uptime)
 export start_uptime
+echo "anchor_server_start_uptime=$start_uptime" >>/mnt/telemetry/timings.txt
 
 # Run server and monitor stdout for ready message
 bash -c "$1" 2>&1 | {

--- a/helpers/lifecycle/start.sh
+++ b/helpers/lifecycle/start.sh
@@ -12,10 +12,13 @@ shopt -s dotglob
 # own. The pair lets the controller convert any uptime reading to wall time.
 # Anchor keys are absolute stamps, never durations — the controller excludes
 # them from histograms.
+# Capture both stamps back-to-back before writing — the file appends can
+# stall on disk I/O and would skew the pair.
 anchor_wall=$(date +%s.%N)
+anchor_uptime=$(opr_uptime)
 [[ "$anchor_wall" == *N* ]] && anchor_wall=$(date +%s) # busybox date without %N
 echo "anchor_wall=$anchor_wall" >>/mnt/telemetry/timings.txt
-echo "anchor_uptime=$(opr_uptime)" >>/mnt/telemetry/timings.txt
+echo "anchor_uptime=$anchor_uptime" >>/mnt/telemetry/timings.txt
 
 # Extract code (handles sidecar pre-extraction)
 . /usr/local/server/helpers/lifecycle/extract.sh

--- a/runtimes/javascript/src/ssr/http-injection.mjs
+++ b/runtimes/javascript/src/ssr/http-injection.mjs
@@ -8,7 +8,9 @@
 import {
   addOprEndpoints,
   addAuthenticationCheck,
+  addFirstRequestTiming,
   addSafeTimeout,
+  recordServerListening,
 } from "./system.mjs";
 import { Logger, loggingNamespace } from "./logger.mjs";
 
@@ -29,6 +31,8 @@ export function overrideEmit(originalEmit) {
     if (addAuthenticationCheck(req, res)) {
       return;
     }
+
+    addFirstRequestTiming(req, res);
 
     req.loggerId = Logger.start(
       req.headers["x-open-runtimes-logging"],
@@ -79,6 +83,7 @@ export function wrapServer(originalServer) {
   return function (...args) {
     const server = originalServer.apply(this, args);
     server.emit = overrideEmit(server.emit);
+    server.once("listening", recordServerListening);
     return server;
   };
 }
@@ -88,6 +93,7 @@ export function wrapCreateServer(originalCreateServer) {
   return function (...args) {
     const server = new originalCreateServer(...args);
     server.emit = overrideEmit(server.emit);
+    server.once("listening", recordServerListening);
     return server;
   };
 }

--- a/runtimes/javascript/src/ssr/system.mjs
+++ b/runtimes/javascript/src/ssr/system.mjs
@@ -1,4 +1,71 @@
+import { appendFileSync } from "node:fs";
 import { readFile } from "node:fs/promises";
+
+const TIMINGS_PATH = "/mnt/telemetry/timings.txt";
+
+// Monotonic offset (seconds since process start) when the SSR server socket
+// started listening; also gates the one-shot first_request stamp.
+let listenedAt;
+let firstRequestPending = true;
+
+function recordTiming(key, seconds) {
+  try {
+    appendFileSync(TIMINGS_PATH, `${key}=${seconds.toFixed(6)}\n`);
+  } catch {
+    // Telemetry must never break the runtime.
+  }
+}
+
+// Called on the wrapped server's "listening" event. Emits boot milestones as
+// offsets from process start (seconds) and the wall-clock anchor for the
+// process timeline. nodeTiming is Node-only (absent on bun); milestones of -1
+// mean "not reached" and are skipped so a missing key signals that.
+export function recordServerListening() {
+  if (listenedAt !== undefined) {
+    return;
+  }
+  listenedAt = performance.now();
+
+  const nodeTiming = performance.nodeTiming;
+  if (nodeTiming) {
+    if (nodeTiming.bootstrapComplete >= 0) {
+      recordTiming("node_boot", nodeTiming.bootstrapComplete / 1000);
+    }
+    if (nodeTiming.environment >= 0) {
+      recordTiming("env_ready", nodeTiming.environment / 1000);
+    }
+  }
+  recordTiming("listen", listenedAt / 1000);
+  recordTiming("anchor_node_wall", performance.timeOrigin / 1000);
+}
+
+// Stamp listen → first response on the first real request (the /__opr
+// endpoints return before this is installed). Wraps writeHead so the value is
+// measured when the response is ready — after any first-render/route-compile
+// work — and can still travel as a response header to the executor.
+export function addFirstRequestTiming(req, res) {
+  if (!firstRequestPending || listenedAt === undefined) {
+    return;
+  }
+  firstRequestPending = false;
+
+  const originalWriteHead = res.writeHead;
+  res.writeHead = function (...args) {
+    const firstRequest = (performance.now() - listenedAt) / 1000;
+    recordTiming("first_request", firstRequest);
+    try {
+      if (!res.headersSent) {
+        res.setHeader(
+          "x-open-runtimes-timings",
+          `first_request=${firstRequest.toFixed(6)}`,
+        );
+      }
+    } catch {
+      // Telemetry must never break the response.
+    }
+    return originalWriteHead.apply(this, args);
+  };
+}
 
 export function addOprEndpoints(req, res) {
   if (req.method === "GET" && req.url === "/__opr/health") {

--- a/runtimes/node/versions/latest/src/server.js
+++ b/runtimes/node/versions/latest/src/server.js
@@ -39,12 +39,7 @@ const server = micro(async (req, res) => {
   );
 
   try {
-    const result = await action(logger, req, res);
-    if (!firstRequestRecorded && listenedAt !== undefined) {
-      firstRequestRecorded = true;
-      recordTiming("first_request", (performance.now() - listenedAt) / 1000);
-    }
-    return result;
+    return await action(logger, req, res);
   } catch (e) {
     logger.write([e], Logger.TYPE_ERROR);
 
@@ -52,6 +47,13 @@ const server = micro(async (req, res) => {
     await logger.end();
 
     return send(res, 500, "");
+  } finally {
+    // Stamp the first real request whether it succeeded or threw —
+    // otherwise a later request would be misattributed as first_request.
+    if (!firstRequestRecorded && listenedAt !== undefined) {
+      firstRequestRecorded = true;
+      recordTiming("first_request", (performance.now() - listenedAt) / 1000);
+    }
   }
 });
 
@@ -227,14 +229,16 @@ const action = async (logger, req, res) => {
         } else {
           throw err;
         }
-      }
-
-      if (!userCodeInitRecorded) {
-        userCodeInitRecorded = true;
-        recordTiming(
-          "user_code_init",
-          (performance.now() - userCodeStart) / 1000,
-        );
+      } finally {
+        // Stamp the first load attempt even when it throws — a retry on a
+        // later request would otherwise be recorded as the cold-start cost.
+        if (!userCodeInitRecorded) {
+          userCodeInitRecorded = true;
+          recordTiming(
+            "user_code_init",
+            (performance.now() - userCodeStart) / 1000,
+          );
+        }
       }
 
       const fn = userFunction.default || userFunction;
@@ -334,12 +338,18 @@ Logger.ready.then(() => {
     listenedAt = performance.now();
 
     // Boot milestones as offsets from process start (seconds): Node core
-    // bootstrap, environment ready, and socket listening. Guard for -1
-    // (milestone not reached). anchor_node_wall is the wall-clock epoch of
-    // process start (timeOrigin) — an absolute stamp, not a duration.
+    // bootstrap, environment ready, and socket listening. A milestone of -1
+    // means "not reached" — skip it so a missing key signals that, instead
+    // of masquerading as a zero-duration event. anchor_node_wall is the
+    // wall-clock epoch of process start (timeOrigin) — an absolute stamp,
+    // not a duration.
     const nodeTiming = performance.nodeTiming;
-    recordTiming("node_boot", Math.max(0, nodeTiming.bootstrapComplete) / 1000);
-    recordTiming("env_ready", Math.max(0, nodeTiming.environment) / 1000);
+    if (nodeTiming.bootstrapComplete >= 0) {
+      recordTiming("node_boot", nodeTiming.bootstrapComplete / 1000);
+    }
+    if (nodeTiming.environment >= 0) {
+      recordTiming("env_ready", nodeTiming.environment / 1000);
+    }
     recordTiming("listen", listenedAt / 1000);
     recordTiming("anchor_node_wall", performance.timeOrigin / 1000);
 

--- a/runtimes/node/versions/latest/src/server.js
+++ b/runtimes/node/versions/latest/src/server.js
@@ -1,9 +1,25 @@
 const micro = require("micro");
 const { buffer, send } = require("micro");
 const fs = require("fs");
+const { performance } = require("perf_hooks");
 const Logger = require("./logger");
 
 const USER_CODE_PATH = "/usr/local/server/src/function";
+const TIMINGS_PATH = "/mnt/telemetry/timings.txt";
+
+// Monotonic offset (seconds since process start) when the server socket
+// started listening; also gates the one-shot first_request stamp.
+let listenedAt;
+let firstRequestRecorded = false;
+let userCodeInitRecorded = false;
+
+const recordTiming = (key, seconds) => {
+  try {
+    fs.appendFileSync(TIMINGS_PATH, `${key}=${seconds.toFixed(6)}\n`);
+  } catch {
+    // Telemetry must never break the runtime.
+  }
+};
 
 const server = micro(async (req, res) => {
   if (req.url === "/__opr/health") {
@@ -23,7 +39,12 @@ const server = micro(async (req, res) => {
   );
 
   try {
-    await action(logger, req, res);
+    const result = await action(logger, req, res);
+    if (!firstRequestRecorded && listenedAt !== undefined) {
+      firstRequestRecorded = true;
+      recordTiming("first_request", (performance.now() - listenedAt) / 1000);
+    }
+    return result;
   } catch (e) {
     logger.write([e], Logger.TYPE_ERROR);
 
@@ -194,6 +215,9 @@ const action = async (logger, req, res) => {
 
   // Guard: Try to load module
   if (output === null) {
+    // User code loads lazily on the first request ("suppressed init"), so
+    // stamp it as an explicit phase instead of losing it in request latency.
+    const userCodeStart = performance.now();
     try {
       try {
         userFunction = require(entrypointFilePath);
@@ -203,6 +227,14 @@ const action = async (logger, req, res) => {
         } else {
           throw err;
         }
+      }
+
+      if (!userCodeInitRecorded) {
+        userCodeInitRecorded = true;
+        recordTiming(
+          "user_code_init",
+          (performance.now() - userCodeStart) / 1000,
+        );
       }
 
       const fn = userFunction.default || userFunction;
@@ -299,6 +331,18 @@ const action = async (logger, req, res) => {
 
 Logger.ready.then(() => {
   server.listen(3000, undefined, undefined, () => {
+    listenedAt = performance.now();
+
+    // Boot milestones as offsets from process start (seconds): Node core
+    // bootstrap, environment ready, and socket listening. Guard for -1
+    // (milestone not reached). anchor_node_wall is the wall-clock epoch of
+    // process start (timeOrigin) — an absolute stamp, not a duration.
+    const nodeTiming = performance.nodeTiming;
+    recordTiming("node_boot", Math.max(0, nodeTiming.bootstrapComplete) / 1000);
+    recordTiming("env_ready", Math.max(0, nodeTiming.environment) / 1000);
+    recordTiming("listen", listenedAt / 1000);
+    recordTiming("anchor_node_wall", performance.timeOrigin / 1000);
+
     console.log("HTTP server successfully started!");
   });
 });

--- a/runtimes/node/versions/latest/src/server.js
+++ b/runtimes/node/versions/latest/src/server.js
@@ -12,6 +12,8 @@ const TIMINGS_PATH = "/mnt/telemetry/timings.txt";
 let listenedAt;
 let firstRequestRecorded = false;
 let userCodeInitRecorded = false;
+let userCodeInitSeconds;
+let timingsHeaderSent = false;
 
 const recordTiming = (key, seconds) => {
   try {
@@ -234,10 +236,8 @@ const action = async (logger, req, res) => {
         // later request would otherwise be recorded as the cold-start cost.
         if (!userCodeInitRecorded) {
           userCodeInitRecorded = true;
-          recordTiming(
-            "user_code_init",
-            (performance.now() - userCodeStart) / 1000,
-          );
+          userCodeInitSeconds = (performance.now() - userCodeStart) / 1000;
+          recordTiming("user_code_init", userCodeInitSeconds);
         }
       }
 
@@ -325,6 +325,20 @@ const action = async (logger, req, res) => {
     !contentTypeValue.includes("charset=")
   ) {
     res.setHeader("content-type", contentTypeValue + "; charset=utf-8");
+  }
+
+  // Report first-request timing phases inline on the first response: the
+  // executor's /__opr/timings scrape happens at readiness, before these
+  // exist. The x-open-runtimes- prefix keeps the header executor-internal.
+  if (!timingsHeaderSent && listenedAt !== undefined) {
+    timingsHeaderSent = true;
+    const pairs = [
+      `first_request=${((performance.now() - listenedAt) / 1000).toFixed(6)}`,
+    ];
+    if (userCodeInitSeconds !== undefined) {
+      pairs.unshift(`user_code_init=${userCodeInitSeconds.toFixed(6)}`);
+    }
+    res.setHeader("x-open-runtimes-timings", pairs.join(";"));
   }
 
   res.setHeader("x-open-runtimes-log-id", logger.id);


### PR DESCRIPTION
Adds clock anchors to the lifecycle telemetry and finer-grained boot timing to the Node runtime and SSR servers:

- `start.sh` writes `anchor_wall`/`anchor_uptime` (captured back-to-back) and `anchor_server_start_uptime` stamps so the uptime-based deltas in `timings.txt` can be mapped to wall time by a consumer. `anchor_*` keys are absolute stamps, not durations.
- The Node runtime emits `node_boot`, `env_ready`, `listen` (via `perf_hooks` `nodeTiming`) plus `anchor_node_wall` (`timeOrigin`) at listen, stamps the first-request lazy require of user code as `user_code_init`, and records `first_request` (listen → first response). Both are also returned on the first response as an `x-open-runtimes-timings` header for executors.
- The SSR injection layer records the same milestones on the wrapped server's `listening` event and stamps `first_request` at `writeHead` of the first real request.

The `timings.txt` format is unchanged — only new keys are added.

## Why this approach

- **Anchor stamps over per-value wall clocks:** durations stay on the container's own monotonic timeline (immune to clock adjustments); a single wall/uptime pair per writer lets any executor convert them, paying cross-clock error once per join instead of per measurement. No new endpoints or protocol — the existing `timings.txt` transport carries everything.
- **`perf_hooks.nodeTiming` over tracing flags:** the boot milestones are already collected by Node at zero cost; no `--trace-events` overhead, no post-processing.
- **Response header over re-polling:** first-request phases exist only after the first request, later than any readiness-time scrape of `/__opr/timings`. Riding the first response costs zero extra requests, and the `x-open-runtimes-` prefix keeps it executor-internal (user code cannot set these headers, and executors already strip them).
- **One injection point over per-framework patches:** instrumenting `system.mjs`/`http-injection.mjs` covers every SSR framework on both node and bun with one implementation that can't drift per framework. Measuring at `writeHead` captures first-render/route-compile cost while headers can still be attached.
- **Telemetry can never break a request:** every write goes through a try/catch helper; unreached milestones are skipped rather than written as 0, so a missing key is meaningful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
