### PR TITLE
Fix aiohttp warning on Python 3.14

### DIFF
--- a/runtimes/python/versions/latest/requirements.txt
+++ b/runtimes/python/versions/latest/requirements.txt
@@ -1,2 +1,3 @@
-aiohttp==3.10.9
+aiohttp==3.10.9; python_version < "3.9"
+aiohttp==3.13.3; python_version >= "3.9"
 gunicorn==23.0.0


### PR DESCRIPTION
## What does this PR do?

Fixes the Python 3.14 runtime warning caused by `aiohttp==3.10.9` using `break` inside a `finally` block.

```text
Python 3.8:  aiohttp 3.10.9 (retained for compatibility)
Python 3.9+: aiohttp 3.13.3 (includes the upstream fix and Python 3.14 support)
```

Environment markers preserve Python 3.8 support while giving newer runtimes a supported aiohttp release.

## Test plan

- `make test ID=python-3.14` — 39 tests, 349 assertions passed
- Imported `aiohttp.web_protocol` with `SyntaxWarning` promoted to an error
- Confirmed Python 3.8 still resolves `aiohttp==3.10.9`
- Confirmed runtime logs contain no `break in finally` warning
