### PR TITLE
perf(ci): registry build cache + zstd compression on publish

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -69,12 +69,19 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN  }}
       - name: Build & push by digest
         id: build
+        # Registry build cache (mode=max) keeps unchanged layers at identical
+        # digests across releases, so Kubernetes nodes pull only changed layers.
+        # zstd compresses new layers for faster decompression on pull; base
+        # layers keep their upstream (gzip) digests so they stay shareable.
         run: |
           IMAGE=$(docker buildx bake --print "$TARGET" | jq -r --arg t "$TARGET" '.target[$t].tags[0] | split(":")[0]')
+          CACHE="openruntimes/buildcache:$TARGET-${PLATFORM//\//-}"
           docker buildx bake "$TARGET" \
             --set "*.platform=$PLATFORM" \
             --set "*.tags=" \
-            --set "*.output=type=image,name=$IMAGE,push-by-digest=true,name-canonical=true,push=true" \
+            --set "*.cache-from=type=registry,ref=$CACHE" \
+            --set "*.cache-to=type=registry,ref=$CACHE,mode=max,image-manifest=true,oci-mediatypes=true" \
+            --set "*.output=type=image,name=$IMAGE,push-by-digest=true,name-canonical=true,push=true,compression=zstd,oci-mediatypes=true" \
             --metadata-file metadata.json
           DIGEST=$(jq -r --arg t "$TARGET" '.[$t]."containerimage.digest"' metadata.json)
           mkdir -p /tmp/digests


### PR DESCRIPTION
## Why

Split out of #512. We run all published runtime images on Kubernetes. Every release rebuilds every layer from scratch on ephemeral CI runners with no build cache, so functionally-identical layers get **new digests each publish** — nodes re-pull the whole image every release even when nothing meaningful changed.

## What

`publish.yaml` (both `deploy` and `deploy-rc`):
- **Registry build cache**: `cache-to=type=registry,mode=max` + `cache-from`, keyed per target at `openruntimes/buildcache:<target>`. Unchanged instructions now resolve to identical layer digests across releases → nodes pull only changed layers.
- **zstd compression**: push with `compression=zstd,oci-mediatypes=true` for faster decompression on pull. Deliberately **no** `force-compression`, so upstream base layers keep their gzip digests and stay shareable with other images.

## Ops note

`openruntimes/buildcache` is created automatically on Docker Hub on first push. If the org restricts auto-creation, create it (private) beforehand.

## Notes

The apk-hygiene half of #512 is in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)