### PR TITLE
fix: whitelist manifest files instead of walking build output

### DIFF
--- a/helpers/build-manifest.sh
+++ b/helpers/build-manifest.sh
@@ -5,6 +5,11 @@
 # listing). Opt-in: a no-op when the variable is unset. Best-effort: never
 # fails the build.
 #
+# The listing is a whitelist, not a walk: the SSR framework entrypoints below
+# that exist, plus the first two HTML files in the output. Outputs can hold
+# millions of generated files, so everything detection does not look for by
+# name stays out.
+#
 # Manifest shape (v1) — future fields become sibling keys:
 #   {"version":1,"files":["index.html","server/entry.mjs"]}
 
@@ -26,11 +31,30 @@ tmp_manifest="${OPEN_RUNTIMES_BUILD_MANIFEST}.tmp"
 rm -f "$tmp_manifest"
 trap 'rm -f "$tmp_manifest"' EXIT
 
-# The output file listing: dependency directories pruned, archive artifacts
-# excluded (mirroring the archive step's excludes), leading ./ stripped, and
-# capped so a pathological output can't produce an unbounded manifest.
-max_files="${OPEN_RUNTIMES_BUILD_MANIFEST_MAX_FILES:-10000}"
-files=$(find . -name node_modules -prune -o -type f ! -name code.sqfs ! -name code.tar ! -name code.tar.gz ! -name code.gz -print 2>/dev/null | head -n "$max_files" | sed 's|^\./||')
+# SSR entrypoints, mirroring the detector's framework file list. Add a path
+# here when a new SSR framework is supported.
+candidates=(
+	'.next/server/webpack-runtime.js' # nextjs
+	'.next/turbopack'                 # nextjs
+	'server.js'                       # nextjs
+	'server/index.mjs'                # nuxt, analog, tanstack-start
+	'handler.js'                      # sveltekit
+	'server/entry.mjs'                # astro
+	'build/server/index.js'           # remix
+	'server/server.mjs'               # angular
+	'server/server.js'                # tanstack-start
+)
+
+# The candidates that exist (-e, since some markers are directories), then the
+# first two HTML files.
+files=$(
+	for candidate in "${candidates[@]}"; do
+		if [ -e "$candidate" ]; then
+			printf '%s\n' "$candidate"
+		fi
+	done
+	find . -name node_modules -prune -o -type f -name '*.html' -print 2>/dev/null | sed 's|^\./||' | head -n 2
+)
 
 # jq guarantees correct JSON string escaping; the fallback covers the common
 # cases (backslash, double quote, tab, carriage return) for images without

--- a/runtimes/python/README.md
+++ b/runtimes/python/README.md
@@ -47,7 +47,7 @@ Output `{"n":0.7232589496628183}` with random float will be displayed after the 
 
 ```python
 def main(context):
-    return context.res.send('Hello Open Runtimes 👋')
+    return context.res.send("Hello Open Runtimes 👋")
 ```
 
 - To handle dependencies, you need to have `requirements.txt` file. To install those dependencies, pass `OPEN_RUNTIMES_BUILD_COMMAND="pip install -r requirements.txt"` during build.

--- a/runtimes/python/versions/ml-3.11/README.md
+++ b/runtimes/python/versions/ml-3.11/README.md
@@ -78,7 +78,7 @@ You can also make changes to the example code and apply the changes with the `do
 
 ```python
 def main(context):
-    return context.res.send('Hello Open Runtimes 👋')
+    return context.res.send("Hello Open Runtimes 👋")
 ```
 
 - To handle dependencies, you need to have `requirements.txt` file. To install those dependencies, pass `OPEN_RUNTIMES_BUILD_COMMAND="pip install -r requirements.txt"` during build.

--- a/runtimes/python/versions/ml-3.12/README.md
+++ b/runtimes/python/versions/ml-3.12/README.md
@@ -78,7 +78,7 @@ You can also make changes to the example code and apply the changes with the `do
 
 ```python
 def main(context):
-    return context.res.send('Hello Open Runtimes 👋')
+    return context.res.send("Hello Open Runtimes 👋")
 ```
 
 - To handle dependencies, you need to have `requirements.txt` file. To install those dependencies, pass `OPEN_RUNTIMES_BUILD_COMMAND="pip install -r requirements.txt"` during build.

--- a/runtimes/python/versions/ml-3.13/README.md
+++ b/runtimes/python/versions/ml-3.13/README.md
@@ -78,7 +78,7 @@ You can also make changes to the example code and apply the changes with the `do
 
 ```python
 def main(context):
-    return context.res.send('Hello Open Runtimes 👋')
+    return context.res.send("Hello Open Runtimes 👋")
 ```
 
 - To handle dependencies, you need to have `requirements.txt` file. To install those dependencies, pass `OPEN_RUNTIMES_BUILD_COMMAND="pip install -r requirements.txt"` during build.

--- a/tests/BuildManifest.php
+++ b/tests/BuildManifest.php
@@ -38,36 +38,50 @@ class BuildManifest extends TestCase
         self::assertSame([], \glob($this->root . '/*.json'));
     }
 
-    public function testWritesVersionedManifestOfOutputFiles(): void
+    public function testWritesVersionedManifestOfSsrEntrypointsAndHtml(): void
     {
         \file_put_contents($this->output . '/index.html', 'html');
         \mkdir($this->output . '/server', 0777, true);
-        \file_put_contents($this->output . '/server/entry.mjs', 'mjs');
+        \file_put_contents($this->output . '/server/server.js', 'js');
+        \file_put_contents($this->output . '/unrelated.js', 'js');
 
         $result = $this->runManifest();
 
         self::assertSame(0, $result['code']);
         $manifest = $this->readManifest();
         self::assertSame(1, $manifest['version']);
-        $files = $manifest['files'];
-        \sort($files);
-        self::assertSame(['index.html', 'server/entry.mjs'], $files);
+        self::assertSame(['server/server.js', 'index.html'], $manifest['files']);
         self::assertStringContainsString('Build manifest written. (2 files)', $result['output']);
         self::assertFileDoesNotExist($this->manifestPath() . '.tmp');
     }
 
-    public function testPrunesNodeModulesAndExcludesArchiveArtifacts(): void
+    public function testListsEntrypointDirectories(): void
     {
-        \file_put_contents($this->output . '/index.html', 'html');
-        \mkdir($this->output . '/node_modules/pkg', 0777, true);
-        \file_put_contents($this->output . '/node_modules/pkg/index.js', 'js');
-        \file_put_contents($this->output . '/code.tar.gz', 'tar');
-        \file_put_contents($this->output . '/code.sqfs', 'sqfs');
+        \mkdir($this->output . '/.next/turbopack', 0777, true);
 
         $result = $this->runManifest();
 
         self::assertSame(0, $result['code']);
-        self::assertSame(['index.html'], $this->readManifest()['files']);
+        self::assertSame(['.next/turbopack'], $this->readManifest()['files']);
+    }
+
+    public function testListsAtMostTwoHtmlFilesAndPrunesNodeModules(): void
+    {
+        foreach (\range(1, 5) as $i) {
+            \file_put_contents($this->output . '/page-' . $i . '.html', 'html');
+        }
+        \mkdir($this->output . '/node_modules/pkg', 0777, true);
+        \file_put_contents($this->output . '/node_modules/pkg/index.html', 'html');
+        \file_put_contents($this->output . '/code.tar.gz', 'tar');
+
+        $result = $this->runManifest();
+
+        self::assertSame(0, $result['code']);
+        $files = $this->readManifest()['files'];
+        self::assertCount(2, $files);
+        foreach ($files as $file) {
+            self::assertMatchesRegularExpression('/^page-\d\.html$/', $file);
+        }
     }
 
     public function testEscapesSpecialCharactersInFileNames(): void
@@ -93,21 +107,6 @@ class BuildManifest extends TestCase
         self::assertDirectoryDoesNotExist($path);
         $manifest = \json_decode((string) \file_get_contents($path), true);
         self::assertSame(['index.html'], $manifest['files']);
-    }
-
-    public function testCapsFileCount(): void
-    {
-        foreach (\range(1, 5) as $i) {
-            \file_put_contents($this->output . '/file-' . $i . '.html', 'html');
-        }
-
-        $result = $this->runManifest([
-            'OPEN_RUNTIMES_BUILD_MANIFEST' => $this->manifestPath(),
-            'OPEN_RUNTIMES_BUILD_MANIFEST_MAX_FILES' => '2',
-        ]);
-
-        self::assertSame(0, $result['code']);
-        self::assertCount(2, $this->readManifest()['files']);
     }
 
     public function testEmptyOutputWritesEmptyFileList(): void


### PR DESCRIPTION
The build manifest listed every non-`node_modules` file in the build output. Outputs that generate huge file trees (docs, specs) blew past the 10k file cap, so the SSR entrypoint could be missing from the listing and rendering detection fell back to `static` — producing "Adapter mismatch. Detected: static does not match with the set adapter: ssr" on valid SSR deployments.

## Changes

- `helpers/build-manifest.sh` now lists only the SSR entrypoints detection looks for by name (mirroring the detector's `SSR::FRAMEWORK_FILES`), plus the first two HTML files with `node_modules` pruned.
- Existence is checked with `-e`, so directory markers like `.next/turbopack` are detected.
- Dropped `OPEN_RUNTIMES_BUILD_MANIFEST_MAX_FILES` and the archive-artifact excludes — the listing is now bounded by the candidate list plus 2, and `code.sqfs`/`code.tar*` can no longer appear.

Adding support for a new SSR framework means adding its entrypoint to the `candidates` array. No orchestrator-side plumbing needed.

## Test plan

`vendor/bin/phpunit tests/BuildManifest.php` — 8/8 pass, covering entrypoint hits/misses, directory markers, the two-HTML cap with `node_modules` pruned, and JSON escaping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)