### PR TITLE
Drop 32-bit ARM support and optimize native builds

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -56,15 +56,10 @@ jobs:
       matrix:
         include: ${{ fromJson(needs.prepare.outputs.builds) }}
     name: ${{ matrix.target }} (${{ matrix.platform }})
-    # 32-bit arm stays on amd64+QEMU: the arm64 runner executes arm32 natively
-    # (no QEMU), so uname reports aarch64 and arch-sniffing builds (swoole) break.
     runs-on: ${{ contains(matrix.platform, 'arm64') && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - name: Set up QEMU
-        if: contains(matrix.platform, 'arm/v')
-        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
       - name: Login to DockerHub

--- a/ci/runtimes.toml
+++ b/ci/runtimes.toml
@@ -327,8 +327,8 @@ output = "./.next"
 "21.0" = { base = "node:21.7.3-alpine3.20" }
 "20.0" = { base = "node:20.20.2-alpine3.22" }
 "19.0" = { base = "node:19.9.0-alpine3.18" }
-"18.0" = { base = "node:18.20.8-alpine3.20", platforms = ["linux/amd64", "linux/arm/v6", "linux/arm/v7", "linux/arm64"] }
-"16.0" = { base = "node:16.20.2-alpine3.18", args = { PNPM_VERSION = "8" }, platforms = ["linux/amd64", "linux/arm/v6", "linux/arm/v7", "linux/arm64"] }
+"18.0" = { base = "node:18.20.8-alpine3.20" }
+"16.0" = { base = "node:16.20.2-alpine3.18", args = { PNPM_VERSION = "8" } }
 
 [deno.build.versions]
 "2.6" = { base = "denoland/deno:alpine-2.6.7" }
@@ -383,9 +383,6 @@ image = "python-ml"
 "3.27" = { base = "ghcr.io/cirruslabs/flutter:3.27.3" }
 "3.24" = { base = "ghcr.io/cirruslabs/flutter:3.24.5" }
 
-[ruby.build]
-platforms = ["linux/amd64", "linux/arm/v6", "linux/arm/v7", "linux/arm64"]
-
 [ruby.build.versions]
 "4.0" = { base = "ruby:4.0.5-alpine3.22" }
 "3.4" = { base = "ruby:3.4.10-alpine3.23" }
@@ -399,7 +396,7 @@ platforms = ["linux/amd64", "linux/arm/v6", "linux/arm/v7", "linux/arm64"]
 "8.3" = { base = "php:8.3.31-cli-alpine3.22", args = { PHP_SWOOLE_VERSION = "v5.1.2", BUILD_PACKAGES = "linux-headers" } }
 "8.2" = { base = "php:8.2.31-cli-alpine3.22", args = { PHP_SWOOLE_VERSION = "v5.1.2", BUILD_PACKAGES = "linux-headers" } }
 "8.1" = { base = "php:8.1.34-cli-alpine3.22", args = { PHP_SWOOLE_VERSION = "v5.1.2" } }
-"8.0" = { base = "php:8.0.30-cli-alpine3.16", args = { PHP_SWOOLE_VERSION = "v4.7.0" }, platforms = ["linux/amd64", "linux/arm/v6", "linux/arm/v7", "linux/arm64"] }
+"8.0" = { base = "php:8.0.30-cli-alpine3.16", args = { PHP_SWOOLE_VERSION = "v4.7.0" } }
 
 [swift.build.versions]
 "6.2" = { base = "swift:6.2.4-jammy" }
@@ -425,9 +422,6 @@ platforms = ["linux/amd64"]
 "17.0" = { base = "eclipse-temurin:17-jdk-jammy" }
 "11.0" = { base = "eclipse-temurin:11-jdk-jammy" }
 "8.0" = { base = "eclipse-temurin:8-jdk-jammy" }
-
-[cpp.build]
-platforms = ["linux/amd64", "linux/arm/v6", "linux/arm/v7", "linux/arm64"]
 
 [cpp.build.versions]
 "23" = { base = "alpine:3.23.3" }

--- a/docker-bake.json
+++ b/docker-bake.json
@@ -367,8 +367,6 @@
       },
       "platforms": [
         "linux/amd64",
-        "linux/arm/v6",
-        "linux/arm/v7",
         "linux/arm64"
       ],
       "tags": [
@@ -393,8 +391,6 @@
       },
       "platforms": [
         "linux/amd64",
-        "linux/arm/v6",
-        "linux/arm/v7",
         "linux/arm64"
       ],
       "tags": [
@@ -1329,8 +1325,6 @@
       },
       "platforms": [
         "linux/amd64",
-        "linux/arm/v6",
-        "linux/arm/v7",
         "linux/arm64"
       ],
       "tags": [
@@ -1354,8 +1348,6 @@
       },
       "platforms": [
         "linux/amd64",
-        "linux/arm/v6",
-        "linux/arm/v7",
         "linux/arm64"
       ],
       "tags": [
@@ -1379,8 +1371,6 @@
       },
       "platforms": [
         "linux/amd64",
-        "linux/arm/v6",
-        "linux/arm/v7",
         "linux/arm64"
       ],
       "tags": [
@@ -1404,8 +1394,6 @@
       },
       "platforms": [
         "linux/amd64",
-        "linux/arm/v6",
-        "linux/arm/v7",
         "linux/arm64"
       ],
       "tags": [
@@ -1429,8 +1417,6 @@
       },
       "platforms": [
         "linux/amd64",
-        "linux/arm/v6",
-        "linux/arm/v7",
         "linux/arm64"
       ],
       "tags": [
@@ -1454,8 +1440,6 @@
       },
       "platforms": [
         "linux/amd64",
-        "linux/arm/v6",
-        "linux/arm/v7",
         "linux/arm64"
       ],
       "tags": [
@@ -1490,7 +1474,7 @@
       ]
     },
     "_php": {
-      "dockerfile-inline": "# syntax=docker/dockerfile:1\n# INCLUDE directives below are resolved by `bun ci/bake.ts`, which inlines the\n# referenced *.dockerfile fragments into docker-bake.json (dockerfile-inline).\nARG BASE_IMAGE\n# Builder stage uses the same base unless a version pins a different one (8.3)\nARG BUILD_BASE_IMAGE=$${BASE_IMAGE}\n\nFROM $${BUILD_BASE_IMAGE} AS step0\n\n# Extra packages only needed to compile extensions (linux-headers on php >= 8.2)\nARG BUILD_PACKAGES=\"\"\nRUN if [ -n \"$BUILD_PACKAGES\" ]; then apk update && apk add --no-cache $BUILD_PACKAGES; fi\n\nARG PHP_SWOOLE_VERSION\nENV PHP_SWOOLE_VERSION=$PHP_SWOOLE_VERSION\nRUN \\\n  apk add --no-cache --virtual .deps \\\n  make \\\n  automake \\\n  autoconf \\\n  gcc \\\n  g++ \\\n  git \\\n  zlib-dev \\\n  brotli-dev \\\n  yaml-dev \\\n  libmaxminddb-dev \\\n  openssl-dev\n\nRUN docker-php-ext-install sockets\n\nRUN \\\n  ## Swoole Extension\n  git clone --depth 1 --branch $PHP_SWOOLE_VERSION https://github.com/swoole/swoole-src.git && \\\n  cd swoole-src && \\\n  phpize && \\\n  ./configure --enable-http2 --enable-openssl && \\\n  make && make install && \\\n  cd ..\n\n# Stage compiled extensions at a fixed path so the final stage doesn't need to\n# know the PHP-ABI-versioned extension directory name.\nRUN mkdir -p /opt/ext \\\n    && cp \"$(php-config --extension-dir)/swoole.so\" /opt/ext/ \\\n    && (cp \"$(php-config --extension-dir)\"/yasd.so* /opt/ext/ 2>/dev/null || true)\n\nFROM $${BASE_IMAGE} AS final\nLABEL maintainer=\"team@appwrite.io\"\nLABEL namespace=\"open-runtimes\"\n\nENV OPEN_RUNTIMES_SECRET=open_runtime_secret\nENV OPEN_RUNTIMES_ENV=production\nENV OPEN_RUNTIMES_HEADERS=\"{}\"\n\nRUN <<EOR\n    if [ -f /etc/alpine-release ]; then\n        apk add util-linux zstd squashfs-tools\n    else\n        apt-get update && apt-get install -y util-linux zstd squashfs-tools\n    fi\nEOR\n\nRUN mkdir -p /mnt/code /mnt/logs /mnt/telemetry /usr/local/build /usr/local/server/src/function\n\nWORKDIR /usr/local/server\n\n# Assemble /usr/local/server from named build contexts, in overlay precedence\n# order (later layers overwrite earlier ones):\n#   1. helpers  -> repo helpers/ (global lifecycle runner + shims)\n#   2. shared   -> runtimes/<shared family>/ (e.g. javascript/ for node), or empty\n#   3. latest   -> runtimes/<runtime>/versions/latest/\n#   4. version  -> runtimes/<runtime>/versions/<version>/ extras, or empty\nCOPY --from=helpers . /usr/local/server/helpers/\nCOPY --from=shared . /usr/local/server/\nCOPY --from=latest . /usr/local/server/\nCOPY --from=version . /usr/local/server/\nRUN rm -f /usr/local/server/.gitkeep /usr/local/server/Dockerfile /usr/local/server/build.dockerfile\n\nENV OPEN_RUNTIMES_ENTRYPOINT=index.php\n\nRUN \\\n  apk update \\\n  && apk add --no-cache --virtual .deps \\\n  make \\\n  automake \\\n  autoconf \\\n  gcc \\\n  g++ \\\n  curl-dev \\\n  && apk add --no-cache \\\n  libstdc++ \\\n  certbot \\\n  brotli-dev \\\n  yaml-dev \\\n  libmaxminddb-dev \\\n  libgomp \\\n  bash \\\n  && docker-php-ext-install opcache \\\n  && apk del .deps \\\n  && rm -rf /var/cache/apk/*\n\nCOPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer\n\nRUN composer update --no-interaction --ignore-platform-reqs --optimize-autoloader --prefer-dist --no-dev\nRUN mv vendor vendor-server\n\nCOPY --from=step0 /opt/ext/ /opt/ext/\nRUN cp /opt/ext/* \"$(php-config --extension-dir)/\" && rm -rf /opt/ext\n\n# Enable Extensions\nRUN echo extension=swoole.so >> /usr/local/etc/php/conf.d/swoole.ini\n\nENV OPEN_RUNTIMES_SERVER_COMMAND=\"php -d memory_limit=8G src/server.php\"\n\nRUN chmod -R +x /usr/local/server/helpers\n\nEXPOSE 3000\n"
+      "dockerfile-inline": "# syntax=docker/dockerfile:1\n# INCLUDE directives below are resolved by `bun ci/bake.ts`, which inlines the\n# referenced *.dockerfile fragments into docker-bake.json (dockerfile-inline).\nARG BASE_IMAGE\n# Builder stage uses the same base unless a version pins a different one (8.3)\nARG BUILD_BASE_IMAGE=$${BASE_IMAGE}\n\nFROM $${BUILD_BASE_IMAGE} AS step0\n\n# Extra packages only needed to compile extensions (linux-headers on php >= 8.2)\nARG BUILD_PACKAGES=\"\"\nRUN if [ -n \"$BUILD_PACKAGES\" ]; then apk update && apk add --no-cache $BUILD_PACKAGES; fi\n\nARG PHP_SWOOLE_VERSION\nENV PHP_SWOOLE_VERSION=$PHP_SWOOLE_VERSION\nRUN \\\n  apk add --no-cache --virtual .deps \\\n  make \\\n  automake \\\n  autoconf \\\n  gcc \\\n  g++ \\\n  git \\\n  zlib-dev \\\n  brotli-dev \\\n  yaml-dev \\\n  libmaxminddb-dev \\\n  openssl-dev\n\nRUN docker-php-ext-install -j\"$(nproc)\" sockets\n\nRUN \\\n  ## Swoole Extension\n  git clone --depth 1 --branch $PHP_SWOOLE_VERSION https://github.com/swoole/swoole-src.git && \\\n  cd swoole-src && \\\n  phpize && \\\n  ./configure --enable-http2 --enable-openssl && \\\n  make -j\"$(nproc)\" && make install && \\\n  cd ..\n\n# Stage compiled extensions at a fixed path so the final stage doesn't need to\n# know the PHP-ABI-versioned extension directory name.\nRUN mkdir -p /opt/ext \\\n    && cp \"$(php-config --extension-dir)/swoole.so\" /opt/ext/ \\\n    && (cp \"$(php-config --extension-dir)\"/yasd.so* /opt/ext/ 2>/dev/null || true)\n\nFROM $${BASE_IMAGE} AS final\nLABEL maintainer=\"team@appwrite.io\"\nLABEL namespace=\"open-runtimes\"\n\nENV OPEN_RUNTIMES_SECRET=open_runtime_secret\nENV OPEN_RUNTIMES_ENV=production\nENV OPEN_RUNTIMES_HEADERS=\"{}\"\n\nRUN <<EOR\n    if [ -f /etc/alpine-release ]; then\n        apk add util-linux zstd squashfs-tools\n    else\n        apt-get update && apt-get install -y util-linux zstd squashfs-tools\n    fi\nEOR\n\nRUN mkdir -p /mnt/code /mnt/logs /mnt/telemetry /usr/local/build /usr/local/server/src/function\n\nWORKDIR /usr/local/server\n\n# Assemble /usr/local/server from named build contexts, in overlay precedence\n# order (later layers overwrite earlier ones):\n#   1. helpers  -> repo helpers/ (global lifecycle runner + shims)\n#   2. shared   -> runtimes/<shared family>/ (e.g. javascript/ for node), or empty\n#   3. latest   -> runtimes/<runtime>/versions/latest/\n#   4. version  -> runtimes/<runtime>/versions/<version>/ extras, or empty\nCOPY --from=helpers . /usr/local/server/helpers/\nCOPY --from=shared . /usr/local/server/\nCOPY --from=latest . /usr/local/server/\nCOPY --from=version . /usr/local/server/\nRUN rm -f /usr/local/server/.gitkeep /usr/local/server/Dockerfile /usr/local/server/build.dockerfile\n\nENV OPEN_RUNTIMES_ENTRYPOINT=index.php\n\nRUN \\\n  apk update \\\n  && apk add --no-cache --virtual .deps \\\n  make \\\n  automake \\\n  autoconf \\\n  gcc \\\n  g++ \\\n  curl-dev \\\n  && apk add --no-cache \\\n  libstdc++ \\\n  certbot \\\n  brotli-dev \\\n  yaml-dev \\\n  libmaxminddb-dev \\\n  libgomp \\\n  bash \\\n  && docker-php-ext-install -j\"$(nproc)\" opcache \\\n  && apk del .deps \\\n  && rm -rf /var/cache/apk/*\n\nCOPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer\n\nRUN composer update --no-interaction --ignore-platform-reqs --optimize-autoloader --prefer-dist --no-dev\nRUN mv vendor vendor-server\n\nCOPY --from=step0 /opt/ext/ /opt/ext/\nRUN cp /opt/ext/* \"$(php-config --extension-dir)/\" && rm -rf /opt/ext\n\n# Enable Extensions\nRUN echo extension=swoole.so >> /usr/local/etc/php/conf.d/swoole.ini\n\nENV OPEN_RUNTIMES_SERVER_COMMAND=\"php -d memory_limit=8G src/server.php\"\n\nRUN chmod -R +x /usr/local/server/helpers\n\nEXPOSE 3000\n"
     },
     "php-8_4": {
       "inherits": [
@@ -1608,8 +1592,6 @@
       },
       "platforms": [
         "linux/amd64",
-        "linux/arm/v6",
-        "linux/arm/v7",
         "linux/arm64"
       ],
       "tags": [
@@ -1992,7 +1974,7 @@
       ]
     },
     "_cpp": {
-      "dockerfile-inline": "# syntax=docker/dockerfile:1\n# INCLUDE directives below are resolved by `bun ci/bake.ts`, which inlines the\n# referenced *.dockerfile fragments into docker-bake.json (dockerfile-inline).\nARG BASE_IMAGE\nFROM $${BASE_IMAGE}\n\nLABEL maintainer=\"team@appwrite.io\"\nLABEL namespace=\"open-runtimes\"\n\nENV OPEN_RUNTIMES_SECRET=open_runtime_secret\nENV OPEN_RUNTIMES_ENV=production\nENV OPEN_RUNTIMES_HEADERS=\"{}\"\n\nRUN <<EOR\n    if [ -f /etc/alpine-release ]; then\n        apk add util-linux zstd squashfs-tools\n    else\n        apt-get update && apt-get install -y util-linux zstd squashfs-tools\n    fi\nEOR\n\nRUN mkdir -p /mnt/code /mnt/logs /mnt/telemetry /usr/local/build /usr/local/server/src/function\n\nWORKDIR /usr/local/server\n\n# Assemble /usr/local/server from named build contexts, in overlay precedence\n# order (later layers overwrite earlier ones):\n#   1. helpers  -> repo helpers/ (global lifecycle runner + shims)\n#   2. shared   -> runtimes/<shared family>/ (e.g. javascript/ for node), or empty\n#   3. latest   -> runtimes/<runtime>/versions/latest/\n#   4. version  -> runtimes/<runtime>/versions/<version>/ extras, or empty\nCOPY --from=helpers . /usr/local/server/helpers/\nCOPY --from=shared . /usr/local/server/\nCOPY --from=latest . /usr/local/server/\nCOPY --from=version . /usr/local/server/\nRUN rm -f /usr/local/server/.gitkeep /usr/local/server/Dockerfile /usr/local/server/build.dockerfile\n\nENV OPEN_RUNTIMES_ENTRYPOINT=index.cc\nARG DEBIAN_FRONTEND=noninteractive\nENV DROGON_VERSION=v1.9.7\n\nRUN apk add --no-cache \\\n    git \\\n    gcc \\\n    g++ \\\n    cmake \\\n    make \\\n    openssl \\\n    doxygen \\\n    jsoncpp-dev \\\n    openssl-dev \\\n    zlib-dev \\\n    curl-dev \\\n    util-linux-dev \\\n    bash\n\nRUN git clone --depth 1 --branch $DROGON_VERSION https://github.com/drogonframework/drogon \\\n    && cd drogon \\\n    && git submodule update --init \\\n    && mkdir build \\\n    && cd build \\\n    && cmake -DCMAKE_BUILD_TYPE=Release .. \\\n    && make -j\"$(nproc)\" \\\n    && make install \\\n    && cd / \\\n    && rm -rf /drogon\n\nEXPOSE 3000\n\nENV OPEN_RUNTIMES_SERVER_COMMAND=\"src/function/cpp_runtime\"\n\nRUN chmod -R +x /usr/local/server/helpers\n\nEXPOSE 3000\n"
+      "dockerfile-inline": "# syntax=docker/dockerfile:1\n# INCLUDE directives below are resolved by `bun ci/bake.ts`, which inlines the\n# referenced *.dockerfile fragments into docker-bake.json (dockerfile-inline).\nARG BASE_IMAGE\nFROM $${BASE_IMAGE}\n\nLABEL maintainer=\"team@appwrite.io\"\nLABEL namespace=\"open-runtimes\"\n\nENV OPEN_RUNTIMES_SECRET=open_runtime_secret\nENV OPEN_RUNTIMES_ENV=production\nENV OPEN_RUNTIMES_HEADERS=\"{}\"\n\nRUN <<EOR\n    if [ -f /etc/alpine-release ]; then\n        apk add util-linux zstd squashfs-tools\n    else\n        apt-get update && apt-get install -y util-linux zstd squashfs-tools\n    fi\nEOR\n\nRUN mkdir -p /mnt/code /mnt/logs /mnt/telemetry /usr/local/build /usr/local/server/src/function\n\nWORKDIR /usr/local/server\n\n# Assemble /usr/local/server from named build contexts, in overlay precedence\n# order (later layers overwrite earlier ones):\n#   1. helpers  -> repo helpers/ (global lifecycle runner + shims)\n#   2. shared   -> runtimes/<shared family>/ (e.g. javascript/ for node), or empty\n#   3. latest   -> runtimes/<runtime>/versions/latest/\n#   4. version  -> runtimes/<runtime>/versions/<version>/ extras, or empty\nCOPY --from=helpers . /usr/local/server/helpers/\nCOPY --from=shared . /usr/local/server/\nCOPY --from=latest . /usr/local/server/\nCOPY --from=version . /usr/local/server/\nRUN rm -f /usr/local/server/.gitkeep /usr/local/server/Dockerfile /usr/local/server/build.dockerfile\n\nENV OPEN_RUNTIMES_ENTRYPOINT=index.cc\nARG DEBIAN_FRONTEND=noninteractive\nENV DROGON_VERSION=v1.9.7\n\nRUN apk add --no-cache \\\n    git \\\n    gcc \\\n    g++ \\\n    cmake \\\n    make \\\n    openssl \\\n    doxygen \\\n    jsoncpp-dev \\\n    openssl-dev \\\n    zlib-dev \\\n    curl-dev \\\n    util-linux-dev \\\n    bash\n\nRUN git clone --depth 1 --branch $DROGON_VERSION https://github.com/drogonframework/drogon \\\n    && cd drogon \\\n    && git submodule update --init \\\n    && mkdir build \\\n    && cd build \\\n    && cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_EXAMPLES=OFF -DBUILD_TESTING=OFF .. \\\n    && make -j\"$(nproc)\" \\\n    && make install \\\n    && cd / \\\n    && rm -rf /drogon\n\nEXPOSE 3000\n\nENV OPEN_RUNTIMES_SERVER_COMMAND=\"src/function/cpp_runtime\"\n\nRUN chmod -R +x /usr/local/server/helpers\n\nEXPOSE 3000\n"
     },
     "cpp-17": {
       "inherits": [
@@ -2010,8 +1992,6 @@
       },
       "platforms": [
         "linux/amd64",
-        "linux/arm/v6",
-        "linux/arm/v7",
         "linux/arm64"
       ],
       "tags": [
@@ -2035,8 +2015,6 @@
       },
       "platforms": [
         "linux/amd64",
-        "linux/arm/v6",
-        "linux/arm/v7",
         "linux/arm64"
       ],
       "tags": [
@@ -2060,8 +2038,6 @@
       },
       "platforms": [
         "linux/amd64",
-        "linux/arm/v6",
-        "linux/arm/v7",
         "linux/arm64"
       ],
       "tags": [

--- a/runtimes/cpp/Dockerfile
+++ b/runtimes/cpp/Dockerfile
@@ -30,7 +30,7 @@ RUN git clone --depth 1 --branch $DROGON_VERSION https://github.com/drogonframew
     && git submodule update --init \
     && mkdir build \
     && cd build \
-    && cmake -DCMAKE_BUILD_TYPE=Release .. \
+    && cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_EXAMPLES=OFF -DBUILD_TESTING=OFF .. \
     && make -j"$(nproc)" \
     && make install \
     && cd / \

--- a/runtimes/php/Dockerfile
+++ b/runtimes/php/Dockerfile
@@ -43,7 +43,7 @@ RUN \
   libmaxminddb-dev \
   libgomp \
   bash \
-  && docker-php-ext-install opcache \
+  && docker-php-ext-install -j"$(nproc)" opcache \
   && apk del .deps \
   && rm -rf /var/cache/apk/*
 

--- a/runtimes/php/build.dockerfile
+++ b/runtimes/php/build.dockerfile
@@ -12,7 +12,7 @@ RUN \
   libmaxminddb-dev \
   openssl-dev
 
-RUN docker-php-ext-install sockets
+RUN docker-php-ext-install -j"$(nproc)" sockets
 
 RUN \
   ## Swoole Extension
@@ -20,6 +20,5 @@ RUN \
   cd swoole-src && \
   phpize && \
   ./configure --enable-http2 --enable-openssl && \
-  make && make install && \
+  make -j"$(nproc)" && make install && \
   cd ..
-


### PR DESCRIPTION
## Summary

- restrict published runtime images to linux/amd64 and linux/arm64
- remove the obsolete ARM32 QEMU setup from the release workflow
- parallelize PHP Swoole, sockets, and OPcache compilation
- skip unused Drogon examples and tests in C++ images

## Motivation

The 0.13.11 release took 50m48s. ARMv6 and ARMv7 builds consumed 274 runner-minutes, exceeding the 203 runner-minutes used by all native amd64 and arm64 builds combined. The slowest ARM32 PHP and C++ jobs took 29-36 minutes each and blocked all manifest publication.

Release run: https://github.com/open-runtimes/open-runtimes/actions/runs/29756950070

## Validation

- bun ./ci/bake.ts --check
- confirmed every generated target uses only linux/amd64 and/or linux/arm64
- built C++ 20 for linux/arm64 and verified drogon_ctl 1.9.7
- built PHP 8.0 and PHP 8.4 for linux/arm64
- verified Swoole, sockets, and OPcache load in both PHP images
- parsed the publish workflow YAML and ran git diff --check