### PR TITLE
feat: load env config once at startup

### DIFF
--- a/runtimes/bun/versions/latest/src/config.ts
+++ b/runtimes/bun/versions/latest/src/config.ts
@@ -1,0 +1,11 @@
+let headers: Record<string, string> = {};
+try {
+  headers = JSON.parse(Bun.env["OPEN_RUNTIMES_HEADERS"] ?? "{}");
+} catch {}
+
+export const config = {
+  secret: Bun.env["OPEN_RUNTIMES_SECRET"] ?? "",
+  headers,
+  entrypoint: Bun.env["OPEN_RUNTIMES_ENTRYPOINT"] ?? "",
+  env: Bun.env["OPEN_RUNTIMES_ENV"] ?? "",
+};

--- a/runtimes/bun/versions/latest/src/logger.ts
+++ b/runtimes/bun/versions/latest/src/logger.ts
@@ -1,6 +1,8 @@
 const fs = require("node:fs");
 import superjson from "superjson";
 
+import { config } from "./config";
+
 export class Logger {
   static TYPE_ERROR = "error";
   static TYPE_LOG = "log";
@@ -19,7 +21,7 @@ export class Logger {
     if (this.enabled) {
       this.id = id
         ? id
-        : process.env.OPEN_RUNTIMES_ENV === "development"
+        : config.env === "development"
           ? "dev"
           : this.generateId();
       this.streamLogs = fs.createWriteStream(`/mnt/logs/${this.id}_logs.log`, {

--- a/runtimes/bun/versions/latest/src/server.ts
+++ b/runtimes/bun/versions/latest/src/server.ts
@@ -1,3 +1,4 @@
+import { config } from "./config";
 import { Logger } from "./logger";
 
 const USER_CODE_PATH = "/usr/local/server/src/function";
@@ -19,9 +20,8 @@ const action = async (logger: Logger, request: any) => {
   }
 
   if (
-    Bun.env["OPEN_RUNTIMES_SECRET"] &&
-    (request.headers.get("x-open-runtimes-secret") ?? "") !==
-      Bun.env["OPEN_RUNTIMES_SECRET"]
+    config.secret &&
+    (request.headers.get("x-open-runtimes-secret") ?? "") !== config.secret
   ) {
     return new Response(
       'Unauthorized. Provide correct "x-open-runtimes-secret" header.',
@@ -45,11 +45,8 @@ const action = async (logger: Logger, request: any) => {
       headers[header.toLowerCase()] = request.headers.get(header);
     });
 
-  const enforcedHeaders = JSON.parse(
-    Bun.env["OPEN_RUNTIMES_HEADERS"] ? Bun.env["OPEN_RUNTIMES_HEADERS"] : "{}",
-  );
-  for (const header in enforcedHeaders) {
-    headers[header.toLowerCase()] = `${enforcedHeaders[header]}`;
+  for (const header in config.headers) {
+    headers[header.toLowerCase()] = `${config.headers[header]}`;
   }
 
   const urlObject = new URL(request.url);
@@ -154,7 +151,7 @@ const action = async (logger: Logger, request: any) => {
   let output: any = null;
   let userFunction: any = null;
 
-  const entrypoint = Bun.env["OPEN_RUNTIMES_ENTRYPOINT"] ?? "";
+  const entrypoint = config.entrypoint;
   const entrypointFilePath = USER_CODE_PATH + "/" + entrypoint;
   const entrypointFile = Bun.file(entrypointFilePath);
 

--- a/runtimes/cpp/versions/latest/src/OprConfig.h
+++ b/runtimes/cpp/versions/latest/src/OprConfig.h
@@ -1,0 +1,47 @@
+#ifndef CPP_RUNTIME_OPRCONFIG_H
+#define CPP_RUNTIME_OPRCONFIG_H
+
+#include <cstdlib>
+#include <json/json.h>
+#include <string>
+
+namespace runtime {
+struct OprConfig {
+  std::string secret;
+  Json::Value headers;
+  std::string env;
+};
+
+inline const OprConfig &config() {
+  static const OprConfig instance = [] {
+    OprConfig config;
+
+    if (std::getenv("OPEN_RUNTIMES_SECRET") != nullptr) {
+      config.secret = std::getenv("OPEN_RUNTIMES_SECRET");
+    }
+
+    if (std::getenv("OPEN_RUNTIMES_ENV") != nullptr) {
+      config.env = std::getenv("OPEN_RUNTIMES_ENV");
+    }
+
+    if (std::getenv("OPEN_RUNTIMES_HEADERS") != nullptr) {
+      std::string serverHeadersString(std::getenv("OPEN_RUNTIMES_HEADERS"));
+
+      if (serverHeadersString.empty()) {
+        serverHeadersString = "{}";
+      }
+
+      Json::Reader reader;
+      if (!reader.parse(serverHeadersString, config.headers)) {
+        config.headers = Json::Value();
+      }
+    }
+
+    return config;
+  }();
+
+  return instance;
+}
+} // namespace runtime
+
+#endif // CPP_RUNTIME_OPRCONFIG_H

--- a/runtimes/cpp/versions/latest/src/RuntimeLogger.h
+++ b/runtimes/cpp/versions/latest/src/RuntimeLogger.h
@@ -1,6 +1,7 @@
 #ifndef CPP_RUNTIME_RUNTIMELOGGER_H
 #define CPP_RUNTIME_RUNTIMELOGGER_H
 
+#include "OprConfig.h"
 #include <chrono>
 #include <cstdlib>
 #include <ctime>
@@ -32,10 +33,7 @@ public:
     }
 
     if (enabled == true) {
-      std::string serverEnv = "";
-      if (std::getenv("OPEN_RUNTIMES_ENV") != nullptr) {
-        serverEnv = std::getenv("OPEN_RUNTIMES_ENV");
-      }
+      std::string serverEnv = config().env;
 
       if (headerId == "") {
         if (serverEnv == "development") {

--- a/runtimes/cpp/versions/latest/src/main.cc
+++ b/runtimes/cpp/versions/latest/src/main.cc
@@ -4,6 +4,7 @@
 #include "RuntimeRequest.h"
 #include "RuntimeOutput.h"
 #include "RuntimeContext.h"
+#include "OprConfig.h"
 #include "RuntimeLogger.h"
 #include "{entrypointFile}"
 #include <vector>
@@ -80,16 +81,14 @@ int main()
                         }
                     }
 
-                    if(std::getenv("OPEN_RUNTIMES_SECRET") != nullptr) {
-                        std::string serverSecret(std::getenv("OPEN_RUNTIMES_SECRET"));
-                        std::string secret = req->getHeader("x-open-runtimes-secret");
+                    const std::string &serverSecret = runtime::config().secret;
+                    std::string secret = req->getHeader("x-open-runtimes-secret");
 
-                        if(serverSecret != "" && secret != serverSecret) {
-                            res->setStatusCode(static_cast<drogon::HttpStatusCode>(500));
-                            res->setBody("Unauthorized. Provide correct \"x-open-runtimes-secret\" header.");
-                            callback(res);
-                            return;
-                        }
+                    if(serverSecret != "" && secret != serverSecret) {
+                        res->setStatusCode(static_cast<drogon::HttpStatusCode>(500));
+                        res->setBody("Unauthorized. Provide correct \"x-open-runtimes-secret\" header.");
+                        callback(res);
+                        return;
                     }
 
                     std::string method = req->getMethodString();
@@ -296,35 +295,19 @@ int main()
                         headers["cookie"] = cookieHeadersString;
                     }
 
-                    char* serverHeadersChar = std::getenv("OPEN_RUNTIMES_HEADERS");
-                    if(serverHeadersChar != nullptr) {
-                        std::string serverHeadersString(serverHeadersChar);
+                    const Json::Value &serverHeaders = runtime::config().headers;
+                    for (const std::string &key : serverHeaders.getMemberNames())
+                    {
+                        std::string headerKey = key;
+                        std::transform(
+                            headerKey.begin(),
+                            headerKey.end(),
+                            headerKey.begin(),
+                            [](unsigned char c){ return std::tolower(c); }
+                        );
 
-                        if(serverHeadersString.empty()) {
-                            serverHeadersString = "{}";
-                        }
-
-                        Json::Value serverHeaders;
-                        Json::Reader serverHeadersReader;
-                        bool parsingResult = serverHeadersReader.parse(serverHeadersString, serverHeaders);
-                        if(!parsingResult)
-                        {
-                            throw std::runtime_error("Invalid JSON body.");
-                        }
-
-                        for (const std::string &key : serverHeaders.getMemberNames())
-                        {
-                            std::string headerKey = key;
-                            std::transform(
-                                headerKey.begin(),
-                                headerKey.end(),
-                                headerKey.begin(),
-                                [](unsigned char c){ return std::tolower(c); }
-                            );
-
-                            auto value = serverHeaders[key];
-                            headers[headerKey] = value.asString();
-                        }
+                        auto value = serverHeaders[key];
+                        headers[headerKey] = value.asString();
                     }
 
                     runtimeRequest.headers = headers;

--- a/runtimes/dart/versions/latest/src/config.dart
+++ b/runtimes/dart/versions/latest/src/config.dart
@@ -1,0 +1,13 @@
+import 'dart:convert';
+import 'dart:io';
+
+final String secret = Platform.environment['OPEN_RUNTIMES_SECRET'] ?? '';
+final String env = Platform.environment['OPEN_RUNTIMES_ENV'] ?? '';
+final Map<String, dynamic> headers = () {
+  try {
+    return jsonDecode(Platform.environment['OPEN_RUNTIMES_HEADERS'] ?? '{}')
+        as Map<String, dynamic>;
+  } catch (e) {
+    return <String, dynamic>{};
+  }
+}();

--- a/runtimes/dart/versions/latest/src/logger.dart
+++ b/runtimes/dart/versions/latest/src/logger.dart
@@ -21,9 +21,7 @@ class Logger {
     if (this.enabled) {
       this.id = id != null
           ? id
-          : (config.env == 'development'
-                ? 'dev'
-                : this.generateId());
+          : (config.env == 'development' ? 'dev' : this.generateId());
 
       this.streamLogs = File(
         '/mnt/logs/' + this.id + '_logs.log',

--- a/runtimes/dart/versions/latest/src/logger.dart
+++ b/runtimes/dart/versions/latest/src/logger.dart
@@ -2,6 +2,8 @@ import 'dart:math';
 import 'dart:convert';
 import 'dart:io';
 
+import 'config.dart' as config;
+
 class Logger {
   static final String TYPE_ERROR = 'error';
   static final String TYPE_LOG = 'log';
@@ -19,7 +21,7 @@ class Logger {
     if (this.enabled) {
       this.id = id != null
           ? id
-          : (Platform.environment['OPEN_RUNTIMES_ENV'] == 'development'
+          : (config.env == 'development'
                 ? 'dev'
                 : this.generateId());
 

--- a/runtimes/dart/versions/latest/src/server.dart
+++ b/runtimes/dart/versions/latest/src/server.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 import 'package:shelf/shelf.dart' as shelf;
 import 'package:shelf/shelf_io.dart' as shelf_io;
 import '{entrypoint}' as user_code;
+import 'config.dart' as config;
 import 'function_types.dart';
 import 'logger.dart';
 
@@ -21,9 +22,8 @@ Future<shelf.Response> action(Logger logger, dynamic req) async {
     }
   }
 
-  if ((Platform.environment['OPEN_RUNTIMES_SECRET'] ?? '') != '' &&
-      (req.headers['x-open-runtimes-secret'] ?? '') !=
-          Platform.environment['OPEN_RUNTIMES_SECRET']) {
+  if (config.secret != '' &&
+      (req.headers['x-open-runtimes-secret'] ?? '') != config.secret) {
     return shelf.Response(
       500,
       body: 'Unauthorized. Provide correct "x-open-runtimes-secret" header.',
@@ -57,13 +57,7 @@ Future<shelf.Response> action(Logger logger, dynamic req) async {
     }
   }
 
-  String? enforcedHeadersString = Platform.environment['OPEN_RUNTIMES_HEADERS'];
-  final enforcedHeaders = jsonDecode(
-    (enforcedHeadersString != null && !enforcedHeadersString.isEmpty)
-        ? enforcedHeadersString
-        : '{}',
-  );
-  enforcedHeaders.forEach((key, value) {
+  config.headers.forEach((key, value) {
     headers[key.toLowerCase()] = '${value}';
   });
 

--- a/runtimes/deno/versions/latest/src/action.ts
+++ b/runtimes/deno/versions/latest/src/action.ts
@@ -1,5 +1,6 @@
 import { Logger } from "./logger.ts";
 import { getContextBody } from "./getContextBody.ts";
+import { config } from "./config.ts";
 
 const USER_CODE_PATH = "/usr/local/server/src/function";
 
@@ -18,9 +19,9 @@ export const action = async (logger: Logger, ctx: any) => {
   }
 
   if (
-    Deno.env.get("OPEN_RUNTIMES_SECRET") &&
+    config.secret &&
     (ctx.request.headers.get("x-open-runtimes-secret") ?? "") !==
-      Deno.env.get("OPEN_RUNTIMES_SECRET")
+      config.secret
   ) {
     ctx.response.status = 500;
     ctx.response.body =
@@ -51,13 +52,8 @@ export const action = async (logger: Logger, ctx: any) => {
     headers[header.toLowerCase()] = ctx.request.headers.get(header);
   });
 
-  const enforcedHeaders = JSON.parse(
-    Deno.env.get("OPEN_RUNTIMES_HEADERS")
-      ? (Deno.env.get("OPEN_RUNTIMES_HEADERS") ?? "{}")
-      : "{}",
-  );
-  for (const header in enforcedHeaders) {
-    headers[header.toLowerCase()] = `${enforcedHeaders[header]}`;
+  for (const header in config.headers) {
+    headers[header.toLowerCase()] = `${config.headers[header]}`;
   }
 
   const scheme = ctx.request.headers.get("x-forwarded-proto") ?? "http";
@@ -162,7 +158,7 @@ export const action = async (logger: Logger, ctx: any) => {
   let output: any = null;
   let userFunction: any = null;
 
-  const entrypoint = Deno.env.get("OPEN_RUNTIMES_ENTRYPOINT") ?? "";
+  const entrypoint = config.entrypoint;
   const entrypointFilePath = USER_CODE_PATH + "/" + entrypoint;
 
   // Guard: Check file exists

--- a/runtimes/deno/versions/latest/src/config.ts
+++ b/runtimes/deno/versions/latest/src/config.ts
@@ -1,0 +1,14 @@
+function parseHeaders(): Record<string, unknown> {
+  try {
+    return JSON.parse(Deno.env.get("OPEN_RUNTIMES_HEADERS") || "{}");
+  } catch {
+    return {};
+  }
+}
+
+export const config = {
+  secret: Deno.env.get("OPEN_RUNTIMES_SECRET") ?? "",
+  headers: parseHeaders(),
+  entrypoint: Deno.env.get("OPEN_RUNTIMES_ENTRYPOINT") ?? "",
+  env: Deno.env.get("OPEN_RUNTIMES_ENV") ?? "",
+};

--- a/runtimes/deno/versions/latest/src/logger.ts
+++ b/runtimes/deno/versions/latest/src/logger.ts
@@ -1,5 +1,6 @@
 import { fileStreamReady } from "./fileStreamReady.ts";
 import { JSONParse } from "./jsonParser.ts";
+import { config } from "./config.ts";
 
 export class Logger {
   static TYPE_ERROR = "error";
@@ -21,7 +22,7 @@ export class Logger {
     if (this.enabled) {
       this.id = id
         ? id
-        : (Deno.env.get("OPEN_RUNTIMES_ENV") === "development"
+        : (config.env === "development"
           ? "dev"
           : this.generateId());
     }

--- a/runtimes/deno/versions/latest/src/logger.ts
+++ b/runtimes/deno/versions/latest/src/logger.ts
@@ -22,9 +22,7 @@ export class Logger {
     if (this.enabled) {
       this.id = id
         ? id
-        : (config.env === "development"
-          ? "dev"
-          : this.generateId());
+        : (config.env === "development" ? "dev" : this.generateId());
     }
   }
 

--- a/runtimes/dotnet/versions/6.0/src/Program.cs
+++ b/runtimes/dotnet/versions/6.0/src/Program.cs
@@ -1,6 +1,5 @@
 using System.IO;
 using System.Text;
-using System.Text.Json;
 using System.Web;
 using DotNetRuntime;
 using Microsoft.AspNetCore.Mvc;
@@ -94,8 +93,7 @@ static async Task<IResult> Action(HttpRequest request, RuntimeLogger logger)
         ? secretValue.ToString()
         : string.Empty;
 
-    string serverSecret = Environment.GetEnvironmentVariable("OPEN_RUNTIMES_SECRET");
-    if (!string.IsNullOrEmpty(serverSecret) && secret != serverSecret)
+    if (!string.IsNullOrEmpty(OprConfig.Secret) && secret != OprConfig.Secret)
     {
         return new CustomResponse(
             System.Text.Encoding.UTF8.GetBytes(
@@ -127,18 +125,9 @@ static async Task<IResult> Action(HttpRequest request, RuntimeLogger logger)
         }
     }
 
-    String enforcedHeadersString = Environment.GetEnvironmentVariable("OPEN_RUNTIMES_HEADERS");
-    if (string.IsNullOrEmpty(enforcedHeadersString))
+    foreach (var entry in OprConfig.Headers)
     {
-        enforcedHeadersString = "{}";
-    }
-
-    Dictionary<string, object> enforcedHeaders =
-        JsonSerializer.Deserialize<Dictionary<string, object>>(enforcedHeadersString)
-        ?? new Dictionary<string, object>();
-    foreach (KeyValuePair<string, object> entry in enforcedHeaders)
-    {
-        headers[entry.Key.ToLower()] = Convert.ToString(entry.Value);
+        headers[entry.Key] = entry.Value;
     }
 
     var hostHeader = request.Headers.TryGetValue("host", out var hostHeaderValue)

--- a/runtimes/dotnet/versions/7.0/Program.cs
+++ b/runtimes/dotnet/versions/7.0/Program.cs
@@ -1,5 +1,4 @@
 using System.Text;
-using System.Text.Json;
 
 namespace DotNetRuntime
 {
@@ -97,8 +96,7 @@ namespace DotNetRuntime
                 ? secretValue.ToString()
                 : string.Empty;
 
-            string serverSecret = Environment.GetEnvironmentVariable("OPEN_RUNTIMES_SECRET");
-            if (!string.IsNullOrEmpty(serverSecret) && secret != serverSecret)
+            if (!string.IsNullOrEmpty(OprConfig.Secret) && secret != OprConfig.Secret)
             {
                 return new CustomResponse(
                     "Unauthorized. Provide correct \"x-open-runtimes-secret\" header."u8.ToArray(),
@@ -129,20 +127,9 @@ namespace DotNetRuntime
                 }
             }
 
-            String enforcedHeadersString = Environment.GetEnvironmentVariable(
-                "OPEN_RUNTIMES_HEADERS"
-            );
-            if (string.IsNullOrEmpty(enforcedHeadersString))
+            foreach (var entry in OprConfig.Headers)
             {
-                enforcedHeadersString = "{}";
-            }
-
-            Dictionary<string, object> enforcedHeaders =
-                JsonSerializer.Deserialize<Dictionary<string, object>>(enforcedHeadersString)
-                ?? new Dictionary<string, object>();
-            foreach (KeyValuePair<string, object> entry in enforcedHeaders)
-            {
-                headers[entry.Key.ToLower()] = Convert.ToString(entry.Value);
+                headers[entry.Key] = entry.Value;
             }
 
             var hostHeader = request.Headers.TryGetValue("host", out var hostHeaderValue)

--- a/runtimes/dotnet/versions/8.0/Program.cs
+++ b/runtimes/dotnet/versions/8.0/Program.cs
@@ -1,5 +1,4 @@
 using System.Text;
-using System.Text.Json;
 
 namespace DotNetRuntime
 {
@@ -97,8 +96,7 @@ namespace DotNetRuntime
                 ? secretValue.ToString()
                 : string.Empty;
 
-            string serverSecret = Environment.GetEnvironmentVariable("OPEN_RUNTIMES_SECRET");
-            if (!string.IsNullOrEmpty(serverSecret) && secret != serverSecret)
+            if (!string.IsNullOrEmpty(OprConfig.Secret) && secret != OprConfig.Secret)
             {
                 return new CustomResponse(
                     "Unauthorized. Provide correct \"x-open-runtimes-secret\" header."u8.ToArray(),
@@ -129,20 +127,9 @@ namespace DotNetRuntime
                 }
             }
 
-            String enforcedHeadersString = Environment.GetEnvironmentVariable(
-                "OPEN_RUNTIMES_HEADERS"
-            );
-            if (string.IsNullOrEmpty(enforcedHeadersString))
+            foreach (var entry in OprConfig.Headers)
             {
-                enforcedHeadersString = "{}";
-            }
-
-            Dictionary<string, object> enforcedHeaders =
-                JsonSerializer.Deserialize<Dictionary<string, object>>(enforcedHeadersString)
-                ?? new Dictionary<string, object>();
-            foreach (KeyValuePair<string, object> entry in enforcedHeaders)
-            {
-                headers[entry.Key.ToLower()] = Convert.ToString(entry.Value);
+                headers[entry.Key] = entry.Value;
             }
 
             var hostHeader = request.Headers.TryGetValue("host", out var hostHeaderValue)

--- a/runtimes/dotnet/versions/latest/src/OprConfig.cs
+++ b/runtimes/dotnet/versions/latest/src/OprConfig.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+
+namespace DotNetRuntime
+{
+    public static class OprConfig
+    {
+        public static readonly String Secret =
+            Environment.GetEnvironmentVariable("OPEN_RUNTIMES_SECRET") ?? "";
+        public static readonly String Env =
+            Environment.GetEnvironmentVariable("OPEN_RUNTIMES_ENV") ?? "";
+        public static readonly Dictionary<string, string> Headers = LoadHeaders();
+
+        private static Dictionary<string, string> LoadHeaders()
+        {
+            var headers = new Dictionary<string, string>();
+            var json = Environment.GetEnvironmentVariable("OPEN_RUNTIMES_HEADERS");
+
+            if (string.IsNullOrEmpty(json))
+            {
+                return headers;
+            }
+
+            try
+            {
+                var parsed =
+                    JsonSerializer.Deserialize<Dictionary<string, object>>(json)
+                    ?? new Dictionary<string, object>();
+                foreach (KeyValuePair<string, object> entry in parsed)
+                {
+                    headers[entry.Key.ToLower()] = Convert.ToString(entry.Value) ?? "";
+                }
+            }
+            catch (JsonException)
+            {
+                // Invalid JSON results in no enforced headers
+            }
+
+            return headers;
+        }
+    }
+}

--- a/runtimes/dotnet/versions/latest/src/RuntimeLogger.cs
+++ b/runtimes/dotnet/versions/latest/src/RuntimeLogger.cs
@@ -38,8 +38,7 @@ namespace DotNetRuntime
             {
                 if (string.IsNullOrEmpty(id))
                 {
-                    String? serverEnv = Environment.GetEnvironmentVariable("OPEN_RUNTIMES_ENV");
-                    if (!string.IsNullOrEmpty(serverEnv) && serverEnv == "development")
+                    if (OprConfig.Env == "development")
                     {
                         this.id = "dev";
                     }

--- a/runtimes/go/versions/latest/src/main.go
+++ b/runtimes/go/versions/latest/src/main.go
@@ -17,6 +17,37 @@ import (
 	"github.com/open-runtimes/types-for-go/v4/openruntimes"
 )
 
+var config = struct {
+	secret  string
+	headers map[string]string
+}{
+	secret:  os.Getenv("OPEN_RUNTIMES_SECRET"),
+	headers: loadHeaders(),
+}
+
+func loadHeaders() map[string]string {
+	headers := map[string]string{}
+
+	var parsed map[string]interface{}
+	if err := json.Unmarshal([]byte(os.Getenv("OPEN_RUNTIMES_HEADERS")), &parsed); err != nil {
+		return headers
+	}
+
+	for key, value := range parsed {
+		valueString := ""
+		switch v := value.(type) {
+		default:
+			valueString = fmt.Sprintf("%#v", value)
+		case string:
+			valueString = v
+		}
+
+		headers[strings.ToLower(key)] = valueString
+	}
+
+	return headers
+}
+
 func action(w http.ResponseWriter, r *http.Request, logger openruntimes.Logger) error {
 	timeout := r.Header.Get("x-open-runtimes-timeout")
 
@@ -36,9 +67,8 @@ func action(w http.ResponseWriter, r *http.Request, logger openruntimes.Logger) 
 	}
 
 	secret := r.Header.Get("x-open-runtimes-secret")
-	serverSecret := os.Getenv("OPEN_RUNTIMES_SECRET")
 
-	if serverSecret != "" && secret != serverSecret {
+	if config.secret != "" && secret != config.secret {
 		w.WriteHeader(http.StatusInternalServerError)
 		w.Header().Set("content-type", "text/plain")
 		w.Write([]byte("Unauthorized. Provide correct \"x-open-runtimes-secret\" header."))
@@ -64,27 +94,8 @@ func action(w http.ResponseWriter, r *http.Request, logger openruntimes.Logger) 
 		}
 	}
 
-	headersEnv := os.Getenv("OPEN_RUNTIMES_HEADERS")
-	if headersEnv == "" {
-		headersEnv = "{}"
-	}
-
-	var enforcedHeaders map[string]interface{}
-	err = json.Unmarshal([]byte(headersEnv), &enforcedHeaders)
-	if err != nil {
-		enforcedHeaders = map[string]interface{}{}
-	}
-
-	for key, value := range enforcedHeaders {
-		valueString := ""
-		switch v := value.(type) {
-		default:
-			valueString = fmt.Sprintf("%#v", value)
-		case string:
-			valueString = v
-		}
-
-		headers[strings.ToLower(key)] = valueString
+	for key, value := range config.headers {
+		headers[key] = value
 	}
 
 	method := r.Method

--- a/runtimes/java/versions/latest/src/main/java/io/openruntimes/java/OprConfig.java
+++ b/runtimes/java/versions/latest/src/main/java/io/openruntimes/java/OprConfig.java
@@ -1,0 +1,43 @@
+package io.openruntimes.java;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.ToNumberPolicy;
+import java.util.HashMap;
+import java.util.Map;
+
+public final class OprConfig {
+  public static final String SECRET;
+  public static final String ENTRYPOINT = System.getenv("OPEN_RUNTIMES_ENTRYPOINT");
+  public static final String ENV;
+  public static final Map<String, String> HEADERS;
+
+  static {
+    String secret = System.getenv("OPEN_RUNTIMES_SECRET");
+    SECRET = secret == null ? "" : secret;
+
+    String env = System.getenv("OPEN_RUNTIMES_ENV");
+    ENV = env == null ? "" : env;
+
+    Map<String, String> headers = new HashMap<>();
+    String headersString = System.getenv("OPEN_RUNTIMES_HEADERS");
+    if (headersString != null && !headersString.isEmpty()) {
+      Gson gson =
+          new GsonBuilder()
+              .serializeNulls()
+              .setObjectToNumberStrategy(ToNumberPolicy.LONG_OR_DOUBLE)
+              .create();
+      try {
+        Map<String, Object> parsed = gson.fromJson(headersString, Map.class);
+        for (Map.Entry<String, Object> entry : parsed.entrySet()) {
+          headers.put(entry.getKey().toLowerCase(), String.valueOf(entry.getValue()));
+        }
+      } catch (Exception e) {
+        // Ignore invalid enforced headers
+      }
+    }
+    HEADERS = headers;
+  }
+
+  private OprConfig() {}
+}

--- a/runtimes/java/versions/latest/src/main/java/io/openruntimes/java/RuntimeLogger.java
+++ b/runtimes/java/versions/latest/src/main/java/io/openruntimes/java/RuntimeLogger.java
@@ -48,13 +48,8 @@ public class RuntimeLogger {
     }
 
     if (this.enabled) {
-      String serverEnv = System.getenv("OPEN_RUNTIMES_ENV");
-      if (serverEnv == null) {
-        serverEnv = "";
-      }
-
       if (id.equals("")) {
-        if (serverEnv.equals("development")) {
+        if (OprConfig.ENV.equals("development")) {
           this.id = "dev";
         } else {
           this.id = this.generateId(7);

--- a/runtimes/java/versions/latest/src/main/java/io/openruntimes/java/Server.java
+++ b/runtimes/java/versions/latest/src/main/java/io/openruntimes/java/Server.java
@@ -1,8 +1,5 @@
 package io.openruntimes.java;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import com.google.gson.ToNumberPolicy;
 import io.javalin.Javalin;
 import io.javalin.http.Context;
 import java.io.IOException;
@@ -16,13 +13,6 @@ import java.util.Map;
 import java.util.concurrent.*;
 
 public class Server {
-
-  private static final Gson gson = new GsonBuilder().serializeNulls().create();
-  private static final Gson gsonInternal =
-      new GsonBuilder()
-          .serializeNulls()
-          .setObjectToNumberStrategy(ToNumberPolicy.LONG_OR_DOUBLE)
-          .create();
 
   private static final ExecutorService executor = Executors.newCachedThreadPool();
 
@@ -112,10 +102,7 @@ public class Server {
       }
     }
 
-    String serverSecret = System.getenv("OPEN_RUNTIMES_SECRET");
-    if (serverSecret == null) {
-      serverSecret = "";
-    }
+    String serverSecret = OprConfig.SECRET;
 
     String secret = ctx.header("x-open-runtimes-secret");
 
@@ -139,17 +126,7 @@ public class Server {
       }
     }
 
-    String enforcedHeadersString = System.getenv("OPEN_RUNTIMES_HEADERS");
-
-    if (enforcedHeadersString == null || enforcedHeadersString.isEmpty()) {
-      enforcedHeadersString = "{}";
-    }
-
-    Map<String, Object> enforcedHeaders = gsonInternal.fromJson(enforcedHeadersString, Map.class);
-
-    for (Map.Entry<String, Object> entry : enforcedHeaders.entrySet()) {
-      headers.put(entry.getKey().toLowerCase(), String.valueOf(entry.getValue()));
-    }
+    headers.putAll(OprConfig.HEADERS);
 
     String scheme = (scheme = ctx.header("x-forwarded-proto")) != null ? scheme : "http";
     String defaultPort = scheme.equals("https") ? "443" : "80";
@@ -203,7 +180,7 @@ public class Server {
     Method classMethod = null;
     Object instance = null;
 
-    String entrypoint = System.getenv("OPEN_RUNTIMES_ENTRYPOINT");
+    String entrypoint = OprConfig.ENTRYPOINT;
 
     // Guard: Try to load module
     try {

--- a/runtimes/javascript/src/server-analog.mjs
+++ b/runtimes/javascript/src/server-analog.mjs
@@ -5,14 +5,14 @@ console.log("Analog server starting ...");
 
 const app = express();
 
+const cacheHeader =
+  process.env.OPEN_RUNTIMES_CACHE_HEADER ?? "CDN-Cache-Control";
+
 // framework-specific logic
 app.use(
   express.static("public", {
     setHeaders: (res, _path) => {
-      res.setHeader(
-        process.env.OPEN_RUNTIMES_CACHE_HEADER ?? "CDN-Cache-Control",
-        "public, max-age=36000",
-      );
+      res.setHeader(cacheHeader, "public, max-age=36000");
     },
   }),
 );

--- a/runtimes/javascript/src/server-angular.mjs
+++ b/runtimes/javascript/src/server-angular.mjs
@@ -5,14 +5,14 @@ console.log("Angular server starting ...");
 
 const app = express();
 
+const cacheHeader =
+  process.env.OPEN_RUNTIMES_CACHE_HEADER ?? "CDN-Cache-Control";
+
 // framework-specific logic
 app.use(
   express.static("browser", {
     setHeaders: (res, _path) => {
-      res.setHeader(
-        process.env.OPEN_RUNTIMES_CACHE_HEADER ?? "CDN-Cache-Control",
-        "public, max-age=36000",
-      );
+      res.setHeader(cacheHeader, "public, max-age=36000");
     },
   }),
 );

--- a/runtimes/javascript/src/server-astro.mjs
+++ b/runtimes/javascript/src/server-astro.mjs
@@ -5,14 +5,14 @@ console.log("Astro server starting ...");
 
 const app = express();
 
+const cacheHeader =
+  process.env.OPEN_RUNTIMES_CACHE_HEADER ?? "CDN-Cache-Control";
+
 // framework-specific logic
 app.use(
   express.static("client", {
     setHeaders: (res, _path) => {
-      res.setHeader(
-        process.env.OPEN_RUNTIMES_CACHE_HEADER ?? "CDN-Cache-Control",
-        "public, max-age=36000",
-      );
+      res.setHeader(cacheHeader, "public, max-age=36000");
     },
   }),
 );

--- a/runtimes/javascript/src/server-next-js.mjs
+++ b/runtimes/javascript/src/server-next-js.mjs
@@ -6,14 +6,14 @@ console.log("Next.js server starting ...");
 
 const app = express();
 
+const cacheHeader =
+  process.env.OPEN_RUNTIMES_CACHE_HEADER ?? "CDN-Cache-Control";
+
 // framework-specific logic
 app.use(
   express.static("public", {
     setHeaders: (res, _path) => {
-      res.setHeader(
-        process.env.OPEN_RUNTIMES_CACHE_HEADER ?? "CDN-Cache-Control",
-        "public, max-age=36000",
-      );
+      res.setHeader(cacheHeader, "public, max-age=36000");
     },
   }),
 );

--- a/runtimes/javascript/src/server-nuxt.mjs
+++ b/runtimes/javascript/src/server-nuxt.mjs
@@ -5,14 +5,14 @@ console.log("Nuxt server starting ...");
 
 const app = express();
 
+const cacheHeader =
+  process.env.OPEN_RUNTIMES_CACHE_HEADER ?? "CDN-Cache-Control";
+
 // framework-specific logic
 app.use(
   express.static("public", {
     setHeaders: (res, _path) => {
-      res.setHeader(
-        process.env.OPEN_RUNTIMES_CACHE_HEADER ?? "CDN-Cache-Control",
-        "public, max-age=36000",
-      );
+      res.setHeader(cacheHeader, "public, max-age=36000");
     },
   }),
 );

--- a/runtimes/javascript/src/server-remix.mjs
+++ b/runtimes/javascript/src/server-remix.mjs
@@ -6,14 +6,14 @@ console.log("Remix server starting ...");
 
 const app = express();
 
+const cacheHeader =
+  process.env.OPEN_RUNTIMES_CACHE_HEADER ?? "CDN-Cache-Control";
+
 // framework-specific logic
 app.use(
   express.static("build/client", {
     setHeaders: (res, _path) => {
-      res.setHeader(
-        process.env.OPEN_RUNTIMES_CACHE_HEADER ?? "CDN-Cache-Control",
-        "public, max-age=36000",
-      );
+      res.setHeader(cacheHeader, "public, max-age=36000");
     },
   }),
 );

--- a/runtimes/javascript/src/server-sveltekit.mjs
+++ b/runtimes/javascript/src/server-sveltekit.mjs
@@ -5,14 +5,14 @@ console.log("SvelteKit server starting ...");
 
 const app = express();
 
+const cacheHeader =
+  process.env.OPEN_RUNTIMES_CACHE_HEADER ?? "CDN-Cache-Control";
+
 // framework-specific logic
 app.use(
   express.static("client", {
     setHeaders: (res, _path) => {
-      res.setHeader(
-        process.env.OPEN_RUNTIMES_CACHE_HEADER ?? "CDN-Cache-Control",
-        "public, max-age=36000",
-      );
+      res.setHeader(cacheHeader, "public, max-age=36000");
     },
   }),
 );

--- a/runtimes/javascript/src/server-tanstack-start.mjs
+++ b/runtimes/javascript/src/server-tanstack-start.mjs
@@ -6,14 +6,14 @@ console.log("TanStack Start server starting ...");
 
 const app = express();
 
+const cacheHeader =
+  process.env.OPEN_RUNTIMES_CACHE_HEADER ?? "CDN-Cache-Control";
+
 // framework-specific logic
 app.use(
   express.static("client", {
     setHeaders: (res, _path) => {
-      res.setHeader(
-        process.env.OPEN_RUNTIMES_CACHE_HEADER ?? "CDN-Cache-Control",
-        "public, max-age=36000",
-      );
+      res.setHeader(cacheHeader, "public, max-age=36000");
     },
   }),
 );

--- a/runtimes/javascript/src/ssr/logger.mjs
+++ b/runtimes/javascript/src/ssr/logger.mjs
@@ -6,6 +6,8 @@ import superjson from "superjson";
 // and Bun) instead of cls-hooked so both runtimes can consume the same file.
 export const loggingNamespace = new AsyncLocalStorage();
 
+const isDevelopment = process.env.OPEN_RUNTIMES_ENV === "development";
+
 export const nativeLog = console.log.bind(console);
 
 export class Logger {
@@ -20,10 +22,7 @@ export class Logger {
     }
 
     if (!id) {
-      id =
-        process.env.OPEN_RUNTIMES_ENV === "development"
-          ? "dev"
-          : Logger.generateId();
+      id = isDevelopment ? "dev" : Logger.generateId();
     }
 
     return id;

--- a/runtimes/javascript/src/ssr/system.mjs
+++ b/runtimes/javascript/src/ssr/system.mjs
@@ -1,5 +1,7 @@
 import { readFile } from "node:fs/promises";
 
+const serverSecret = process.env["OPEN_RUNTIMES_SECRET"];
+
 export function addOprEndpoints(req, res) {
   if (req.method === "GET" && req.url === "/__opr/health") {
     const body = "OK";
@@ -25,7 +27,6 @@ export function addOprEndpoints(req, res) {
 }
 
 export function addAuthenticationCheck(req, res) {
-  const serverSecret = process.env["OPEN_RUNTIMES_SECRET"];
   const headerSecret = req.headers["x-open-runtimes-secret"];
 
   if (serverSecret && serverSecret !== headerSecret) {

--- a/runtimes/kotlin/versions/latest/src/main/kotlin/io/openruntimes/kotlin/OprConfig.kt
+++ b/runtimes/kotlin/versions/latest/src/main/kotlin/io/openruntimes/kotlin/OprConfig.kt
@@ -1,0 +1,16 @@
+package io.openruntimes.kotlin
+
+object OprConfig {
+    val secret: String = System.getenv("OPEN_RUNTIMES_SECRET") ?: ""
+    val headers: Map<String, String> =
+        try {
+            gsonInternal
+                .fromJson(System.getenv("OPEN_RUNTIMES_HEADERS") ?: "{}", MutableMap::class.java)
+                .entries
+                .associate { "${it.key}".lowercase() to "${it.value}" }
+        } catch (e: Exception) {
+            emptyMap()
+        }
+    val entrypoint: String = System.getenv("OPEN_RUNTIMES_ENTRYPOINT") ?: ""
+    val env: String = System.getenv("OPEN_RUNTIMES_ENV") ?: ""
+}

--- a/runtimes/kotlin/versions/latest/src/main/kotlin/io/openruntimes/kotlin/RuntimeLogger.kt
+++ b/runtimes/kotlin/versions/latest/src/main/kotlin/io/openruntimes/kotlin/RuntimeLogger.kt
@@ -52,13 +52,8 @@ class RuntimeLogger(
         }
 
         if (this.enabled) {
-            var serverEnv = System.getenv("OPEN_RUNTIMES_ENV")
-            if (serverEnv == null) {
-                serverEnv = ""
-            }
-
             if (this.id.equals("")) {
-                if (serverEnv.equals("development")) {
+                if (OprConfig.env.equals("development")) {
                     this.id = "dev"
                 } else {
                     this.id = this.generateId()

--- a/runtimes/kotlin/versions/latest/src/main/kotlin/io/openruntimes/kotlin/Server.kt
+++ b/runtimes/kotlin/versions/latest/src/main/kotlin/io/openruntimes/kotlin/Server.kt
@@ -84,7 +84,7 @@ suspend fun action(
     }
 
     val secret = ctx.header("x-open-runtimes-secret") ?: ""
-    val serverSecret = System.getenv("OPEN_RUNTIMES_SECRET") ?: ""
+    val serverSecret = OprConfig.secret
 
     if (serverSecret != "" && secret != serverSecret) {
         ctx.status(500).result("Unauthorized. Provide correct \"x-open-runtimes-secret\" header.")
@@ -102,16 +102,7 @@ suspend fun action(
         }
     }
 
-    var enforcedHeadersString = System.getenv("OPEN_RUNTIMES_HEADERS")
-    if (enforcedHeadersString == null || enforcedHeadersString.isEmpty()) {
-        enforcedHeadersString = "{}"
-    }
-    val enforcedHeaders = gsonInternal.fromJson(enforcedHeadersString, MutableMap::class.java)
-
-    for (entry in enforcedHeaders.entries.iterator()) {
-        val header = "${entry.key}".lowercase()
-        headers[header] = "${entry.value}"
-    }
+    headers.putAll(OprConfig.headers)
 
     val hostHeader = ctx.header("host") ?: ""
     val protoHeader = ctx.header("x-forwarded-proto") ?: "http"
@@ -176,7 +167,7 @@ suspend fun action(
     var classMethod: kotlin.reflect.KFunction<*>? = null
     var instance: Any? = null
 
-    val entrypoint = System.getenv("OPEN_RUNTIMES_ENTRYPOINT")
+    val entrypoint = OprConfig.entrypoint
 
     // Guard: Try to load module
     try {

--- a/runtimes/node/versions/latest/src/config.js
+++ b/runtimes/node/versions/latest/src/config.js
@@ -1,0 +1,13 @@
+let headers = {};
+try {
+  headers = JSON.parse(process.env.OPEN_RUNTIMES_HEADERS || "{}");
+} catch {
+  // Silently ignore invalid JSON and keep empty enforced headers
+}
+
+module.exports = Object.freeze({
+  secret: process.env.OPEN_RUNTIMES_SECRET,
+  headers,
+  entrypoint: process.env.OPEN_RUNTIMES_ENTRYPOINT,
+  env: process.env.OPEN_RUNTIMES_ENV,
+});

--- a/runtimes/node/versions/latest/src/logger.js
+++ b/runtimes/node/versions/latest/src/logger.js
@@ -1,4 +1,5 @@
 const fs = require("fs");
+const config = require("./config");
 
 let _superjson;
 const _superjsonReady = import("superjson").then((m) => {
@@ -23,7 +24,7 @@ class Logger {
     if (this.enabled) {
       this.id = id
         ? id
-        : process.env.OPEN_RUNTIMES_ENV === "development"
+        : config.env === "development"
           ? "dev"
           : this.generateId();
       this.streamLogs = fs.createWriteStream(`/mnt/logs/${this.id}_logs.log`, {

--- a/runtimes/node/versions/latest/src/server.js
+++ b/runtimes/node/versions/latest/src/server.js
@@ -2,6 +2,7 @@ const micro = require("micro");
 const { buffer, send } = require("micro");
 const fs = require("fs");
 const Logger = require("./logger");
+const config = require("./config");
 
 const USER_CODE_PATH = "/usr/local/server/src/function";
 
@@ -50,9 +51,8 @@ const action = async (logger, req, res) => {
   }
 
   if (
-    process.env["OPEN_RUNTIMES_SECRET"] &&
-    req.headers[`x-open-runtimes-secret`] !==
-      process.env["OPEN_RUNTIMES_SECRET"]
+    config.secret &&
+    req.headers[`x-open-runtimes-secret`] !== config.secret
   ) {
     return send(
       res,
@@ -73,13 +73,8 @@ const action = async (logger, req, res) => {
       headers[header.toLowerCase()] = req.headers[header];
     });
 
-  const enforcedHeaders = JSON.parse(
-    process.env.OPEN_RUNTIMES_HEADERS
-      ? process.env.OPEN_RUNTIMES_HEADERS
-      : "{}",
-  );
-  for (const header in enforcedHeaders) {
-    headers[header.toLowerCase()] = `${enforcedHeaders[header]}`;
+  for (const header in config.headers) {
+    headers[header.toLowerCase()] = `${config.headers[header]}`;
   }
 
   const scheme = req.headers["x-forwarded-proto"] ?? "http";
@@ -180,7 +175,7 @@ const action = async (logger, req, res) => {
   let output = null;
   let userFunction = null;
 
-  const entrypoint = process.env.OPEN_RUNTIMES_ENTRYPOINT;
+  const entrypoint = config.entrypoint;
   const entrypointFilePath = USER_CODE_PATH + "/" + entrypoint;
 
   // Guard: Check file exists

--- a/runtimes/php/versions/latest/src/config.php
+++ b/runtimes/php/versions/latest/src/config.php
@@ -1,0 +1,17 @@
+<?php
+
+final class Config
+{
+    public readonly string $secret;
+    public readonly array $headers;
+    public readonly string $entrypoint;
+    public readonly string $env;
+
+    public function __construct()
+    {
+        $this->secret = \getenv('OPEN_RUNTIMES_SECRET') ?: '';
+        $this->headers = \json_decode(\getenv('OPEN_RUNTIMES_HEADERS') ?: '{}', true) ?: [];
+        $this->entrypoint = \getenv('OPEN_RUNTIMES_ENTRYPOINT') ?: '';
+        $this->env = \getenv('OPEN_RUNTIMES_ENV') ?: '';
+    }
+}

--- a/runtimes/php/versions/latest/src/logger.php
+++ b/runtimes/php/versions/latest/src/logger.php
@@ -12,12 +12,12 @@ class Logger
     private mixed $streamLogs = null;
     private mixed $streamErrors = null;
 
-    public function __construct(?string $status = null, ?string $id = null)
+    public function __construct(?string $status = null, ?string $id = null, ?string $env = null)
     {
         $this->enabled = (!empty($status) ? $status : 'enabled') === 'enabled';
 
         if ($this->enabled) {
-            $this->id = !empty($id) ? $id : (\getenv('OPEN_RUNTIMES_ENV') === 'development' ? 'dev' : $this->generateId());
+            $this->id = !empty($id) ? $id : ($env === 'development' ? 'dev' : $this->generateId());
 
             $this->streamLogs = \fopen('/mnt/logs/' . $this->id . '_logs.log', 'a');
             $this->streamErrors = \fopen('/mnt/logs/' . $this->id . '_errors.log', 'a');

--- a/runtimes/php/versions/latest/src/server.php
+++ b/runtimes/php/versions/latest/src/server.php
@@ -3,6 +3,7 @@
 require 'vendor-server/autoload.php';
 require_once 'types.php';
 require_once 'logger.php';
+require_once 'config.php';
 
 // Use the native curl hook instead of the userland one bundled in
 // SWOOLE_HOOK_ALL. The userland hook only maps a fixed set of curl options and
@@ -19,9 +20,10 @@ $server->set([
 
 const USER_CODE_PATH = '/usr/local/server/src/function';
 
+$config = new Config();
 $userFunction = null;
 
-$action = function (Logger $logger, mixed $req, mixed $res) use (&$userFunction) {
+$action = function (Logger $logger, mixed $req, mixed $res) use (&$userFunction, $config) {
     $requestHeaders = $req->header;
 
     $cookieHeaders = [];
@@ -46,7 +48,7 @@ $action = function (Logger $logger, mixed $req, mixed $res) use (&$userFunction)
         $safeTimeout = \intval($timeout);
     }
 
-    if ((getenv('OPEN_RUNTIMES_SECRET') ?? '') != "" && ($requestHeaders['x-open-runtimes-secret'] ?? '') !== getenv('OPEN_RUNTIMES_SECRET')) {
+    if ($config->secret !== '' && ($requestHeaders['x-open-runtimes-secret'] ?? '') !== $config->secret) {
         $res->status(500);
         $res->end('Unauthorized. Provide correct "x-open-runtimes-secret" header.');
         return;
@@ -105,8 +107,7 @@ $action = function (Logger $logger, mixed $req, mixed $res) use (&$userFunction)
         }
     }
 
-    $enforcedHeaders = json_decode(getenv('OPEN_RUNTIMES_HEADERS') ?? '{}', true);
-    foreach ($enforcedHeaders as $key => $value) {
+    foreach ($config->headers as $key => $value) {
         $context->req->headers[\strtolower($key)] = \strval($value);
     }
 
@@ -114,7 +115,7 @@ $action = function (Logger $logger, mixed $req, mixed $res) use (&$userFunction)
 
     $output = null;
 
-    $entrypoint = getenv('OPEN_RUNTIMES_ENTRYPOINT');
+    $entrypoint = $config->entrypoint;
     $entrypointPath = USER_CODE_PATH . '/' . $entrypoint;
 
     // Guard: Check file exists
@@ -216,7 +217,7 @@ $action = function (Logger $logger, mixed $req, mixed $res) use (&$userFunction)
     $res->end($output['body']);
 };
 
-$server->on("Request", function ($req, $res) use ($action) {
+$server->on("Request", function ($req, $res) use ($action, $config) {
     if ($req->server['path_info'] === '/__opr/health') {
         $res->status(200);
         $res->end('OK');
@@ -230,7 +231,7 @@ $server->on("Request", function ($req, $res) use ($action) {
         return;
     }
 
-    $logger = new Logger($req->header['x-open-runtimes-logging'] ?? '', $req->header['x-open-runtimes-log-id'] ?? '');
+    $logger = new Logger($req->header['x-open-runtimes-logging'] ?? '', $req->header['x-open-runtimes-log-id'] ?? '', $config->env);
 
     try {
         $action($logger, $req, $res);

--- a/runtimes/python/versions/latest/src/config.py
+++ b/runtimes/python/versions/latest/src/config.py
@@ -1,0 +1,11 @@
+import json
+import os
+
+SECRET = os.getenv("OPEN_RUNTIMES_SECRET", "")
+ENTRYPOINT = os.getenv("OPEN_RUNTIMES_ENTRYPOINT")
+ENV = os.getenv("OPEN_RUNTIMES_ENV")
+
+try:
+    HEADERS = json.loads(os.getenv("OPEN_RUNTIMES_HEADERS", "") or "{}")
+except ValueError:
+    HEADERS = {}

--- a/runtimes/python/versions/latest/src/logger.py
+++ b/runtimes/python/versions/latest/src/logger.py
@@ -5,6 +5,8 @@ import math
 import os
 from io import StringIO
 
+import config
+
 
 class Logger:
     TYPE_ERROR = "error"
@@ -29,9 +31,7 @@ class Logger:
                 self.enabled = False
 
         if self.enabled is True:
-            is_development = False
-            if os.getenv("OPEN_RUNTIMES_ENV") == "development":
-                is_development = True
+            is_development = config.ENV == "development"
 
             if id is None or id == "":
                 if is_development is True:

--- a/runtimes/python/versions/latest/src/server.py
+++ b/runtimes/python/versions/latest/src/server.py
@@ -1,9 +1,9 @@
 import asyncio
 import importlib
-import json
 import os
 import traceback
 
+import config
 from aiohttp import web, web_exceptions, web_request
 from function_types import Context
 from logger import Logger
@@ -21,9 +21,10 @@ async def action(logger, request: web_request.Request):
 
         safeTimeout = int(timeout)
 
-    if os.getenv("OPEN_RUNTIMES_SECRET", "") != "" and request.headers.get(
-        "x-open-runtimes-secret", ""
-    ) != os.getenv("OPEN_RUNTIMES_SECRET", ""):
+    if (
+        config.SECRET != ""
+        and request.headers.get("x-open-runtimes-secret", "") != config.SECRET
+    ):
         return web.Response(
             text='Unauthorized. Provide correct "x-open-runtimes-secret" header.',
             status=500,
@@ -73,18 +74,15 @@ async def action(logger, request: web_request.Request):
         if not key.lower().startswith("x-open-runtimes-"):
             context.req.headers[key.lower()] = headers[key]
 
-    server_headers = os.getenv("OPEN_RUNTIMES_HEADERS", "")
-    server_headers = server_headers if server_headers else "{}"
-    enforced_headers = json.loads(server_headers)
-    for key in enforced_headers.keys():
-        context.req.headers[key.lower()] = str(enforced_headers[key])
+    for key in config.HEADERS.keys():
+        context.req.headers[key.lower()] = str(config.HEADERS[key])
 
     logger.override_native_logs()
 
     output = None
     userModule = None
 
-    entrypoint = os.getenv("OPEN_RUNTIMES_ENTRYPOINT")
+    entrypoint = config.ENTRYPOINT
     entrypointFilePath = "/usr/local/server/src/function/" + entrypoint
 
     # Guard: Check file exists

--- a/runtimes/ruby/versions/latest/src/config.rb
+++ b/runtimes/ruby/versions/latest/src/config.rb
@@ -1,0 +1,12 @@
+require 'json'
+
+module Config
+  SECRET = (ENV['OPEN_RUNTIMES_SECRET'] || '').freeze
+  ENTRYPOINT = ENV['OPEN_RUNTIMES_ENTRYPOINT'].freeze
+  ENV_NAME = (ENV['OPEN_RUNTIMES_ENV'] || "").freeze
+  HEADERS = begin
+    JSON.parse(ENV['OPEN_RUNTIMES_HEADERS'] || '{}')
+  rescue JSON::ParserError
+    {}
+  end.freeze
+end

--- a/runtimes/ruby/versions/latest/src/logger.rb
+++ b/runtimes/ruby/versions/latest/src/logger.rb
@@ -1,5 +1,7 @@
 require 'securerandom'
 
+require_relative 'config.rb'
+
 class RuntimeLogger
   TYPE_LOG = "log"
   TYPE_ERROR = "error"
@@ -23,7 +25,7 @@ class RuntimeLogger
     end
 
     if @enabled === true
-      serverEnv = ENV['OPEN_RUNTIMES_ENV'] || ""
+      serverEnv = Config::ENV_NAME
 
       if id.nil? || id.empty?
         if serverEnv === "development"

--- a/runtimes/ruby/versions/latest/src/server.rb
+++ b/runtimes/ruby/versions/latest/src/server.rb
@@ -1,6 +1,7 @@
 require 'sinatra'
 require 'json'
 
+require_relative 'config.rb'
 require_relative 'types.rb'
 require_relative 'logger.rb'
 require_relative 'execute.rb'
@@ -23,7 +24,7 @@ def action(request, response, logger)
   end
 
   secret = request.env['HTTP_X_OPEN_RUNTIMES_SECRET'] || ''
-  server_secret = ENV['OPEN_RUNTIMES_SECRET'] || ''
+  server_secret = Config::SECRET
 
   if !(server_secret.empty?) && secret != server_secret
     response.status = 500
@@ -108,8 +109,7 @@ def action(request, response, logger)
     end
   end
 
-  enforced_headers = JSON.parse(ENV['OPEN_RUNTIMES_HEADERS'].empty? ? '{}' : ENV['OPEN_RUNTIMES_HEADERS'])
-  enforced_headers.each do |key, value|
+  Config::HEADERS.each do |key, value|
     headers[key.downcase] = value.to_s
   end
 
@@ -121,7 +121,7 @@ def action(request, response, logger)
   output = nil
   user_function_loaded = false
 
-  entrypoint = ENV['OPEN_RUNTIMES_ENTRYPOINT']
+  entrypoint = Config::ENTRYPOINT
   entrypoint_file_path = USER_CODE_PATH + '/' + entrypoint
 
   # Guard: Check file exists

--- a/runtimes/swift/versions/latest/Sources/Runtime/OprConfig.swift
+++ b/runtimes/swift/versions/latest/Sources/Runtime/OprConfig.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+enum OprConfig {
+    static let secret = ProcessInfo.processInfo.environment["OPEN_RUNTIMES_SECRET"] ?? ""
+    static let env = ProcessInfo.processInfo.environment["OPEN_RUNTIMES_ENV"] ?? ""
+
+    static let headers: [String: String] = {
+        guard
+            let serverHeadersString = ProcessInfo.processInfo.environment["OPEN_RUNTIMES_HEADERS"],
+            serverHeadersString != "",
+            let data = serverHeadersString.data(using: .utf8),
+            let serverHeaders = (try? JSONSerialization.jsonObject(
+                with: data,
+                options: .allowFragments
+            )) as? [String: Any?]
+        else {
+            return [:]
+        }
+
+        var headers = [String: String]()
+        for (key, value) in serverHeaders {
+            if let value {
+                headers[key.lowercased()] = String(describing: value)
+            } else {
+                headers[key.lowercased()] = ""
+            }
+        }
+        return headers
+    }()
+}

--- a/runtimes/swift/versions/latest/Sources/Runtime/RuntimeLogger.swift
+++ b/runtimes/swift/versions/latest/Sources/Runtime/RuntimeLogger.swift
@@ -17,8 +17,7 @@ class RuntimeLogger {
 
         if enabled {
             if id == "" {
-                let serverEnv = ProcessInfo.processInfo.environment["OPEN_RUNTIMES_ENV"]
-                if serverEnv == "development" {
+                if OprConfig.env == "development" {
                     self.id = "dev"
                 } else {
                     self.id = generateId()

--- a/runtimes/swift/versions/latest/Sources/Runtime/main.swift
+++ b/runtimes/swift/versions/latest/Sources/Runtime/main.swift
@@ -87,18 +87,16 @@ func action(logger: RuntimeLogger, req: Request) async throws -> Response {
         safeTimeout = timeoutInt
     }
 
-    if let serverSecret = ProcessInfo.processInfo.environment["OPEN_RUNTIMES_SECRET"] {
-        if serverSecret != "" {
-            if !req.headers.contains(name: "x-open-runtimes-secret")
-                || req.headers["x-open-runtimes-secret"].first != serverSecret
-            {
-                return Response(
-                    status: .internalServerError,
-                    body: .init(
-                        string: "Unauthorized. Provide correct \"x-open-runtimes-secret\" header."
-                    )
+    if OprConfig.secret != "" {
+        if !req.headers.contains(name: "x-open-runtimes-secret")
+            || req.headers["x-open-runtimes-secret"].first != OprConfig.secret
+        {
+            return Response(
+                status: .internalServerError,
+                body: .init(
+                    string: "Unauthorized. Provide correct \"x-open-runtimes-secret\" header."
                 )
-            }
+            )
         }
     }
 
@@ -152,24 +150,8 @@ func action(logger: RuntimeLogger, req: Request) async throws -> Response {
         }
     }
 
-    if var serverHeadersString = ProcessInfo.processInfo.environment["OPEN_RUNTIMES_HEADERS"] {
-        if serverHeadersString == "" {
-            serverHeadersString = "{}"
-        }
-
-        let serverHeaders =
-            try JSONSerialization.jsonObject(
-                with: serverHeadersString.data(using: .utf8)!,
-                options: .allowFragments
-            ) as! [String: Any?]
-
-        for (key, value) in serverHeaders {
-            if let value {
-                headers[key.lowercased()] = String(describing: value)
-            } else {
-                headers[key.lowercased()] = ""
-            }
-        }
+    for (key, value) in OprConfig.headers {
+        headers[key] = value
     }
 
     var bodyBinary = Data()


### PR DESCRIPTION
## What

Every runtime read `OPEN_RUNTIMES_*` env vars from the environment on each request (a syscall per read), and JSON-parsed `OPEN_RUNTIMES_HEADERS` on every request. Each runtime now loads these once at process startup into a small idiomatic config construct, and the request path just references cached values.

## Naming

- Scripting runtimes (node, bun, deno, python, php, ruby, dart): `src/config.*`, mirroring their lowercase `logger.*` siblings — exported const / module constants / `module Config` / final class per language idiom.
- Compiled runtimes where user function code shares the runtime's namespace/package/module (java, kotlin, swift, dotnet, cpp): `OprConfig` — a plain `Config` could collide with a user-defined class since user code compiles into the same scope (`io.openruntimes.java`, `DotNetRuntime`, the swift `Runtime` target). `_OprConfig` was ruled out: C++ reserves `_`+uppercase identifiers and ktlint rejects the leading underscore.
- Go: package-level `config` struct value in `main.go`.
- Members are uniformly `secret` / `headers` / `entrypoint` / `env` in each language's casing. Ruby uses `ENV_NAME` (bare `ENV` shadows the global); go/cpp/swift/dotnet omit `entrypoint` since it's resolved at build time there.

## Notable details

- Enforced headers are parsed and key-lowercased once at startup; the per-request work is a plain map merge.
- Node's 8 SSR server variants also had a per-response `OPEN_RUNTIMES_CACHE_HEADER` read hoisted to module scope.
- Dotnet's per-version `Program.cs` copies (6.0/7.0/8.0) were updated too, since that runtime keeps `Program.cs` outside `latest`.
- Behavior change: invalid JSON in `OPEN_RUNTIMES_HEADERS` now yields empty enforced headers instead of failing every request with a 500. PHP additionally had a latent bug here (`getenv()` returns `false`, so the `?? '{}'` fallback never fired and the merge loop could iterate `null`).
- Flutter and static have no request-serving code — unchanged.

## Verification

Local: `node --check` (13 files), `bun build`, `py_compile`, `ruby -c`, `php -l`, `gofmt`/`go vet`/`go build` (stubbed handler), `dotnet build` (0 errors), `swiftc -parse`, cpp syntax check against a jsoncpp stub. Deno, dart, kotlin, java had no local toolchain — CI is the gate for those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)