### PR TITLE
ci: fix arm build failures from native arm runners

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -56,12 +56,14 @@ jobs:
       matrix:
         include: ${{ fromJson(needs.prepare.outputs.builds) }}
     name: ${{ matrix.target }} (${{ matrix.platform }})
-    runs-on: ${{ contains(matrix.platform, 'arm') && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
+    # 32-bit arm stays on amd64+QEMU: the arm64 runner executes arm32 natively
+    # (no QEMU), so uname reports aarch64 and arch-sniffing builds (swoole) break.
+    runs-on: ${{ contains(matrix.platform, 'arm64') && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Set up QEMU
-        if: contains(matrix.platform, 'arm/v') # 32-bit arm still emulated on the arm64 runner
+        if: contains(matrix.platform, 'arm/v')
         uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3

--- a/ci/runtimes.toml
+++ b/ci/runtimes.toml
@@ -335,7 +335,7 @@ output = "./.next"
 "2.5" = { base = "denoland/deno:alpine-2.5.7" }
 "2.0" = { base = "denoland/deno:alpine-2.0.6" }
 "1.46" = { base = "denoland/deno:alpine-1.46.3" }
-"1.40" = { base = "denoland/deno:alpine-1.40.5" }
+"1.40" = { base = "denoland/deno:alpine-1.40.5", platforms = ["linux/amd64"] }
 "1.35" = { base = "denoland/deno:alpine-1.35.3", platforms = ["linux/amd64"] }
 "1.24" = { base = "denoland/deno:alpine-1.24.3", platforms = ["linux/amd64"] }
 "1.21" = { base = "denoland/deno:alpine-1.21.3", platforms = ["linux/amd64"] }

--- a/docker-bake.json
+++ b/docker-bake.json
@@ -512,8 +512,7 @@
         "BASE_IMAGE": "denoland/deno:alpine-1.40.5"
       },
       "platforms": [
-        "linux/amd64",
-        "linux/arm64"
+        "linux/amd64"
       ],
       "tags": [
         "${REGISTRY}/deno:v5-1.40${TAG_SUFFIX}",


### PR DESCRIPTION
## What

Fixes the two target failures in the 0.13.8 release ([run 29576198717](https://github.com/open-runtimes/open-runtimes/actions/runs/29576198717)), both fallout from #518's move to native arm runners:

- **`deno-1_40` (linux/arm64)** — `denoland/deno:alpine-1.40.5` is amd64-only. buildx silently accepts a single-arch base for any platform, so the old QEMU-on-amd64 pipeline published "arm64" images containing amd64 binaries; on a real arm64 runner the first `RUN` dies with `exec /bin/sh: exec format error`. Drop `linux/arm64` from its platforms, matching deno 1.35/1.24/1.21.

- **`php-8_0` (linux/arm/v6, arm/v7)** — arm64 kernels execute arm32 containers natively, and `setup-qemu-action` installs no arm32 handler on arm64 hosts, so `uname -m` reports `aarch64` inside the arm/v7 build. Swoole v4.7.0's configure then selects arm64 boost asm that the arm32 assembler rejects (`Error: ARM register expected`). Route 32-bit arm builds back to amd64+QEMU (where `uname` reports `armv7l`, as before #518); arm64 builds stay native.

## Notes

- The partial-manifest guard from #518 worked as designed: no broken manifests were pushed, and all other targets published. After this merges, re-running the 0.13.8 publish fills in the two missing targets.
- The dropped deno-1.40 arm64 image was never functional on arm64 hardware (mislabeled amd64 bits), so no working platform is removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)