### PR TITLE
fix: resolve the build output directory from the build itself

### DIFF
--- a/ci/runtimes.toml
+++ b/ci/runtimes.toml
@@ -263,17 +263,19 @@ tools = "node --version && npm --version && npx --version && pnpm --version && y
 test = "SSR/TanstackStart.php"
 output = "./dist"
 
-# tanstack_start_native builds dist, so pointing it at the nitro layout pins that
-# the build resolves the directory from its own output rather than failing.
-[tanstack_start_output_fallback]
+# A site created before its layout was known configures no output directory. The
+# nitro project is the one that pins both halves: the build resolves .output on
+# its own, and it emits dist too, so it only gets there if .output is looked for
+# beside dist rather than inside it.
+[tanstack_start_output_detected]
 report_size = false
 runtime = { name = "node", version = "24" }
-test_resource_dir = "tanstack_start_native"
+test_resource_dir = "tanstack_start_nitro_v2"
 commands = { install = "source /usr/local/server/helpers/tanstack-start/env.sh && npm install && npm run build && bash /usr/local/server/helpers/tanstack-start/bundle.sh", start = "bash helpers/tanstack-start/server.sh" }
 formatter = { prepare = "npm i -g @biomejs/biome", check = "biome format .", write = "biome format --write ." }
 tools = "node --version && npm --version && npx --version && pnpm --version && yarn --version && bun --version && python --version && pip --version && make --version && git --version && g++ --version && gcc --version && modclean --version"
 test = "SSR/TanstackStart.php"
-output = "./.output"
+output = ""
 
 [remix]
 report_size = false

--- a/ci/runtimes.toml
+++ b/ci/runtimes.toml
@@ -271,7 +271,7 @@ test_resource_dir = "tanstack_start_nitro_v2"
 commands = { install = "source /usr/local/server/helpers/tanstack-start/env.sh && npm install && npm run build && bash /usr/local/server/helpers/tanstack-start/bundle.sh", start = "bash helpers/tanstack-start/server.sh" }
 formatter = { prepare = "npm i -g @biomejs/biome", check = "biome format .", write = "biome format --write ." }
 tools = "node --version && npm --version && npx --version && pnpm --version && yarn --version && bun --version && python --version && pip --version && make --version && git --version && g++ --version && gcc --version && modclean --version"
-test = "SSR/TanstackStart.php"
+test = "SSR/TanstackStartNitro.php"
 output = ""
 
 [remix]

--- a/ci/runtimes.toml
+++ b/ci/runtimes.toml
@@ -263,6 +263,19 @@ tools = "node --version && npm --version && npx --version && pnpm --version && y
 test = "SSR/TanstackStart.php"
 output = "./dist"
 
+# Same project as tanstack_start_native, which builds dist, pointed at the nitro
+# layout it never writes. Pins that the build resolves the directory from its own
+# output instead of failing on the configured one.
+[tanstack_start_wrong_output]
+report_size = false
+runtime = { name = "node", version = "24" }
+test_resource_dir = "tanstack_start_native"
+commands = { install = "source /usr/local/server/helpers/tanstack-start/env.sh && npm install && npm run build && bash /usr/local/server/helpers/tanstack-start/bundle.sh", start = "bash helpers/tanstack-start/server.sh" }
+formatter = { prepare = "npm i -g @biomejs/biome", check = "biome format .", write = "biome format --write ." }
+tools = "node --version && npm --version && npx --version && pnpm --version && yarn --version && bun --version && python --version && pip --version && make --version && git --version && g++ --version && gcc --version && modclean --version"
+test = "SSR/TanstackStart.php"
+output = "./.output"
+
 [remix]
 report_size = false
 runtime = { name = "node", version = "24" }

--- a/ci/runtimes.toml
+++ b/ci/runtimes.toml
@@ -263,10 +263,9 @@ tools = "node --version && npm --version && npx --version && pnpm --version && y
 test = "SSR/TanstackStart.php"
 output = "./dist"
 
-# Same project as tanstack_start_native, which builds dist, pointed at the nitro
-# layout it never writes. Pins that the build resolves the directory from its own
-# output instead of failing on the configured one.
-[tanstack_start_wrong_output]
+# tanstack_start_native builds dist, so pointing it at the nitro layout pins that
+# the build resolves the directory from its own output rather than failing.
+[tanstack_start_output_fallback]
 report_size = false
 runtime = { name = "node", version = "24" }
 test_resource_dir = "tanstack_start_native"

--- a/ci/runtimes.toml
+++ b/ci/runtimes.toml
@@ -263,10 +263,7 @@ tools = "node --version && npm --version && npx --version && pnpm --version && y
 test = "SSR/TanstackStart.php"
 output = "./dist"
 
-# A site created before its layout was known configures no output directory. The
-# nitro project is the one that pins both halves: the build resolves .output on
-# its own, and it emits dist too, so it only gets there if .output is looked for
-# beside dist rather than inside it.
+# No output directory configured, so the build resolves it from what it wrote
 [tanstack_start_output_detected]
 report_size = false
 runtime = { name = "node", version = "24" }

--- a/helpers/lifecycle/build.sh
+++ b/helpers/lifecycle/build.sh
@@ -45,6 +45,17 @@ bash -c "$1"
 
 opr_log "Build command execution finished."
 
+# A framework's bundle step is appended to the build command, so it runs in the
+# subshell above and a directory it resolves cannot reach the pack and archive
+# phases through the environment. It leaves the resolved one here instead.
+if [ -s /tmp/.opr-output-directory ]; then
+	OPEN_RUNTIMES_OUTPUT_DIRECTORY="$(cat /tmp/.opr-output-directory)"
+	export OPEN_RUNTIMES_OUTPUT_DIRECTORY
+	rm -f /tmp/.opr-output-directory
+
+	opr_log "Build output resolved to $OPEN_RUNTIMES_OUTPUT_DIRECTORY."
+fi
+
 # --- Compile ---
 
 cd /usr/local/server

--- a/helpers/lifecycle/build.sh
+++ b/helpers/lifecycle/build.sh
@@ -41,11 +41,9 @@ cd /usr/local/build
 
 opr_log "Build command execution started."
 
-# A framework's bundle step is appended to the build command, so it runs in the
-# subshell below and a directory it resolves cannot reach the pack and archive
-# phases through the environment. It leaves the resolved one in this file
-# instead. Clear it first: the path is fixed, so only a file the build itself
-# wrote may redirect the archive.
+# A bundle step appended to the build command runs in the subshell below and
+# cannot export to the phases after it, so it leaves a resolved output directory
+# here. Clear it first: only what this build wrote may redirect the archive.
 rm -f /tmp/.opr-output-directory
 
 bash -c "$1"

--- a/helpers/lifecycle/build.sh
+++ b/helpers/lifecycle/build.sh
@@ -41,13 +41,17 @@ cd /usr/local/build
 
 opr_log "Build command execution started."
 
+# A framework's bundle step is appended to the build command, so it runs in the
+# subshell below and a directory it resolves cannot reach the pack and archive
+# phases through the environment. It leaves the resolved one in this file
+# instead. Clear it first: the path is fixed, so only a file the build itself
+# wrote may redirect the archive.
+rm -f /tmp/.opr-output-directory
+
 bash -c "$1"
 
 opr_log "Build command execution finished."
 
-# A framework's bundle step is appended to the build command, so it runs in the
-# subshell above and a directory it resolves cannot reach the pack and archive
-# phases through the environment. It leaves the resolved one here instead.
 if [ -s /tmp/.opr-output-directory ]; then
 	OPEN_RUNTIMES_OUTPUT_DIRECTORY="$(cat /tmp/.opr-output-directory)"
 	export OPEN_RUNTIMES_OUTPUT_DIRECTORY

--- a/runtimes/javascript/helpers/tanstack-start/bundle.sh
+++ b/runtimes/javascript/helpers/tanstack-start/bundle.sh
@@ -9,9 +9,7 @@ RESOLVED=0
 cd /usr/local/build
 
 # TanStack Start writes .output with a nitro plugin registered and dist without
-# one, and the directory is configured before the build runs. When the build
-# went to the other layout, take the same directory there instead of failing on
-# one that was never written.
+# one, and the directory is configured before the build runs.
 if [ -n "$OPEN_RUNTIMES_OUTPUT_DIRECTORY" ] && [ -z "$(ls -A "$OPEN_RUNTIMES_OUTPUT_DIRECTORY" 2>/dev/null)" ]; then
 	CONFIGURED="${OPEN_RUNTIMES_OUTPUT_DIRECTORY#./}"
 	CONFIGURED="${CONFIGURED%/}"

--- a/runtimes/javascript/helpers/tanstack-start/bundle.sh
+++ b/runtimes/javascript/helpers/tanstack-start/bundle.sh
@@ -7,12 +7,9 @@ IS_SSR=0
 
 cd /usr/local/build
 
-# TanStack Start writes .output with a nitro plugin registered and dist without
-# one, and the directory is configured before the build runs. A site created
-# before its layout was known carries no value at all, and an empty one is not a
-# choice to override: resolve it below from what the build wrote, the way the
-# rendering strategy is left for the first build to decide. A directory the user
-# did set is obeyed even when the build wrote elsewhere.
+# TanStack Start writes .output with a nitro plugin registered, dist without one,
+# and the directory is configured before the build runs. Nothing configured means
+# nothing to override, so let the build decide.
 DETECT=0
 if [ -z "$OPEN_RUNTIMES_OUTPUT_DIRECTORY" ]; then
 	DETECT=1
@@ -33,10 +30,7 @@ if [ -e "$ENTRYPOINT" ]; then
 	IS_SSR=1 # Native SSR (middleware)
 fi
 
-# If SSR not detected yet, try default folders. What this finds is handed back
-# only when nothing was configured; against a directory the user set it stays
-# local to the bundling below, since a static site's directory is not wrong just
-# because the server tree sits next to it.
+# If SSR not detected yet, try default folders
 if [ "$IS_SSR" -eq 0 ]; then
 	cd /usr/local/build
 	if [ -d "dist" ]; then
@@ -63,8 +57,7 @@ fi
 # Change back to output directory before bundling
 cd /usr/local/build
 
-# No server anywhere means the build was prerendered, and its assets sit one
-# level into whichever layout it chose.
+# A prerendered build has no server; its assets sit one level in
 if [ "$DETECT" -eq 1 ] && [ -z "$OPEN_RUNTIMES_OUTPUT_DIRECTORY" ]; then
 	for CANDIDATE in ./.output/public ./dist/client; do
 		if [ -d "$CANDIDATE" ]; then
@@ -74,9 +67,7 @@ if [ "$DETECT" -eq 1 ] && [ -z "$OPEN_RUNTIMES_OUTPUT_DIRECTORY" ]; then
 	done
 fi
 
-# This script is appended to the build command, so it runs in that subshell and
-# a directory resolved here cannot reach the pack and archive phases through the
-# environment. Leave it in the file the lifecycle reads instead.
+# Hand it back to the lifecycle, which cannot see a variable set in this subshell
 if [ "$DETECT" -eq 1 ] && [ -n "$OPEN_RUNTIMES_OUTPUT_DIRECTORY" ]; then
 	echo -e "\e[90m$(date +[%H:%M:%S]) \e[31m[\e[0mopen-runtimes\e[31m]\e[97m Build output resolved to $OPEN_RUNTIMES_OUTPUT_DIRECTORY. \e[0m"
 	echo -n "$OPEN_RUNTIMES_OUTPUT_DIRECTORY" >/tmp/.opr-output-directory

--- a/runtimes/javascript/helpers/tanstack-start/bundle.sh
+++ b/runtimes/javascript/helpers/tanstack-start/bundle.sh
@@ -4,30 +4,18 @@ set -e
 shopt -s dotglob
 
 IS_SSR=0
-RESOLVED=0
 
 cd /usr/local/build
 
 # TanStack Start writes .output with a nitro plugin registered and dist without
-# one, and the directory is configured before the build runs.
-if [ -n "$OPEN_RUNTIMES_OUTPUT_DIRECTORY" ] && [ -z "$(ls -A "$OPEN_RUNTIMES_OUTPUT_DIRECTORY" 2>/dev/null)" ]; then
-	CONFIGURED="${OPEN_RUNTIMES_OUTPUT_DIRECTORY#./}"
-	CONFIGURED="${CONFIGURED%/}"
-
-	case "$CONFIGURED" in
-	.output) COUNTERPART="./dist" ;;
-	dist) COUNTERPART="./.output" ;;
-	.output/public) COUNTERPART="./dist/client" ;;
-	dist/client) COUNTERPART="./.output/public" ;;
-	*) COUNTERPART="" ;;
-	esac
-
-	if [ -n "$COUNTERPART" ] && [ -n "$(ls -A "$COUNTERPART" 2>/dev/null)" ]; then
-		echo -e "\e[90m$(date +[%H:%M:%S]) \e[31m[\e[0mopen-runtimes\e[31m]\e[33m Build wrote $COUNTERPART, not the configured $OPEN_RUNTIMES_OUTPUT_DIRECTORY. Using $COUNTERPART. \e[0m"
-		OPEN_RUNTIMES_OUTPUT_DIRECTORY="$COUNTERPART"
-		echo -n "$COUNTERPART" >/tmp/.opr-output-directory
-		RESOLVED=1
-	fi
+# one, and the directory is configured before the build runs. A site created
+# before its layout was known carries no value at all, and an empty one is not a
+# choice to override: resolve it below from what the build wrote, the way the
+# rendering strategy is left for the first build to decide. A directory the user
+# did set is obeyed even when the build wrote elsewhere.
+DETECT=0
+if [ -z "$OPEN_RUNTIMES_OUTPUT_DIRECTORY" ]; then
+	DETECT=1
 fi
 
 if [ -n "$OPEN_RUNTIMES_OUTPUT_DIRECTORY" ]; then
@@ -45,10 +33,11 @@ if [ -e "$ENTRYPOINT" ]; then
 	IS_SSR=1 # Native SSR (middleware)
 fi
 
-# If SSR not detected yet, try default folders. This one stays local to the
-# bundling below: a static build has no server entry either, and its configured
-# directory is not wrong just because the server tree sits next to it.
-if [ "$IS_SSR" -eq 0 ] && [ "$RESOLVED" -eq 0 ]; then
+# If SSR not detected yet, try default folders. What this finds is handed back
+# only when nothing was configured; against a directory the user set it stays
+# local to the bundling below, since a static site's directory is not wrong just
+# because the server tree sits next to it.
+if [ "$IS_SSR" -eq 0 ]; then
 	cd /usr/local/build
 	if [ -d "dist" ]; then
 		cd ./dist
@@ -73,6 +62,26 @@ fi
 
 # Change back to output directory before bundling
 cd /usr/local/build
+
+# No server anywhere means the build was prerendered, and its assets sit one
+# level into whichever layout it chose.
+if [ "$DETECT" -eq 1 ] && [ -z "$OPEN_RUNTIMES_OUTPUT_DIRECTORY" ]; then
+	for CANDIDATE in ./.output/public ./dist/client; do
+		if [ -d "$CANDIDATE" ]; then
+			OPEN_RUNTIMES_OUTPUT_DIRECTORY="$CANDIDATE"
+			break
+		fi
+	done
+fi
+
+# This script is appended to the build command, so it runs in that subshell and
+# a directory resolved here cannot reach the pack and archive phases through the
+# environment. Leave it in the file the lifecycle reads instead.
+if [ "$DETECT" -eq 1 ] && [ -n "$OPEN_RUNTIMES_OUTPUT_DIRECTORY" ]; then
+	echo -e "\e[90m$(date +[%H:%M:%S]) \e[31m[\e[0mopen-runtimes\e[31m]\e[97m Build output resolved to $OPEN_RUNTIMES_OUTPUT_DIRECTORY. \e[0m"
+	echo -n "$OPEN_RUNTIMES_OUTPUT_DIRECTORY" >/tmp/.opr-output-directory
+fi
+
 if [ -n "$OPEN_RUNTIMES_OUTPUT_DIRECTORY" ]; then
 	cd "$OPEN_RUNTIMES_OUTPUT_DIRECTORY"
 fi

--- a/runtimes/javascript/helpers/tanstack-start/bundle.sh
+++ b/runtimes/javascript/helpers/tanstack-start/bundle.sh
@@ -4,6 +4,33 @@ set -e
 shopt -s dotglob
 
 IS_SSR=0
+RESOLVED=0
+
+cd /usr/local/build
+
+# TanStack Start writes .output with a nitro plugin registered and dist without
+# one, and the directory is configured before the build runs. When the build
+# went to the other layout, take the same directory there instead of failing on
+# one that was never written.
+if [ -n "$OPEN_RUNTIMES_OUTPUT_DIRECTORY" ] && [ -z "$(ls -A "$OPEN_RUNTIMES_OUTPUT_DIRECTORY" 2>/dev/null)" ]; then
+	CONFIGURED="${OPEN_RUNTIMES_OUTPUT_DIRECTORY#./}"
+	CONFIGURED="${CONFIGURED%/}"
+
+	case "$CONFIGURED" in
+	.output) COUNTERPART="./dist" ;;
+	dist) COUNTERPART="./.output" ;;
+	.output/public) COUNTERPART="./dist/client" ;;
+	dist/client) COUNTERPART="./.output/public" ;;
+	*) COUNTERPART="" ;;
+	esac
+
+	if [ -n "$COUNTERPART" ] && [ -n "$(ls -A "$COUNTERPART" 2>/dev/null)" ]; then
+		echo -e "\e[90m$(date +[%H:%M:%S]) \e[31m[\e[0mopen-runtimes\e[31m]\e[33m Build wrote $COUNTERPART, not the configured $OPEN_RUNTIMES_OUTPUT_DIRECTORY. Using $COUNTERPART. \e[0m"
+		OPEN_RUNTIMES_OUTPUT_DIRECTORY="$COUNTERPART"
+		echo -n "$COUNTERPART" >/tmp/.opr-output-directory
+		RESOLVED=1
+	fi
+fi
 
 if [ -n "$OPEN_RUNTIMES_OUTPUT_DIRECTORY" ]; then
 	cd "$OPEN_RUNTIMES_OUTPUT_DIRECTORY"
@@ -20,8 +47,10 @@ if [ -e "$ENTRYPOINT" ]; then
 	IS_SSR=1 # Native SSR (middleware)
 fi
 
-# If SSR not detected yet, try default folders
-if [ "$IS_SSR" -eq 0 ]; then
+# If SSR not detected yet, try default folders. This one stays local to the
+# bundling below: a static build has no server entry either, and its configured
+# directory is not wrong just because the server tree sits next to it.
+if [ "$IS_SSR" -eq 0 ] && [ "$RESOLVED" -eq 0 ]; then
 	cd /usr/local/build
 	if [ -d "dist" ]; then
 		cd ./dist

--- a/runtimes/javascript/helpers/tanstack-start/bundle.sh
+++ b/runtimes/javascript/helpers/tanstack-start/bundle.sh
@@ -32,6 +32,8 @@ if [ "$IS_SSR" -eq 0 ]; then
 		fi
 	fi
 
+	# Back to the build root, so .output is looked for beside dist and not inside it
+	cd /usr/local/build
 	if [ -d ".output" ]; then
 		cd ./.output
 		ENTRYPOINT="./server/index.mjs"
@@ -45,7 +47,7 @@ fi
 # Change back to output directory before bundling
 cd /usr/local/build
 if [ -n "$OPEN_RUNTIMES_OUTPUT_DIRECTORY" ]; then
-	cd $OPEN_RUNTIMES_OUTPUT_DIRECTORY
+	cd "$OPEN_RUNTIMES_OUTPUT_DIRECTORY"
 fi
 
 if [ "$IS_SSR" -eq 1 ]; then


### PR DESCRIPTION
## Problem

The output directory is configured before the build runs, so it can name a directory the build never writes. TanStack Start is where this bites: it writes `.output` with a nitro plugin registered and `dist` without one, and which of the two a project produces is not knowable from the settings form.

A site configured for the layout it did not build dies on `cd` into a directory that is not there, or reaches `helpers/lifecycle/build.sh` and stops at *"No build output found"*.

`helpers/tanstack-start/bundle.sh` already probes for the real output when it cannot find a server entry under the configured directory, but the result never leaves the script. The bundle step is appended to the build command by the consumer, so it runs inside `bash -c "$1"`, and a plain variable assignment there cannot reach the pack and archive phases. The scan also stops one directory short of `.output` — see below.

## Changes

**1. `helpers/lifecycle/build.sh` reads back a corrected directory.** A helper that works out where the build really went writes it to `/tmp/.opr-output-directory`; the lifecycle picks it up after the build command and exports it, so pack and archive both see it. No helper wrote one before this, so the hook is inert for every runtime that does not opt in.

**2. `helpers/tanstack-start/bundle.sh` takes the other layout when the configured one is empty.** The two layouts are mapped pairwise rather than scanned for:

| configured | taken instead |
|---|---|
| `./.output` | `./dist` |
| `./dist` | `./.output` |
| `./.output/public` | `./dist/client` |
| `./dist/client` | `./.output/public` |

Mapping the pair keeps the distinction the configured value carried, so a static site is corrected to the other layout's **assets** and not to its build root. Only this correction is handed back to the lifecycle.

The existing fallback scan deliberately stays local. It fires for every static build, since a static build has no server entry to find, and a static site's directory is not wrong just because the server tree sits beside it — nitro emits a server even for a fully prerendered build. Handing that one back would redirect a correctly configured static deployment to its build root.

**3. The scan looks for `.output` beside `dist`, not inside it.** It entered `./dist` to look for a server and never returned, so the `.output` check that followed resolved against `/usr/local/build/dist`. A project emitting both trees — which a nitro build does, since vite writes `dist` on the way to `.output` — could never reach the second one.

## Verification

`tanstack_start_output_fallback` builds the existing `tanstack_start_native` project, which writes `dist`, against a configured `./.output` it never writes. It reuses that fixture and the `node-24` bake target, so it bakes no new image; like every other SSR entry it picks up the `cleanup-variants` profile and runs the build, baseline and NFT variants. On `main` this configuration fails the build.

Eleven scenarios were also exercised against fake build trees, covering both layouts in both adapters, each flip, and the cases where a usable configured directory must be left alone:

```
-- configured directory is correct (no correction) --
  ok   nitro ssr                                      -> ./.output
  ok   vite-native ssr                                -> ./dist
  ok   nitro static                                   -> ./.output/public
  ok   vite-native static                             -> ./dist/client

-- layout flipped under the configured directory --
  ok   ssr: .output configured, dist built            -> ./dist
  ok   ssr: dist configured, .output built            -> ./.output
  ok   static: dist/client configured, nitro built    -> ./.output/public
  ok   static: .output/public configured, vite built  -> ./dist/client

-- a usable configured directory is never overridden --
  ok   static assets kept, server tree beside them    -> ./dist/client
  ok   build root kept when both trees present        -> (build root)

-- correction is not re-corrected --
  ok   flip to nitro static, server tree present      -> ./.output/public
```

`shfmt -d .` and `shellcheck -e SC1091 -S warning` clean across the repo.

## Not addressed

A static build with a server tree beside it still logs *"Bundling for SSR"* and moves `node_modules` into the sibling SSR root. This reproduces unchanged on `main`, and it is harmless because the archive takes the configured directory either way, but it is confusing in the logs and worth a separate look.

## Context

The same misconfiguration is being narrowed from the other end in [utopia-php/detector#19](https://github.com/utopia-php/detector/pull/19), which resolves the directory from the project's dependencies and vite config so the value is right before a build exists. That one prefills the setting and can be wrong; this one reads the build itself and cannot. They cover different halves — a value the user typed by hand only this side can fix, and a value shown in the UI only that side can.
