### PR TITLE
ci: bump test step timeout to 20m

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -99,7 +99,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
       - name: Run tests
-        timeout-minutes: 15
+        timeout-minutes: 20
         working-directory: ./
         run: bun ci/test.ts ${{ matrix.ID }}
       - name: Report image size


### PR DESCRIPTION
php-8.0 compiles the Swoole extension from source (~13 min, no build cache in the test pipeline), which made the 15-minute `Run tests` cap deterministically fail on #520 — three consecutive attempts timed out at 15m3Xs mid-compile. Bumping to 20 minutes gives that matrix entry realistic headroom.

Longer-term, buildx layer caching in `ci/test.ts` would fix this properly and speed every job up; this is the minimal unblock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)