### PR TITLE
Update npm across JavaScript runtimes

### DIFF
--- a/ci/runtimes.toml
+++ b/ci/runtimes.toml
@@ -321,26 +321,26 @@ output = "./.next"
 # ─────────────────────────────────────────────────────────────────────────────
 
 [node.build.versions]
-"26" = { base = "node:26.5.0-alpine3.24", args = { INSTALL_SSR_TOOLING = "true", YARN_VERSION = "1.22.22" } }
-"25" = { base = "node:25.9.0-alpine3.23", args = { INSTALL_SSR_TOOLING = "true" } }
-"24" = { base = "node:24.18.0-alpine3.23", args = { INSTALL_SSR_TOOLING = "true" } }
-"23" = { base = "node:23.11.1-alpine3.22", args = { INSTALL_SSR_TOOLING = "true" } }
-"22" = { base = "node:22.23.1-alpine3.23", args = { INSTALL_SSR_TOOLING = "true" } }
-"21.0" = { base = "node:21.7.3-alpine3.20" }
-"20.0" = { base = "node:20.20.2-alpine3.23" }
-"19.0" = { base = "node:19.9.0-alpine3.18" }
-"18.0" = { base = "node:18.20.8-alpine3.20" }
-"16.0" = { base = "node:16.20.2-alpine3.18", args = { PNPM_VERSION = "8" } }
+"26" = { base = "node:26.5.0-alpine3.24", args = { INSTALL_SSR_TOOLING = "true", NPM_VERSION = "12.0.2", YARN_VERSION = "1.22.22" } }
+"25" = { base = "node:25.9.0-alpine3.23", args = { INSTALL_SSR_TOOLING = "true", NPM_VERSION = "11.19.0" } }
+"24" = { base = "node:24.18.0-alpine3.23", args = { INSTALL_SSR_TOOLING = "true", NPM_VERSION = "12.0.2" } }
+"23" = { base = "node:23.11.1-alpine3.22", args = { INSTALL_SSR_TOOLING = "true", NPM_VERSION = "11.19.0" } }
+"22" = { base = "node:22.23.1-alpine3.23", args = { INSTALL_SSR_TOOLING = "true", NPM_VERSION = "12.0.2" } }
+"21.0" = { base = "node:21.7.3-alpine3.20", args = { NPM_VERSION = "10.9.9" } }
+"20.0" = { base = "node:20.20.2-alpine3.23", args = { NPM_VERSION = "11.19.0" } }
+"19.0" = { base = "node:19.9.0-alpine3.18", args = { NPM_VERSION = "9.9.4" } }
+"18.0" = { base = "node:18.20.8-alpine3.20", args = { NPM_VERSION = "10.9.9" } }
+"16.0" = { base = "node:16.20.2-alpine3.18", args = { NPM_VERSION = "9.9.4", PNPM_VERSION = "8" } }
 
 [deno.build.versions]
-"2.6" = { base = "denoland/deno:alpine-2.6.7" }
-"2.5" = { base = "denoland/deno:alpine-2.5.7" }
-"2.0" = { base = "denoland/deno:alpine-2.0.6" }
-"1.46" = { base = "denoland/deno:alpine-1.46.3" }
-"1.40" = { base = "denoland/deno:alpine-1.40.5", platforms = ["linux/amd64"] }
-"1.35" = { base = "denoland/deno:alpine-1.35.3", platforms = ["linux/amd64"] }
-"1.24" = { base = "denoland/deno:alpine-1.24.3", platforms = ["linux/amd64"] }
-"1.21" = { base = "denoland/deno:alpine-1.21.3", platforms = ["linux/amd64"] }
+"2.6" = { base = "denoland/deno:alpine-2.6.7", args = { NPM_VERSION = "12.0.2" } }
+"2.5" = { base = "denoland/deno:alpine-2.5.7", args = { NPM_VERSION = "12.0.2" } }
+"2.0" = { base = "denoland/deno:alpine-2.0.6", args = { NPM_VERSION = "10.9.9" } }
+"1.46" = { base = "denoland/deno:alpine-1.46.3", args = { NPM_VERSION = "10.9.9" } }
+"1.40" = { base = "denoland/deno:alpine-1.40.5", args = { NPM_VERSION = "10.9.9" }, platforms = ["linux/amd64"] }
+"1.35" = { base = "denoland/deno:alpine-1.35.3", args = { NPM_VERSION = "9.9.4" }, platforms = ["linux/amd64"] }
+"1.24" = { base = "denoland/deno:alpine-1.24.3", args = { NPM_VERSION = "7.24.2" }, platforms = ["linux/amd64"] }
+"1.21" = { base = "denoland/deno:alpine-1.21.3", args = { NPM_VERSION = "7.24.2" }, platforms = ["linux/amd64"] }
 
 [python.build.versions]
 "3.14" = { base = "python:3.14.6-alpine3.23" }
@@ -445,10 +445,10 @@ platforms = ["linux/amd64"]
 "1.23" = { base = "golang:1.23.12-alpine3.22" }
 
 [bun.build.versions]
-"1.3" = { base = "oven/bun:1.3.8-alpine" }
-"1.2" = { base = "oven/bun:1.2.23-alpine" }
-"1.1" = { base = "oven/bun:1.1.45-alpine" }
-"1.0" = { base = "oven/bun:1.0.36-alpine" }
+"1.3" = { base = "oven/bun:1.3.8-alpine", args = { NPM_VERSION = "12.0.2" } }
+"1.2" = { base = "oven/bun:1.2.23-alpine", args = { NPM_VERSION = "10.9.9" } }
+"1.1" = { base = "oven/bun:1.1.45-alpine", args = { NPM_VERSION = "10.9.9" } }
+"1.0" = { base = "oven/bun:1.0.36-alpine", args = { NPM_VERSION = "10.9.9" } }
 
 [rust.build.versions]
 "1.83" = { base = "rust:1.83-alpine" }

--- a/docker-bake.json
+++ b/docker-bake.json
@@ -185,7 +185,7 @@
   },
   "target": {
     "_node": {
-      "dockerfile-inline": "# syntax=docker/dockerfile:1\n# INCLUDE directives below are resolved by `bun ci/bake.ts`, which inlines the\n# referenced *.dockerfile fragments into docker-bake.json (dockerfile-inline).\nARG BASE_IMAGE\nFROM $${BASE_IMAGE}\n\nLABEL maintainer=\"team@appwrite.io\"\nLABEL namespace=\"open-runtimes\"\n\nENV OPEN_RUNTIMES_SECRET=open_runtime_secret\nENV OPEN_RUNTIMES_ENV=production\nENV OPEN_RUNTIMES_HEADERS=\"{}\"\n\nRUN <<EOR\n    if [ -f /etc/alpine-release ]; then\n        apk add --no-cache util-linux zstd squashfs-tools\n    else\n        apt-get update && apt-get install -y util-linux zstd squashfs-tools\n    fi\nEOR\n\nRUN mkdir -p /mnt/code /mnt/logs /mnt/telemetry /usr/local/build /usr/local/server/src/function\n\nWORKDIR /usr/local/server\n\n# Assemble /usr/local/server from named build contexts, in overlay precedence\n# order (later layers overwrite earlier ones):\n#   1. helpers  -> repo helpers/ (global lifecycle runner + shims)\n#   2. shared   -> runtimes/<shared family>/ (e.g. javascript/ for node), or empty\n#   3. latest   -> runtimes/<runtime>/versions/latest/\n#   4. version  -> runtimes/<runtime>/versions/<version>/ extras, or empty\nCOPY --from=helpers . /usr/local/server/helpers/\nCOPY --from=shared . /usr/local/server/\nCOPY --from=latest . /usr/local/server/\nCOPY --from=version . /usr/local/server/\nRUN rm -f /usr/local/server/.gitkeep /usr/local/server/Dockerfile /usr/local/server/build.dockerfile\n\nRUN apk add --no-cache bash nss font-noto ca-certificates gcompat\n\n# https://pnpm.io/installation#compatibility (node 16 needs pnpm 8)\nARG PNPM_VERSION=9.15.9\nRUN npm install pnpm@$${PNPM_VERSION} modclean@2.1.2 -g\n\n# Node 26 dropped the bundled Yarn from the official images (Corepack went in\n# 25). Install it there to keep tooling parity; older bases already ship Yarn,\n# and installing over their symlink fails with EEXIST.\nARG YARN_VERSION=\"\"\nRUN if [ -n \"$YARN_VERSION\" ]; then npm install yarn@$${YARN_VERSION} -g; fi\n\nRUN npm ci && npm cache clean --force\n\n# Additional tooling needed for Node runtimes used for SSR (Sites)\n# alpine-sdk - basic tooling like git, gcc, g++, make...\n# python3-dev - Install Python (useful to some NPM libs)\n# py3-pip - Python package manager\n# gcompat - Pre-requirement for Bun\nARG INSTALL_SSR_TOOLING=\"false\"\nARG BUN_VERSION=1.3.2\n# The Bun npm package retains multiple platform variants. Keep only the\n# resolved executable and remove npm's downloaded package cache.\nRUN if [ \"$INSTALL_SSR_TOOLING\" = \"true\" ]; then \\\n        apk add --no-cache alpine-sdk python3-dev py3-pip gcompat && \\\n        npm install bun@$${BUN_VERSION} -g && \\\n        cp -L /usr/local/bin/bun /tmp/bun && \\\n        npm uninstall -g bun && \\\n        install -m 0755 /tmp/bun /usr/local/bin/bun && \\\n        ln -sf /usr/local/bin/bun /usr/local/bin/bunx && \\\n        rm -f /tmp/bun && \\\n        npm cache clean --force; \\\n    fi\n\nENV OPEN_RUNTIMES_SERVER_COMMAND=\"node --max_old_space_size=8192 src/server.js\"\n\n# Next.js packing: keep node's pre-consolidation behavior (ship node_modules\n# untouched) instead of the shared packer's modclean fallback used by bun/deno.\nENV OPEN_RUNTIMES_NEXTJS_CLEANUP=none\n\nRUN chmod -R +x /usr/local/server/helpers\n\nEXPOSE 3000\n"
+      "dockerfile-inline": "# syntax=docker/dockerfile:1\n# INCLUDE directives below are resolved by `bun ci/bake.ts`, which inlines the\n# referenced *.dockerfile fragments into docker-bake.json (dockerfile-inline).\nARG BASE_IMAGE\nFROM $${BASE_IMAGE}\n\nLABEL maintainer=\"team@appwrite.io\"\nLABEL namespace=\"open-runtimes\"\n\nENV OPEN_RUNTIMES_SECRET=open_runtime_secret\nENV OPEN_RUNTIMES_ENV=production\nENV OPEN_RUNTIMES_HEADERS=\"{}\"\n\nRUN <<EOR\n    if [ -f /etc/alpine-release ]; then\n        apk add --no-cache util-linux zstd squashfs-tools\n    else\n        apt-get update && apt-get install -y util-linux zstd squashfs-tools\n    fi\nEOR\n\nRUN mkdir -p /mnt/code /mnt/logs /mnt/telemetry /usr/local/build /usr/local/server/src/function\n\nWORKDIR /usr/local/server\n\n# Assemble /usr/local/server from named build contexts, in overlay precedence\n# order (later layers overwrite earlier ones):\n#   1. helpers  -> repo helpers/ (global lifecycle runner + shims)\n#   2. shared   -> runtimes/<shared family>/ (e.g. javascript/ for node), or empty\n#   3. latest   -> runtimes/<runtime>/versions/latest/\n#   4. version  -> runtimes/<runtime>/versions/<version>/ extras, or empty\nCOPY --from=helpers . /usr/local/server/helpers/\nCOPY --from=shared . /usr/local/server/\nCOPY --from=latest . /usr/local/server/\nCOPY --from=version . /usr/local/server/\nRUN rm -f /usr/local/server/.gitkeep /usr/local/server/Dockerfile /usr/local/server/build.dockerfile\n\nRUN apk add --no-cache bash nss font-noto ca-certificates gcompat\n\nARG NPM_VERSION\nRUN npm install npm@$${NPM_VERSION} -g && \\\n    hash -r && \\\n    test \"$(npm --version)\" = \"$${NPM_VERSION}\" && \\\n    test \"$(npx --version)\" = \"$${NPM_VERSION}\" && \\\n    rm -rf /root/.npm\n\n# https://pnpm.io/installation#compatibility (node 16 needs pnpm 8)\nARG PNPM_VERSION=9.15.9\nRUN npm install pnpm@$${PNPM_VERSION} modclean@2.1.2 -g\n\n# Node 26 dropped the bundled Yarn from the official images (Corepack went in\n# 25). Install it there to keep tooling parity; older bases already ship Yarn,\n# and installing over their symlink fails with EEXIST.\nARG YARN_VERSION=\"\"\nRUN if [ -n \"$YARN_VERSION\" ]; then npm install yarn@$${YARN_VERSION} -g; fi\n\nRUN npm ci && npm cache clean --force\n\n# Additional tooling needed for Node runtimes used for SSR (Sites)\n# alpine-sdk - basic tooling like git, gcc, g++, make...\n# python3-dev - Install Python (useful to some NPM libs)\n# py3-pip - Python package manager\n# gcompat - Pre-requirement for Bun\nARG INSTALL_SSR_TOOLING=\"false\"\nARG BUN_VERSION=1.3.2\n# The Bun npm package retains multiple platform variants. Keep only the\n# resolved executable and remove npm's downloaded package cache.\nRUN if [ \"$INSTALL_SSR_TOOLING\" = \"true\" ]; then \\\n        apk add --no-cache alpine-sdk python3-dev py3-pip gcompat && \\\n        npm install bun@$${BUN_VERSION} -g && \\\n        cp -L /usr/local/bin/bun /tmp/bun && \\\n        npm uninstall -g bun && \\\n        install -m 0755 /tmp/bun /usr/local/bin/bun && \\\n        ln -sf /usr/local/bin/bun /usr/local/bin/bunx && \\\n        rm -f /tmp/bun && \\\n        npm cache clean --force; \\\n    fi\n\nENV OPEN_RUNTIMES_SERVER_COMMAND=\"node --max_old_space_size=8192 src/server.js\"\n\n# Next.js packing: keep node's pre-consolidation behavior (ship node_modules\n# untouched) instead of the shared packer's modclean fallback used by bun/deno.\nENV OPEN_RUNTIMES_NEXTJS_CLEANUP=none\n\nRUN chmod -R +x /usr/local/server/helpers\n\nEXPOSE 3000\n"
     },
     "node-22": {
       "inherits": [
@@ -200,7 +200,8 @@
       },
       "args": {
         "BASE_IMAGE": "node:22.23.1-alpine3.23",
-        "INSTALL_SSR_TOOLING": "true"
+        "INSTALL_SSR_TOOLING": "true",
+        "NPM_VERSION": "12.0.2"
       },
       "platforms": [
         "linux/amd64",
@@ -224,7 +225,8 @@
       },
       "args": {
         "BASE_IMAGE": "node:23.11.1-alpine3.22",
-        "INSTALL_SSR_TOOLING": "true"
+        "INSTALL_SSR_TOOLING": "true",
+        "NPM_VERSION": "11.19.0"
       },
       "platforms": [
         "linux/amd64",
@@ -248,7 +250,8 @@
       },
       "args": {
         "BASE_IMAGE": "node:24.18.0-alpine3.23",
-        "INSTALL_SSR_TOOLING": "true"
+        "INSTALL_SSR_TOOLING": "true",
+        "NPM_VERSION": "12.0.2"
       },
       "platforms": [
         "linux/amd64",
@@ -272,7 +275,8 @@
       },
       "args": {
         "BASE_IMAGE": "node:25.9.0-alpine3.23",
-        "INSTALL_SSR_TOOLING": "true"
+        "INSTALL_SSR_TOOLING": "true",
+        "NPM_VERSION": "11.19.0"
       },
       "platforms": [
         "linux/amd64",
@@ -297,6 +301,7 @@
       "args": {
         "BASE_IMAGE": "node:26.5.0-alpine3.24",
         "INSTALL_SSR_TOOLING": "true",
+        "NPM_VERSION": "12.0.2",
         "YARN_VERSION": "1.22.22"
       },
       "platforms": [
@@ -320,7 +325,8 @@
         "version": "./docker/empty"
       },
       "args": {
-        "BASE_IMAGE": "node:21.7.3-alpine3.20"
+        "BASE_IMAGE": "node:21.7.3-alpine3.20",
+        "NPM_VERSION": "10.9.9"
       },
       "platforms": [
         "linux/amd64",
@@ -343,7 +349,8 @@
         "version": "./docker/empty"
       },
       "args": {
-        "BASE_IMAGE": "node:20.20.2-alpine3.23"
+        "BASE_IMAGE": "node:20.20.2-alpine3.23",
+        "NPM_VERSION": "11.19.0"
       },
       "platforms": [
         "linux/amd64",
@@ -366,7 +373,8 @@
         "version": "./docker/empty"
       },
       "args": {
-        "BASE_IMAGE": "node:19.9.0-alpine3.18"
+        "BASE_IMAGE": "node:19.9.0-alpine3.18",
+        "NPM_VERSION": "9.9.4"
       },
       "platforms": [
         "linux/amd64",
@@ -389,7 +397,8 @@
         "version": "./docker/empty"
       },
       "args": {
-        "BASE_IMAGE": "node:18.20.8-alpine3.20"
+        "BASE_IMAGE": "node:18.20.8-alpine3.20",
+        "NPM_VERSION": "10.9.9"
       },
       "platforms": [
         "linux/amd64",
@@ -413,6 +422,7 @@
       },
       "args": {
         "BASE_IMAGE": "node:16.20.2-alpine3.18",
+        "NPM_VERSION": "9.9.4",
         "PNPM_VERSION": "8"
       },
       "platforms": [
@@ -425,7 +435,7 @@
       ]
     },
     "_deno": {
-      "dockerfile-inline": "# syntax=docker/dockerfile:1\n# INCLUDE directives below are resolved by `bun ci/bake.ts`, which inlines the\n# referenced *.dockerfile fragments into docker-bake.json (dockerfile-inline).\nARG BASE_IMAGE\nFROM $${BASE_IMAGE}\n\nLABEL maintainer=\"team@appwrite.io\"\nLABEL namespace=\"open-runtimes\"\n\nENV OPEN_RUNTIMES_SECRET=open_runtime_secret\nENV OPEN_RUNTIMES_ENV=production\nENV OPEN_RUNTIMES_HEADERS=\"{}\"\n\nRUN <<EOR\n    if [ -f /etc/alpine-release ]; then\n        apk add --no-cache util-linux zstd squashfs-tools\n    else\n        apt-get update && apt-get install -y util-linux zstd squashfs-tools\n    fi\nEOR\n\nRUN mkdir -p /mnt/code /mnt/logs /mnt/telemetry /usr/local/build /usr/local/server/src/function\n\nWORKDIR /usr/local/server\n\n# Assemble /usr/local/server from named build contexts, in overlay precedence\n# order (later layers overwrite earlier ones):\n#   1. helpers  -> repo helpers/ (global lifecycle runner + shims)\n#   2. shared   -> runtimes/<shared family>/ (e.g. javascript/ for node), or empty\n#   3. latest   -> runtimes/<runtime>/versions/latest/\n#   4. version  -> runtimes/<runtime>/versions/<version>/ extras, or empty\nCOPY --from=helpers . /usr/local/server/helpers/\nCOPY --from=shared . /usr/local/server/\nCOPY --from=latest . /usr/local/server/\nCOPY --from=version . /usr/local/server/\nRUN rm -f /usr/local/server/.gitkeep /usr/local/server/Dockerfile /usr/local/server/build.dockerfile\n\nRUN apk add --no-cache bash nss font-noto ca-certificates nodejs-current npm python3 make g++ gcc git\n\n# Deno's alpine image bundles a glibc-shim libgcc_s.so.1 at /usr/local/lib/\n# that conflicts with node's musl-linked expectations. Remove it so node loads\n# the system (alpine) libgcc from /usr/lib instead. Deno stays functional —\n# its binary is statically linked and doesn't need the shim at runtime.\nRUN rm -f /usr/local/lib/libgcc_s.so*\nRUN npm install modclean@2.1.2 -g && \\\n\tif deno --version | head -1 | grep -qE '^deno 2\\.'; then npm install pnpm yarn -g; fi && \\\n\tnpm install --no-save --prefix /usr/local/server @vercel/nft@^0.29.2\n\nENV OPEN_RUNTIMES_ENTRYPOINT=mod.ts\nENV DENO_DIR=/usr/builds/deno-cache\n\n# Pre-populate /usr/local/server/node_modules so the shared SSR preload's\n# `import superjson from \"superjson\"` resolves under --node-modules-dir=manual\n# at runtime. We use deno install against the runtimes/javascript/src/ssr/\n# deno.json import map that's already been overlaid into\n# /usr/local/server/src/ssr/.\n#\n# Only deno 2.x exposes the npm-style `deno install` (with --allow-scripts and\n# --node-modules-dir=auto|manual). On deno 1.x the same subcommand is the\n# CLI-script installer where --node-modules-dir takes only true|false and\n# --allow-scripts doesn't exist, so we skip the step there. Deno 1.x also\n# predates --import (required for the SSR preload) so SSR isn't viable on\n# those versions anyway. Probing --allow-scripts is a clean 2.x-only signal.\nRUN if [ -f /usr/local/server/src/ssr/deno.json ] && \\\n\tdeno install --help 2>/dev/null | grep -q -- '--allow-scripts'; then \\\n\tcp /usr/local/server/src/ssr/deno.json /usr/local/server/deno.json && \\\n\tcd /usr/local/server && deno install --node-modules-dir=auto --allow-scripts && \\\n\trm /usr/local/server/deno.json; \\\n\tfi\n\nENV OPEN_RUNTIMES_SERVER_COMMAND=\"deno run --allow-run --allow-net --allow-write --allow-read --allow-env src/server.ts\"\n\nRUN chmod -R +x /usr/local/server/helpers\n\nEXPOSE 3000\n"
+      "dockerfile-inline": "# syntax=docker/dockerfile:1\n# INCLUDE directives below are resolved by `bun ci/bake.ts`, which inlines the\n# referenced *.dockerfile fragments into docker-bake.json (dockerfile-inline).\nARG BASE_IMAGE\nFROM $${BASE_IMAGE}\n\nLABEL maintainer=\"team@appwrite.io\"\nLABEL namespace=\"open-runtimes\"\n\nENV OPEN_RUNTIMES_SECRET=open_runtime_secret\nENV OPEN_RUNTIMES_ENV=production\nENV OPEN_RUNTIMES_HEADERS=\"{}\"\n\nRUN <<EOR\n    if [ -f /etc/alpine-release ]; then\n        apk add --no-cache util-linux zstd squashfs-tools\n    else\n        apt-get update && apt-get install -y util-linux zstd squashfs-tools\n    fi\nEOR\n\nRUN mkdir -p /mnt/code /mnt/logs /mnt/telemetry /usr/local/build /usr/local/server/src/function\n\nWORKDIR /usr/local/server\n\n# Assemble /usr/local/server from named build contexts, in overlay precedence\n# order (later layers overwrite earlier ones):\n#   1. helpers  -> repo helpers/ (global lifecycle runner + shims)\n#   2. shared   -> runtimes/<shared family>/ (e.g. javascript/ for node), or empty\n#   3. latest   -> runtimes/<runtime>/versions/latest/\n#   4. version  -> runtimes/<runtime>/versions/<version>/ extras, or empty\nCOPY --from=helpers . /usr/local/server/helpers/\nCOPY --from=shared . /usr/local/server/\nCOPY --from=latest . /usr/local/server/\nCOPY --from=version . /usr/local/server/\nRUN rm -f /usr/local/server/.gitkeep /usr/local/server/Dockerfile /usr/local/server/build.dockerfile\n\nRUN apk add --no-cache bash nss font-noto ca-certificates nodejs-current npm python3 make g++ gcc git\n\n# Deno's alpine image bundles a glibc-shim libgcc_s.so.1 at /usr/local/lib/\n# that conflicts with node's musl-linked expectations. Remove it so node loads\n# the system (alpine) libgcc from /usr/lib instead. Deno stays functional —\n# its binary is statically linked and doesn't need the shim at runtime.\nRUN rm -f /usr/local/lib/libgcc_s.so*\nARG NPM_VERSION\nRUN npm install npm@$${NPM_VERSION} -g && \\\n\thash -r && \\\n\ttest \"$(npm --version)\" = \"$${NPM_VERSION}\" && \\\n\ttest \"$(npx --version)\" = \"$${NPM_VERSION}\" && \\\n\trm -rf /root/.npm\nRUN npm install modclean@2.1.2 -g && \\\n\tif deno --version | head -1 | grep -qE '^deno 2\\.'; then npm install pnpm yarn -g; fi && \\\n\tnpm install --no-save --prefix /usr/local/server @vercel/nft@^0.29.2\n\nENV OPEN_RUNTIMES_ENTRYPOINT=mod.ts\nENV DENO_DIR=/usr/builds/deno-cache\n\n# Pre-populate /usr/local/server/node_modules so the shared SSR preload's\n# `import superjson from \"superjson\"` resolves under --node-modules-dir=manual\n# at runtime. We use deno install against the runtimes/javascript/src/ssr/\n# deno.json import map that's already been overlaid into\n# /usr/local/server/src/ssr/.\n#\n# Only deno 2.x exposes the npm-style `deno install` (with --allow-scripts and\n# --node-modules-dir=auto|manual). On deno 1.x the same subcommand is the\n# CLI-script installer where --node-modules-dir takes only true|false and\n# --allow-scripts doesn't exist, so we skip the step there. Deno 1.x also\n# predates --import (required for the SSR preload) so SSR isn't viable on\n# those versions anyway. Probing --allow-scripts is a clean 2.x-only signal.\nRUN if [ -f /usr/local/server/src/ssr/deno.json ] && \\\n\tdeno install --help 2>/dev/null | grep -q -- '--allow-scripts'; then \\\n\tcp /usr/local/server/src/ssr/deno.json /usr/local/server/deno.json && \\\n\tcd /usr/local/server && deno install --node-modules-dir=auto --allow-scripts && \\\n\trm /usr/local/server/deno.json; \\\n\tfi\n\nENV OPEN_RUNTIMES_SERVER_COMMAND=\"deno run --allow-run --allow-net --allow-write --allow-read --allow-env src/server.ts\"\n\nRUN chmod -R +x /usr/local/server/helpers\n\nEXPOSE 3000\n"
     },
     "deno-2_6": {
       "inherits": [
@@ -439,7 +449,8 @@
         "version": "./docker/empty"
       },
       "args": {
-        "BASE_IMAGE": "denoland/deno:alpine-2.6.7"
+        "BASE_IMAGE": "denoland/deno:alpine-2.6.7",
+        "NPM_VERSION": "12.0.2"
       },
       "platforms": [
         "linux/amd64",
@@ -462,7 +473,8 @@
         "version": "./docker/empty"
       },
       "args": {
-        "BASE_IMAGE": "denoland/deno:alpine-2.5.7"
+        "BASE_IMAGE": "denoland/deno:alpine-2.5.7",
+        "NPM_VERSION": "12.0.2"
       },
       "platforms": [
         "linux/amd64",
@@ -485,7 +497,8 @@
         "version": "./runtimes/deno/versions/2.0"
       },
       "args": {
-        "BASE_IMAGE": "denoland/deno:alpine-2.0.6"
+        "BASE_IMAGE": "denoland/deno:alpine-2.0.6",
+        "NPM_VERSION": "10.9.9"
       },
       "platforms": [
         "linux/amd64",
@@ -508,7 +521,8 @@
         "version": "./runtimes/deno/versions/1.46"
       },
       "args": {
-        "BASE_IMAGE": "denoland/deno:alpine-1.46.3"
+        "BASE_IMAGE": "denoland/deno:alpine-1.46.3",
+        "NPM_VERSION": "10.9.9"
       },
       "platforms": [
         "linux/amd64",
@@ -531,7 +545,8 @@
         "version": "./runtimes/deno/versions/1.40"
       },
       "args": {
-        "BASE_IMAGE": "denoland/deno:alpine-1.40.5"
+        "BASE_IMAGE": "denoland/deno:alpine-1.40.5",
+        "NPM_VERSION": "10.9.9"
       },
       "platforms": [
         "linux/amd64"
@@ -553,7 +568,8 @@
         "version": "./runtimes/deno/versions/1.35"
       },
       "args": {
-        "BASE_IMAGE": "denoland/deno:alpine-1.35.3"
+        "BASE_IMAGE": "denoland/deno:alpine-1.35.3",
+        "NPM_VERSION": "9.9.4"
       },
       "platforms": [
         "linux/amd64"
@@ -575,7 +591,8 @@
         "version": "./runtimes/deno/versions/1.24"
       },
       "args": {
-        "BASE_IMAGE": "denoland/deno:alpine-1.24.3"
+        "BASE_IMAGE": "denoland/deno:alpine-1.24.3",
+        "NPM_VERSION": "7.24.2"
       },
       "platforms": [
         "linux/amd64"
@@ -597,7 +614,8 @@
         "version": "./runtimes/deno/versions/1.21"
       },
       "args": {
-        "BASE_IMAGE": "denoland/deno:alpine-1.21.3"
+        "BASE_IMAGE": "denoland/deno:alpine-1.21.3",
+        "NPM_VERSION": "7.24.2"
       },
       "platforms": [
         "linux/amd64"
@@ -2262,7 +2280,7 @@
       ]
     },
     "_bun": {
-      "dockerfile-inline": "# syntax=docker/dockerfile:1\n# INCLUDE directives below are resolved by `bun ci/bake.ts`, which inlines the\n# referenced *.dockerfile fragments into docker-bake.json (dockerfile-inline).\nARG BASE_IMAGE\nFROM $${BASE_IMAGE}\n\nLABEL maintainer=\"team@appwrite.io\"\nLABEL namespace=\"open-runtimes\"\n\nENV OPEN_RUNTIMES_SECRET=open_runtime_secret\nENV OPEN_RUNTIMES_ENV=production\nENV OPEN_RUNTIMES_HEADERS=\"{}\"\n\nRUN <<EOR\n    if [ -f /etc/alpine-release ]; then\n        apk add --no-cache util-linux zstd squashfs-tools\n    else\n        apt-get update && apt-get install -y util-linux zstd squashfs-tools\n    fi\nEOR\n\nRUN mkdir -p /mnt/code /mnt/logs /mnt/telemetry /usr/local/build /usr/local/server/src/function\n\nWORKDIR /usr/local/server\n\n# Assemble /usr/local/server from named build contexts, in overlay precedence\n# order (later layers overwrite earlier ones):\n#   1. helpers  -> repo helpers/ (global lifecycle runner + shims)\n#   2. shared   -> runtimes/<shared family>/ (e.g. javascript/ for node), or empty\n#   3. latest   -> runtimes/<runtime>/versions/latest/\n#   4. version  -> runtimes/<runtime>/versions/<version>/ extras, or empty\nCOPY --from=helpers . /usr/local/server/helpers/\nCOPY --from=shared . /usr/local/server/\nCOPY --from=latest . /usr/local/server/\nCOPY --from=version . /usr/local/server/\nRUN rm -f /usr/local/server/.gitkeep /usr/local/server/Dockerfile /usr/local/server/build.dockerfile\n\nENV OPEN_RUNTIMES_ENTRYPOINT=index.ts\n# Bun 1.0 arm64 includes glibc, whose /usr/lib/libc.so conflicts with musl-dev from g++.\nRUN APK_ADD_FLAGS=\"\" \\\n  && if apk info -e glibc > /dev/null 2>&1; then APK_ADD_FLAGS=\"--force-overwrite\"; fi \\\n  && apk add --no-cache $${APK_ADD_FLAGS} bash npm nss font-noto ca-certificates python3 make g++ gcc git\nRUN npm install pnpm@9.15.9 yarn modclean@2.1.2 -g\nRUN bun install && npm install --no-save --prefix /usr/local/server @vercel/nft@^0.29.2\n\nENV OPEN_RUNTIMES_SERVER_COMMAND=\"bun src/server.ts\"\n\nRUN chmod -R +x /usr/local/server/helpers\n\nEXPOSE 3000\n"
+      "dockerfile-inline": "# syntax=docker/dockerfile:1\n# INCLUDE directives below are resolved by `bun ci/bake.ts`, which inlines the\n# referenced *.dockerfile fragments into docker-bake.json (dockerfile-inline).\nARG BASE_IMAGE\nFROM $${BASE_IMAGE}\n\nLABEL maintainer=\"team@appwrite.io\"\nLABEL namespace=\"open-runtimes\"\n\nENV OPEN_RUNTIMES_SECRET=open_runtime_secret\nENV OPEN_RUNTIMES_ENV=production\nENV OPEN_RUNTIMES_HEADERS=\"{}\"\n\nRUN <<EOR\n    if [ -f /etc/alpine-release ]; then\n        apk add --no-cache util-linux zstd squashfs-tools\n    else\n        apt-get update && apt-get install -y util-linux zstd squashfs-tools\n    fi\nEOR\n\nRUN mkdir -p /mnt/code /mnt/logs /mnt/telemetry /usr/local/build /usr/local/server/src/function\n\nWORKDIR /usr/local/server\n\n# Assemble /usr/local/server from named build contexts, in overlay precedence\n# order (later layers overwrite earlier ones):\n#   1. helpers  -> repo helpers/ (global lifecycle runner + shims)\n#   2. shared   -> runtimes/<shared family>/ (e.g. javascript/ for node), or empty\n#   3. latest   -> runtimes/<runtime>/versions/latest/\n#   4. version  -> runtimes/<runtime>/versions/<version>/ extras, or empty\nCOPY --from=helpers . /usr/local/server/helpers/\nCOPY --from=shared . /usr/local/server/\nCOPY --from=latest . /usr/local/server/\nCOPY --from=version . /usr/local/server/\nRUN rm -f /usr/local/server/.gitkeep /usr/local/server/Dockerfile /usr/local/server/build.dockerfile\n\nENV OPEN_RUNTIMES_ENTRYPOINT=index.ts\n# Bun 1.0 arm64 includes glibc, whose /usr/lib/libc.so conflicts with musl-dev from g++.\nRUN APK_ADD_FLAGS=\"\" \\\n  && if apk info -e glibc > /dev/null 2>&1; then APK_ADD_FLAGS=\"--force-overwrite\"; fi \\\n  && apk add --no-cache $${APK_ADD_FLAGS} bash npm nss font-noto ca-certificates python3 make g++ gcc git\nARG NPM_VERSION\nRUN npm install npm@$${NPM_VERSION} -g && \\\n  hash -r && \\\n  test \"$(npm --version)\" = \"$${NPM_VERSION}\" && \\\n  test \"$(npx --version)\" = \"$${NPM_VERSION}\" && \\\n  rm -rf /root/.npm\nRUN npm install pnpm@9.15.9 yarn modclean@2.1.2 -g\nRUN bun install && npm install --no-save --prefix /usr/local/server @vercel/nft@^0.29.2\n\nENV OPEN_RUNTIMES_SERVER_COMMAND=\"bun src/server.ts\"\n\nRUN chmod -R +x /usr/local/server/helpers\n\nEXPOSE 3000\n"
     },
     "bun-1_3": {
       "inherits": [
@@ -2276,7 +2294,8 @@
         "version": "./docker/empty"
       },
       "args": {
-        "BASE_IMAGE": "oven/bun:1.3.8-alpine"
+        "BASE_IMAGE": "oven/bun:1.3.8-alpine",
+        "NPM_VERSION": "12.0.2"
       },
       "platforms": [
         "linux/amd64",
@@ -2299,7 +2318,8 @@
         "version": "./docker/empty"
       },
       "args": {
-        "BASE_IMAGE": "oven/bun:1.2.23-alpine"
+        "BASE_IMAGE": "oven/bun:1.2.23-alpine",
+        "NPM_VERSION": "10.9.9"
       },
       "platforms": [
         "linux/amd64",
@@ -2322,7 +2342,8 @@
         "version": "./docker/empty"
       },
       "args": {
-        "BASE_IMAGE": "oven/bun:1.1.45-alpine"
+        "BASE_IMAGE": "oven/bun:1.1.45-alpine",
+        "NPM_VERSION": "10.9.9"
       },
       "platforms": [
         "linux/amd64",
@@ -2345,7 +2366,8 @@
         "version": "./docker/empty"
       },
       "args": {
-        "BASE_IMAGE": "oven/bun:1.0.36-alpine"
+        "BASE_IMAGE": "oven/bun:1.0.36-alpine",
+        "NPM_VERSION": "10.9.9"
       },
       "platforms": [
         "linux/amd64",

--- a/runtimes/bun/Dockerfile
+++ b/runtimes/bun/Dockerfile
@@ -11,6 +11,12 @@ ENV OPEN_RUNTIMES_ENTRYPOINT=index.ts
 RUN APK_ADD_FLAGS="" \
   && if apk info -e glibc > /dev/null 2>&1; then APK_ADD_FLAGS="--force-overwrite"; fi \
   && apk add --no-cache ${APK_ADD_FLAGS} bash npm nss font-noto ca-certificates python3 make g++ gcc git
+ARG NPM_VERSION
+RUN npm install npm@${NPM_VERSION} -g && \
+  hash -r && \
+  test "$(npm --version)" = "${NPM_VERSION}" && \
+  test "$(npx --version)" = "${NPM_VERSION}" && \
+  rm -rf /root/.npm
 RUN npm install pnpm@9.15.9 yarn modclean@2.1.2 -g
 RUN bun install && npm install --no-save --prefix /usr/local/server @vercel/nft@^0.29.2
 

--- a/runtimes/deno/Dockerfile
+++ b/runtimes/deno/Dockerfile
@@ -13,6 +13,12 @@ RUN apk add --no-cache bash nss font-noto ca-certificates nodejs-current npm pyt
 # the system (alpine) libgcc from /usr/lib instead. Deno stays functional —
 # its binary is statically linked and doesn't need the shim at runtime.
 RUN rm -f /usr/local/lib/libgcc_s.so*
+ARG NPM_VERSION
+RUN npm install npm@${NPM_VERSION} -g && \
+	hash -r && \
+	test "$(npm --version)" = "${NPM_VERSION}" && \
+	test "$(npx --version)" = "${NPM_VERSION}" && \
+	rm -rf /root/.npm
 RUN npm install modclean@2.1.2 -g && \
 	if deno --version | head -1 | grep -qE '^deno 2\.'; then npm install pnpm yarn -g; fi && \
 	npm install --no-save --prefix /usr/local/server @vercel/nft@^0.29.2

--- a/runtimes/node/Dockerfile
+++ b/runtimes/node/Dockerfile
@@ -8,6 +8,13 @@ INCLUDE ./docker/base-before
 
 RUN apk add --no-cache bash nss font-noto ca-certificates gcompat
 
+ARG NPM_VERSION
+RUN npm install npm@${NPM_VERSION} -g && \
+    hash -r && \
+    test "$(npm --version)" = "${NPM_VERSION}" && \
+    test "$(npx --version)" = "${NPM_VERSION}" && \
+    rm -rf /root/.npm
+
 # https://pnpm.io/installation#compatibility (node 16 needs pnpm 8)
 ARG PNPM_VERSION=9.15.9
 RUN npm install pnpm@${PNPM_VERSION} modclean@2.1.2 -g


### PR DESCRIPTION
## Description

Related issue: #XXXX

Pins npm in every npm-based runtime image to the newest release compatible with that image's installed Node.js version. The Dockerfiles now install the configured npm version, assert that both `npm` and `npx` resolve to the exact pin, and remove the npm cache from the layer. `docker-bake.json` is regenerated from `ci/runtimes.toml`.

## Runtime updates

| Runtime | Version | Bundled npm | Pinned npm |
|---|---:|---:|---:|
| Node | 26 | 11.17.0 | 12.0.2 |
| Node | 25 | 11.12.1 | 11.19.0 |
| Node | 24 | 11.16.0 | 12.0.2 |
| Node | 23 | 10.9.2 | 11.19.0 |
| Node | 22 | 10.9.8 | 12.0.2 |
| Node | 21.0 | 10.5.0 | 10.9.9 |
| Node | 20.0 | 10.8.2 | 11.19.0 |
| Node | 19.0 | 9.6.3 | 9.9.4 |
| Node | 18.0 | 10.8.2 | 10.9.9 |
| Node | 16.0 | 8.19.4 | 9.9.4 |
| Deno | 2.6 | 11.11.0 | 12.0.2 |
| Deno | 2.5 | 11.11.0 | 12.0.2 |
| Deno | 2.0 | 10.9.1 | 10.9.9 |
| Deno | 1.46 | 10.9.1 | 10.9.9 |
| Deno | 1.40 | 9.6.6 | 10.9.9 |
| Deno | 1.35 | 9.1.2 | 9.9.4 |
| Deno | 1.24 | 6.14.17 | 7.24.2 |
| Deno | 1.21 | 6.14.17 | 7.24.2 |
| Bun | 1.3 | 11.6.4 | 12.0.2 |
| Bun | 1.2 | 10.9.1 | 10.9.9 |
| Bun | 1.1 | 10.9.1 | 10.9.9 |
| Bun | 1.0 | 9.6.6 | 10.9.9 |

The selected pins follow each npm release's declared Node.js engine range, so older runtime images receive the latest compatible npm rather than an incompatible current release.

## Testing performed

| Check | Result | Details |
|---|---|---|
| npm registry and engine compatibility audit | Passed | Audited all 22 Node, Deno, and Bun runtime targets and selected the latest npm release supported by each installed Node.js version. |
| Bake generation validation | Passed | `bun ci/bake.ts --check` reports `docker-bake.json is up to date`. |
| Docker image builds | Passed | Built all 22 targets successfully: 10 Node, 8 Deno, and 4 Bun images. Current targets used the local ARM64 platform; legacy Deno targets used their declared AMD64 platform. |
| Exact binary version checks | Passed | Every built image reported the configured version for both `npm --version` and `npx --version`; the same assertions also run during each image build. |
| Node 22 runtime integration suite | 39/40 passed | `TEST_PLATFORM=linux/arm64 bun ci/test.ts node-22 --skip-image --skip-formatter`. The only failure was `testHeadlessBrowser`: OrbStack could not run the fixture's x86 Chromium binary on the ARM64 host because `/lib64/ld-linux-x86-64.so.2` was unavailable. All npm-backed fixture installs/builds passed. |
| Patch whitespace validation | Passed | `git diff --check`. |

## Type of change

- [x] Runtime dependency maintenance
- [ ] Breaking change

## Pre-flight checklist

- [x] I reviewed the generated bake configuration.
- [x] I built every affected runtime target.
- [x] I documented the local architecture limitation observed in the integration suite.
