### PR TITLE
fix: make clean leaves the profiled test containers running

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,5 +24,5 @@ bake:
 	bun ci/bake.ts
 
 clean:
-	docker compose -f tests/compose.yaml --profile "*" down --remove-orphans || true
+	docker compose -f tests/compose.yaml --profile "*" down --remove-orphans 2>/dev/null || true
 	rm -rf tests/.runtime /tmp/logs

--- a/Makefile
+++ b/Makefile
@@ -24,5 +24,5 @@ bake:
 	bun ci/bake.ts
 
 clean:
-	docker compose -f tests/compose.yaml down --remove-orphans 2>/dev/null || true
+	docker compose -f tests/compose.yaml --profile "*" down --remove-orphans || true
 	rm -rf tests/.runtime /tmp/logs


### PR DESCRIPTION
`make clean` could only ever reach 3 of the 11 services in `tests/compose.yaml`. The other 8 sit behind a profile, and compose skips profiled services on `down` unless the profile is active — `--remove-orphans` doesn't cover them either, since compose knows about them.

Found a `serve-no-export` container still running 23 hours after an interrupted test run. `make clean` reported nothing and exited 0.

```
$ docker compose -f tests/compose.yaml config --services
serve serve-secondary serve-teritary

$ docker compose -f tests/compose.yaml --profile "*" config --services
build build-baseline build-nft build-no-export formatter phpunit serve
serve-no-export serve-secondary serve-teritary tools
```

Adding `--profile "*"` removed the container that `down --remove-orphans` had left.

`ci/test.ts` is unaffected — it passes `COMPOSE_PROFILES` and sweeps leftover containers, so its cleanup already worked. Only the manual fallback was broken.

The `2>/dev/null` stays for now. It is why this went unnoticed, since the command exits 0 whether or not it removed anything, but dropping it prints 24 `variable is not set` warnings from the env vars only `ci/test.ts` sets. Giving those defaults in `tests/compose.yaml` would let the redirect come off — happy to do that here or separately.