### PR TITLE
fix(node,bun): flush execution logs before responding

### DIFF
--- a/runtimes/bun/versions/latest/src/logger.ts
+++ b/runtimes/bun/versions/latest/src/logger.ts
@@ -93,10 +93,12 @@ export class Logger {
 
     await Promise.all([
       new Promise((res) => {
-        this.streamLogs?.end(undefined, undefined, res);
+        this.streamLogs?.on("close", res);
+        this.streamLogs?.end();
       }),
       new Promise((res) => {
-        this.streamErrors?.end(undefined, undefined, res);
+        this.streamErrors?.on("close", res);
+        this.streamErrors?.end();
       }),
     ]);
   }

--- a/runtimes/node/versions/latest/src/logger.js
+++ b/runtimes/node/versions/latest/src/logger.js
@@ -94,10 +94,12 @@ class Logger {
 
     await Promise.all([
       new Promise((res) => {
-        this.streamLogs.end(undefined, undefined, res);
+        this.streamLogs.on("close", res);
+        this.streamLogs.end();
       }),
       new Promise((res) => {
-        this.streamErrors.end(undefined, undefined, res);
+        this.streamErrors.on("close", res);
+        this.streamErrors.end();
       }),
     ]);
   }


### PR DESCRIPTION
## What does this PR do?

Fixes execution logs intermittently coming back empty on the node and bun runtimes.

`Logger.end()` resolved on the write stream's `'finish'` event:

```js
new Promise((res) => { this.streamLogs.end(undefined, undefined, res); })
```

`writable.end(chunk, enc, cb)` attaches `cb` to `'finish'`, which fires once the data has been handed to the file descriptor — **not** once the descriptor is closed. `server.js` awaits `logger.end()` and then sends the response, so the reply leaves the runtime with the fd still open.

Execution logs are written to `/mnt/logs`, which is an NFS mount in Appwrite Cloud. An NFS client keeps dirty pages in its page cache and flushes them to the server on close. The executor is a *different* NFS client and reads `{logId}_logs.log` the moment the response arrives — so it finds the file it expects (`createWriteStream` creates it at request start) holding zero bytes, and records the execution as successful with no logs at all.

Awaiting `'close'` instead makes the flush part of `end()`.

## Test Plan

Reproduced against a real NFS logs server, writer and reader pods pinned to different nodes, with the writer replicating this exact sequence (write → `end()` → respond) and the reader replicating the executor's (read on response):

| Flush mode | Runs | Full | Empty | Partial |
|---|---|---|---|---|
| `end()` → `'finish'` (before) | 700 | 670 | **30 (4.3%)** | 0 |
| await `'close'` (after) | 1000 | 1000 | **0** | 0 |
| `fsync` before responding | 400 | 400 | **0** | 0 |

Small logs are all-or-nothing, because nothing reaches the server until close. Larger ones are also truncated: 150 runs at ~305KB gave 10 empty **and 7 partial**, since the page cache writes those out in the background.

Latency cost of the fix, same rig, 300 runs, round trip as seen by the caller: p50 7.5ms → 10.5ms, p99 15.8ms → 22.3ms. `fsync` also closes the gap but costs more (p50 12.1ms, p99 32.7ms) and is unnecessary — close already forces the flush.

This matches production: on one Appwrite Cloud shard, a customer function on `openruntimes/node:v5-22` lost logs on ~4% of its executions, and across 8,236 completed executions there was not a single log that ended mid-line — the all-or-nothing signature above.

## Related PRs and Issues

`python`, `php` and `deno` close the descriptor synchronously in `end()` and are unaffected. The javascript SSR logger uses `appendFileSync` per line and is likewise unaffected.

## Have you read the [Contributing Guidelines on issues](https://github.com/open-runtimes/open-runtimes/blob/main/CONTRIBUTING.md)?

Yes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
