### PR TITLE
feat: add skip build compression method

### DIFF
--- a/docs/add-runtime.md
+++ b/docs/add-runtime.md
@@ -133,9 +133,11 @@ hooks beyond what its shared family already provides.
 Build output compression is controlled by `OPEN_RUNTIMES_BUILD_COMPRESSION`.
 The default is `gzip` for downloadable artifact compatibility. `auto` picks by
 output size — skipping compression under 5MB and using `gzip` at or above it —
-and explicit values `squashfs`, `gzip`, `zstd`, and `none` are supported.
-SquashFS packages with LZ4 for faster packaging and extraction; downloaded
-SquashFS outputs can be extracted with `unsquashfs -d output code.sqfs`.
+and explicit values `squashfs`, `gzip`, `zstd`, `none`, and `skip` are supported.
+`none` writes an uncompressed `code.tar.gz`, whereas `skip` writes no archive at
+all — the raw build output is left in the output dir with a `.extracted` marker so
+start-up symlinks it directly. SquashFS packages with LZ4 for faster packaging and
+extraction; downloaded SquashFS outputs can be extracted with `unsquashfs -d output code.sqfs`.
 
 ## 4. Writing the runtime server
 

--- a/helpers/lifecycle/build.sh
+++ b/helpers/lifecycle/build.sh
@@ -83,7 +83,12 @@ echo "OPEN_RUNTIMES_COMPRESSION=$COMPRESSION_METHOD" >>.open-runtimes
 
 OUTPUT_DIR="${OPEN_RUNTIMES_BUILD_OUTPUT_DIR:-/mnt/code}"
 mkdir -p "$OUTPUT_DIR"
-if [ "$COMPRESSION_METHOD" = "none" ]; then
+if [ "$COMPRESSION_METHOD" = "skip" ]; then
+	# No archive: drop the raw build output into the output dir and mark it
+	# pre-extracted so start-up symlinks it directly (like a sidecar would).
+	cp -R . "$OUTPUT_DIR/"
+	touch "$OUTPUT_DIR/.extracted"
+elif [ "$COMPRESSION_METHOD" = "none" ]; then
 	tar --exclude code.sqfs --exclude code.tar --exclude code.tar.gz --exclude code.gz -cf "$OUTPUT_DIR/code.tar.gz" .
 elif [ "$COMPRESSION_METHOD" = "squashfs" ]; then
 	processors=$(nproc 2>/dev/null || echo 1)

--- a/helpers/lifecycle/compression.sh
+++ b/helpers/lifecycle/compression.sh
@@ -4,6 +4,8 @@
 
 if [ "$OPEN_RUNTIMES_BUILD_COMPRESSION" = "none" ]; then
 	COMPRESSION_METHOD="none"
+elif [ "$OPEN_RUNTIMES_BUILD_COMPRESSION" = "skip" ]; then
+	COMPRESSION_METHOD="skip"
 elif [ "$OPEN_RUNTIMES_BUILD_COMPRESSION" = "squashfs" ]; then
 	COMPRESSION_METHOD="squashfs"
 elif [ "$OPEN_RUNTIMES_BUILD_COMPRESSION" = "zstd" ]; then

--- a/tests/BuildCompression.php
+++ b/tests/BuildCompression.php
@@ -49,6 +49,16 @@ class BuildCompression extends TestCase
         self::assertStringContainsString('METHOD=gzip', $result['output']);
     }
 
+    public function testExplicitSkipCompressionIsSupported(): void
+    {
+        $result = $this->runCompressionSelection([
+            'OPEN_RUNTIMES_BUILD_COMPRESSION' => 'skip',
+        ]);
+
+        self::assertSame(0, $result['code']);
+        self::assertStringContainsString('METHOD=skip', $result['output']);
+    }
+
     public function testExplicitSquashfsCompressionIsSupported(): void
     {
         $result = $this->runCompressionSelection([
@@ -67,6 +77,8 @@ class BuildCompression extends TestCase
         self::assertStringContainsString('mksquashfs . "$OUTPUT_DIR/code.sqfs"', $build);
         self::assertStringContainsString('-comp lz4 -b 1M -noappend -no-xattrs -no-progress', $build);
         self::assertStringContainsString('"$COMPRESSION_METHOD" = "none"', $build);
+        self::assertStringContainsString('"$COMPRESSION_METHOD" = "skip"', $build);
+        self::assertStringContainsString('touch "$OUTPUT_DIR/.extracted"', $build);
         self::assertStringContainsString('"$COMPRESSION_METHOD" = "zstd"', $build);
         self::assertStringContainsString('"$OUTPUT_DIR/code.tar.gz"', $build);
     }


### PR DESCRIPTION
## What

Adds a new `OPEN_RUNTIMES_BUILD_COMPRESSION=skip` method that writes **no archive at all**.

| Method | Result |
|--------|--------|
| `none` | uncompressed tar left behind (`code.tar.gz`) |
| `skip` | no archive — raw build output copied into the output dir with a `.extracted` marker |

At start-up, `extract.sh` already treats a `.extracted` marker as "pre-extracted" and symlinks the files directly into the function dir (the same path a sidecar uses), so no tar/extraction step is ever involved for `skip`.

## Changes

- `helpers/lifecycle/compression.sh` — recognize `skip`
- `helpers/lifecycle/build.sh` — `skip` branch copies raw output + touches `.extracted`
- `helpers/lifecycle/extract.sh` — no change needed (existing `.extracted` path handles it)
- `docs/add-runtime.md` — documented `skip` vs `none`
- `tests/BuildCompression.php` — added selection + build-lifecycle assertions

🤖 Generated with [Claude Code](https://claude.com/claude-code)