### PR TITLE
perf: reduce SquashFS block size

### DIFF
--- a/helpers/lifecycle/build.sh
+++ b/helpers/lifecycle/build.sh
@@ -94,7 +94,7 @@ elif [ "$COMPRESSION_METHOD" = "squashfs" ]; then
 	processors=$(nproc 2>/dev/null || echo 1)
 	squashfs_log=$(mktemp)
 	trap 'rm -f "$squashfs_log"' EXIT
-	if mksquashfs . "$OUTPUT_DIR/code.sqfs" -comp lz4 -b 1M -noappend -no-xattrs -no-progress -processors "$processors" -wildcards -e code.sqfs code.tar code.tar.gz code.gz >"$squashfs_log" 2>&1; then
+	if mksquashfs . "$OUTPUT_DIR/code.sqfs" -comp lz4 -b 128K -noappend -no-xattrs -no-progress -processors "$processors" -wildcards -e code.sqfs code.tar code.tar.gz code.gz >"$squashfs_log" 2>&1; then
 		rm -f "$squashfs_log"
 		trap - EXIT
 	else

--- a/tests/BuildCompression.php
+++ b/tests/BuildCompression.php
@@ -75,7 +75,7 @@ class BuildCompression extends TestCase
 
         self::assertStringContainsString('"$COMPRESSION_METHOD" = "squashfs"', $build);
         self::assertStringContainsString('mksquashfs . "$OUTPUT_DIR/code.sqfs"', $build);
-        self::assertStringContainsString('-comp lz4 -b 1M -noappend -no-xattrs -no-progress', $build);
+        self::assertStringContainsString('-comp lz4 -b 128K -noappend -no-xattrs -no-progress', $build);
         self::assertStringContainsString('"$COMPRESSION_METHOD" = "none"', $build);
         self::assertStringContainsString('"$COMPRESSION_METHOD" = "skip"', $build);
         self::assertStringContainsString('touch "$OUTPUT_DIR/.extracted"', $build);


### PR DESCRIPTION
## Summary

Reduce runtime SquashFS data blocks from 1 MiB to 128 KiB. This reduces decompression amplification when runtimes load many small files during cold startup.

The build-cache SquashFS remains at 1 MiB because it has a separate sequential extraction workload and its storage path is versioned as `lz4-b1M`.

## Benchmark

The benchmark generated 100,000 distinct JavaScript-like modules across 256 directories. Modules use shared source syntax but unique identifiers, constants, dependency references, and varying line counts. The fixture contains 229,055,417 bytes of logical content; all 100,000 files produced unique SHA-256 hashes.

Each variant was built and measured three times. Mounted reads hashed every file with 8 parallel readers using the kernel-default SquashFS decompressor, matching the behavior available on current Edge staging nodes.

| Variant | Average package time | Average mount time | Average parallel read | Artifact size |
| --- | ---: | ---: | ---: | ---: |
| LZ4 128K | 3.31s | 18ms | 13.54s | 37,224,448 bytes |
| LZ4 1M | 3.38s | 25ms | 26.36s | 36,528,128 bytes |

The 128 KiB image reduced mounted read time by 48.6% while increasing artifact size by 1.9%. Packaging time was effectively unchanged and was 2.2% faster in this run.

Raw measurements:

| Variant | Package times | Parallel read times |
| --- | --- | --- |
| LZ4 128K | 3.585s, 3.232s, 3.103s | 15.713s, 12.292s, 12.607s |
| LZ4 1M | 3.878s, 2.956s, 3.313s | 25.936s, 27.956s, 25.186s |

An earlier 25,000 tiny-file stress test showed the same trend: 1.51s average reads with 128 KiB blocks versus 5.38s with 1 MiB blocks. Testing uncompressed inode metadata and disabled fragments did not improve reads and substantially increased artifact size.

Per-mount multithreaded decompression is unavailable on the current Edge staging kernel, so no kernel behavior change is required for this improvement.

## Tests

- `vendor/bin/phpunit tests/BuildCompression.php`
- `bash -n helpers/lifecycle/build.sh`
- `git diff --check`