### PR TITLE
fix: take outstanding runtime security releases (node, php, python, go)

### DIFF
--- a/ci/runtimes.toml
+++ b/ci/runtimes.toml
@@ -345,9 +345,9 @@ output = "./.next"
 [python.build.versions]
 "3.14" = { base = "python:3.14.6-alpine3.23" }
 "3.13" = { base = "python:3.13.14-alpine3.23" }
-"3.12" = { base = "python:3.12.12-alpine3.23" }
-"3.11" = { base = "python:3.11.14-alpine3.23" }
-"3.10" = { base = "python:3.10.19-alpine3.23" }
+"3.12" = { base = "python:3.12.13-alpine3.23" }
+"3.11" = { base = "python:3.11.15-alpine3.23" }
+"3.10" = { base = "python:3.10.20-alpine3.23" }
 "3.9" = { base = "python:3.9.25-alpine3.22" }
 "3.8" = { base = "python:3.8.20-alpine3.20" }
 
@@ -357,8 +357,8 @@ image = "python-ml"
 
 [python-ml.build.versions]
 "3.13" = { base = "python:3.13.14-bookworm", version_dir = "ml-3.13", args = { SYSTEM_PACKAGES = "gcc pkg-config libhdf5-dev" } }
-"3.12" = { base = "python:3.12.12-bookworm", version_dir = "ml-3.12", args = { SYSTEM_PACKAGES = "gcc pkg-config libhdf5-dev" } }
-"3.11" = { base = "python:3.11.14-bookworm", version_dir = "ml-3.11", args = { SYSTEM_PACKAGES = "gcc pkg-config libhdf5-dev" } }
+"3.12" = { base = "python:3.12.13-bookworm", version_dir = "ml-3.12", args = { SYSTEM_PACKAGES = "gcc pkg-config libhdf5-dev" } }
+"3.11" = { base = "python:3.11.15-bookworm", version_dir = "ml-3.11", args = { SYSTEM_PACKAGES = "gcc pkg-config libhdf5-dev" } }
 
 [dart.build.versions]
 "3.12" = { base = "dart:3.12.2" }

--- a/ci/runtimes.toml
+++ b/ci/runtimes.toml
@@ -440,7 +440,7 @@ platforms = ["linux/amd64"]
 
 [go.build.versions]
 "1.26" = { base = "golang:1.26.5-alpine3.23" }
-"1.25" = { base = "golang:1.25.10-alpine3.23" }
+"1.25" = { base = "golang:1.25.12-alpine3.23" }
 "1.24" = { base = "golang:1.24.13-alpine3.23" }
 "1.23" = { base = "golang:1.23.12-alpine3.22" }
 

--- a/ci/runtimes.toml
+++ b/ci/runtimes.toml
@@ -321,11 +321,11 @@ output = "./.next"
 # ─────────────────────────────────────────────────────────────────────────────
 
 [node.build.versions]
-"26" = { base = "node:26.5.0-alpine3.24", args = { INSTALL_SSR_TOOLING = "true", YARN_VERSION = "1.22.22" } }
+"26" = { base = "node:26.5.1-alpine3.24", args = { INSTALL_SSR_TOOLING = "true", YARN_VERSION = "1.22.22" } }
 "25" = { base = "node:25.9.0-alpine3.23", args = { INSTALL_SSR_TOOLING = "true" } }
-"24" = { base = "node:24.18.0-alpine3.23", args = { INSTALL_SSR_TOOLING = "true" } }
+"24" = { base = "node:24.19.0-alpine3.23", args = { INSTALL_SSR_TOOLING = "true" } }
 "23" = { base = "node:23.11.1-alpine3.22", args = { INSTALL_SSR_TOOLING = "true" } }
-"22" = { base = "node:22.23.1-alpine3.23", args = { INSTALL_SSR_TOOLING = "true" } }
+"22" = { base = "node:22.23.2-alpine3.23", args = { INSTALL_SSR_TOOLING = "true" } }
 "21.0" = { base = "node:21.7.3-alpine3.20" }
 "20.0" = { base = "node:20.20.2-alpine3.23" }
 "19.0" = { base = "node:19.9.0-alpine3.18" }

--- a/ci/runtimes.toml
+++ b/ci/runtimes.toml
@@ -394,9 +394,9 @@ image = "python-ml"
 "3.0" = { base = "ruby:3.0.7-alpine3.16" }
 
 [php.build.versions]
-"8.4" = { base = "php:8.4.22-cli-alpine3.23", args = { PHP_SWOOLE_VERSION = "v6.1.1", BUILD_PACKAGES = "linux-headers" } }
-"8.3" = { base = "php:8.3.31-cli-alpine3.23", args = { PHP_SWOOLE_VERSION = "v5.1.2", BUILD_PACKAGES = "linux-headers" } }
-"8.2" = { base = "php:8.2.31-cli-alpine3.23", args = { PHP_SWOOLE_VERSION = "v5.1.2", BUILD_PACKAGES = "linux-headers" } }
+"8.4" = { base = "php:8.4.24-cli-alpine3.23", args = { PHP_SWOOLE_VERSION = "v6.1.1", BUILD_PACKAGES = "linux-headers" } }
+"8.3" = { base = "php:8.3.33-cli-alpine3.23", args = { PHP_SWOOLE_VERSION = "v5.1.2", BUILD_PACKAGES = "linux-headers" } }
+"8.2" = { base = "php:8.2.33-cli-alpine3.23", args = { PHP_SWOOLE_VERSION = "v5.1.2", BUILD_PACKAGES = "linux-headers" } }
 "8.1" = { base = "php:8.1.34-cli-alpine3.22", args = { PHP_SWOOLE_VERSION = "v5.1.2" } }
 "8.0" = { base = "php:8.0.30-cli-alpine3.16", args = { PHP_SWOOLE_VERSION = "v4.7.0" } }
 

--- a/docker-bake.json
+++ b/docker-bake.json
@@ -2204,7 +2204,7 @@
         "version": "./docker/empty"
       },
       "args": {
-        "BASE_IMAGE": "golang:1.25.10-alpine3.23"
+        "BASE_IMAGE": "golang:1.25.12-alpine3.23"
       },
       "platforms": [
         "linux/amd64",

--- a/docker-bake.json
+++ b/docker-bake.json
@@ -668,7 +668,7 @@
         "version": "./docker/empty"
       },
       "args": {
-        "BASE_IMAGE": "python:3.12.12-alpine3.23"
+        "BASE_IMAGE": "python:3.12.13-alpine3.23"
       },
       "platforms": [
         "linux/amd64",
@@ -691,7 +691,7 @@
         "version": "./docker/empty"
       },
       "args": {
-        "BASE_IMAGE": "python:3.11.14-alpine3.23"
+        "BASE_IMAGE": "python:3.11.15-alpine3.23"
       },
       "platforms": [
         "linux/amd64",
@@ -714,7 +714,7 @@
         "version": "./docker/empty"
       },
       "args": {
-        "BASE_IMAGE": "python:3.10.19-alpine3.23"
+        "BASE_IMAGE": "python:3.10.20-alpine3.23"
       },
       "platforms": [
         "linux/amd64",
@@ -807,7 +807,7 @@
         "version": "./runtimes/python/versions/ml-3.12"
       },
       "args": {
-        "BASE_IMAGE": "python:3.12.12-bookworm",
+        "BASE_IMAGE": "python:3.12.13-bookworm",
         "SYSTEM_PACKAGES": "gcc pkg-config libhdf5-dev"
       },
       "platforms": [
@@ -831,7 +831,7 @@
         "version": "./runtimes/python/versions/ml-3.11"
       },
       "args": {
-        "BASE_IMAGE": "python:3.11.14-bookworm",
+        "BASE_IMAGE": "python:3.11.15-bookworm",
         "SYSTEM_PACKAGES": "gcc pkg-config libhdf5-dev"
       },
       "platforms": [

--- a/docker-bake.json
+++ b/docker-bake.json
@@ -1514,7 +1514,7 @@
         "version": "./docker/empty"
       },
       "args": {
-        "BASE_IMAGE": "php:8.4.22-cli-alpine3.23",
+        "BASE_IMAGE": "php:8.4.24-cli-alpine3.23",
         "PHP_SWOOLE_VERSION": "v6.1.1",
         "BUILD_PACKAGES": "linux-headers"
       },
@@ -1539,7 +1539,7 @@
         "version": "./docker/empty"
       },
       "args": {
-        "BASE_IMAGE": "php:8.3.31-cli-alpine3.23",
+        "BASE_IMAGE": "php:8.3.33-cli-alpine3.23",
         "PHP_SWOOLE_VERSION": "v5.1.2",
         "BUILD_PACKAGES": "linux-headers"
       },
@@ -1564,7 +1564,7 @@
         "version": "./docker/empty"
       },
       "args": {
-        "BASE_IMAGE": "php:8.2.31-cli-alpine3.23",
+        "BASE_IMAGE": "php:8.2.33-cli-alpine3.23",
         "PHP_SWOOLE_VERSION": "v5.1.2",
         "BUILD_PACKAGES": "linux-headers"
       },

--- a/docker-bake.json
+++ b/docker-bake.json
@@ -199,7 +199,7 @@
         "version": "./docker/empty"
       },
       "args": {
-        "BASE_IMAGE": "node:22.23.1-alpine3.23",
+        "BASE_IMAGE": "node:22.23.2-alpine3.23",
         "INSTALL_SSR_TOOLING": "true"
       },
       "platforms": [
@@ -247,7 +247,7 @@
         "version": "./docker/empty"
       },
       "args": {
-        "BASE_IMAGE": "node:24.18.0-alpine3.23",
+        "BASE_IMAGE": "node:24.19.0-alpine3.23",
         "INSTALL_SSR_TOOLING": "true"
       },
       "platforms": [
@@ -295,7 +295,7 @@
         "version": "./docker/empty"
       },
       "args": {
-        "BASE_IMAGE": "node:26.5.0-alpine3.24",
+        "BASE_IMAGE": "node:26.5.1-alpine3.24",
         "INSTALL_SSR_TOOLING": "true",
         "YARN_VERSION": "1.22.22"
       },


### PR DESCRIPTION
Twelve base images were pinned below their line's current security release. This bumps each to the latest patch upstream publishes for that same line. No new version lines, no Alpine minor changes, no tooling changes — patch bumps only.

## Node — [July 29 2026 security releases](https://nodejs.org/en/blog/vulnerability/july-2026-security-releases)

| Line | From | To |
| --- | --- | --- |
| 26 | `26.5.0-alpine3.24` | `26.5.1-alpine3.24` |
| 24 | `24.18.0-alpine3.23` | `24.19.0-alpine3.23` |
| 22 | `22.23.1-alpine3.23` | `22.23.2-alpine3.23` |

11 CVEs, three of them HIGH:

- `CVE-2026-56846` — HTTP/2 retained headers can bypass `maxSessionMemory` limits
- `CVE-2026-56848` — HTTP/2 re-entrant send can cause heap-use-after-free
- `CVE-2026-58043` — Permission Model path matching can over-grant filesystem access

24 goes to 24.19.0 rather than the 24.18.1 security release itself, since 24.19.0 shipped Aug 3 and supersedes it. 26 stays on 26.5.1 — 26.6.0 is out upstream but has no Docker image published yet.

## PHP — July 30 2026 releases

| Line | From | To |
| --- | --- | --- |
| 8.4 | `8.4.22-cli-alpine3.23` | `8.4.24-cli-alpine3.23` |
| 8.3 | `8.3.31-cli-alpine3.23` | `8.3.33-cli-alpine3.23` |
| 8.2 | `8.2.31-cli-alpine3.23` | `8.2.33-cli-alpine3.23` |

All three were **two** releases behind, missing both the Jul 2 and Jul 30 rounds. Jul 30 fixes `CVE-2026-17544` (BCMath OOB write in `bccomp()`), `CVE-2026-17543` (PGSQL SQL injection via `E'...'` backslash breakout), `CVE-2026-7260` (Phar crash via recursive symlinks), `CVE-2026-9672` (GD libgd upgrade).

8.1 stays on 8.1.34 — that branch is past security EOL and has shipped nothing since Dec 2025.

## Python — March 3 2026 releases

| Line | From | To |
| --- | --- | --- |
| 3.12 | `3.12.12-alpine3.23` | `3.12.13-alpine3.23` |
| 3.11 | `3.11.14-alpine3.23` | `3.11.15-alpine3.23` |
| 3.10 | `3.10.19-alpine3.23` | `3.10.20-alpine3.23` |
| ml-3.12 | `3.12.12-bookworm` | `3.12.13-bookworm` |
| ml-3.11 | `3.11.14-bookworm` | `3.11.15-bookworm` |

3.12, 3.11 and 3.10 are all in the security-fixes-only stage, so every release on those branches is a security release. Covers `CVE-2024-6923` (email header injection via unsafe folding), `CVE-2026-24515` / `CVE-2026-25210` (libexpat 2.7.4), `CVE-2025-59375` (XML memory amplification), plus control-character rejection in HTTP cookies / WSGI headers / URL parsing and an SSL use-after-free.

3.14 and 3.13 were already current. python-ml tracks the same CPython patches on `-bookworm`.

## Go

| Line | From | To |
| --- | --- | --- |
| 1.25 | `1.25.10-alpine3.23` | `1.25.12-alpine3.23` |

Missing two security releases: `go1.25.11` (`crypto/x509`, `mime`, `net/textproto`) and `go1.25.12` (`crypto/tls`, `os`). 1.26, 1.24 and 1.23 are already at their line maxima.

## Verification

- All 12 tags confirmed present on the registry with both `linux/amd64` and `linux/arm64`.
- `bun ci/bake.ts --check` passes; `docker-bake.json` regenerated in the same commits.
- Built `go-1_25`, `python-3_12`, `python-ml-3_12`, `node-26`, `node-22` and `php-8_4` on `linux/arm64` — all succeed. `php-8_4` compiles Swoole v6.1.1 from source against the new 8.4.24 base, so the bump doesn't break the extension build.

## Notes

- Alpine minors are deliberately untouched. node 26 stays on `alpine3.24` rather than realigning to the repo's 3.23 standard — that's a fleet-consistency decision, not a CVE fix.
- Swoole, pnpm and other tooling pins are untouched here; several are stale but belong in separate changes.
- **Conflicts with #532**, which rewrites every `[node.build.versions]` line to add `NPM_VERSION`. Whichever lands second needs a trivial rebase.
