### PR TITLE
feat: configurable logs directory, always passthrough to stdout/stderr

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,8 @@ Runtime-specific behavior lives in an optional `hooks/` directory next to `helpe
 
 Every request sent to any of the runtimes must have the `x-open-runtimes-secret` header. The value of this header has to match the value of environment variable `OPEN_RUNTIMES_SECRET` set on the runtime. All example scripts use `secret-key` as the key and we strongly recommend changing this key before production use.
 
+Execution logs are always written to the runtime's `stdout` (logs) and `stderr` (errors). In addition, each execution's logs are written to `<id>_logs.log` and `<id>_errors.log` in the directory set by `OPEN_RUNTIMES_LOGS_DIRECTORY`, where `<id>` is the value of the `x-open-runtimes-log-id` response header. The directory defaults to `/mnt/logs` and must already exist; set the variable to an empty value to write logs to `stdout`/`stderr` only.
+
 ## Contributing
 
 All code contributions - including those of people having commit access - must go through a pull request and be approved by a core developer before being merged. This is to ensure a proper review of all the code.

--- a/runtimes/bun/versions/latest/src/config.ts
+++ b/runtimes/bun/versions/latest/src/config.ts
@@ -8,4 +8,5 @@ export const config = {
   headers,
   entrypoint: Bun.env["OPEN_RUNTIMES_ENTRYPOINT"] ?? "",
   env: Bun.env["OPEN_RUNTIMES_ENV"] ?? "",
+  logsDirectory: Bun.env["OPEN_RUNTIMES_LOGS_DIRECTORY"] ?? "/mnt/logs",
 };

--- a/runtimes/bun/versions/latest/src/logger.ts
+++ b/runtimes/bun/versions/latest/src/logger.ts
@@ -77,14 +77,20 @@ export class Logger {
       stringLog += "... Log truncated due to size limit (8000 characters)";
     }
 
+    // Each sink is guarded on its own so one failing never drops the other
     try {
-      stream?.write(stringLog + "\n");
       (type === Logger.TYPE_ERROR ? process.stderr : process.stdout).write(
         stringLog + "\n",
       );
     } catch (error) {
       // Silently fail to prevent 500 errors in runtime
       // Log write failures should not crash the runtime
+    }
+
+    try {
+      stream?.write(stringLog + "\n");
+    } catch (error) {
+      // Silently fail to prevent 500 errors in runtime
     }
   }
 

--- a/runtimes/bun/versions/latest/src/logger.ts
+++ b/runtimes/bun/versions/latest/src/logger.ts
@@ -24,15 +24,20 @@ export class Logger {
         : config.env === "development"
           ? "dev"
           : this.generateId();
-      this.streamLogs = fs.createWriteStream(`/mnt/logs/${this.id}_logs.log`, {
-        flags: "a",
-      });
-      this.streamErrors = fs.createWriteStream(
-        `/mnt/logs/${this.id}_errors.log`,
-        {
-          flags: "a",
-        },
-      );
+      if (config.logsDirectory) {
+        this.streamLogs = fs.createWriteStream(
+          `${config.logsDirectory}/${this.id}_logs.log`,
+          {
+            flags: "a",
+          },
+        );
+        this.streamErrors = fs.createWriteStream(
+          `${config.logsDirectory}/${this.id}_errors.log`,
+          {
+            flags: "a",
+          },
+        );
+      }
     }
   }
 
@@ -50,10 +55,6 @@ export class Logger {
 
     const stream =
       type === Logger.TYPE_ERROR ? this.streamErrors : this.streamLogs;
-
-    if (!stream) {
-      return;
-    }
 
     let stringLog = messages
       .map((message) => {
@@ -77,7 +78,10 @@ export class Logger {
     }
 
     try {
-      stream.write(stringLog + "\n");
+      (type === Logger.TYPE_ERROR ? process.stderr : process.stdout).write(
+        stringLog + "\n",
+      );
+      stream?.write(stringLog + "\n");
     } catch (error) {
       // Silently fail to prevent 500 errors in runtime
       // Log write failures should not crash the runtime
@@ -91,16 +95,17 @@ export class Logger {
 
     this.enabled = false;
 
-    await Promise.all([
-      new Promise((res) => {
-        this.streamLogs?.on("close", res);
-        this.streamLogs?.end();
-      }),
-      new Promise((res) => {
-        this.streamErrors?.on("close", res);
-        this.streamErrors?.end();
-      }),
-    ]);
+    await Promise.all(
+      [this.streamLogs, this.streamErrors]
+        .filter((stream) => stream !== null)
+        .map(
+          (stream) =>
+            new Promise((res) => {
+              stream.on("close", res);
+              stream.end();
+            }),
+        ),
+    );
   }
 
   overrideNativeLogs() {

--- a/runtimes/bun/versions/latest/src/logger.ts
+++ b/runtimes/bun/versions/latest/src/logger.ts
@@ -78,10 +78,10 @@ export class Logger {
     }
 
     try {
+      stream?.write(stringLog + "\n");
       (type === Logger.TYPE_ERROR ? process.stderr : process.stdout).write(
         stringLog + "\n",
       );
-      stream?.write(stringLog + "\n");
     } catch (error) {
       // Silently fail to prevent 500 errors in runtime
       // Log write failures should not crash the runtime

--- a/runtimes/cpp/versions/latest/src/OprConfig.h
+++ b/runtimes/cpp/versions/latest/src/OprConfig.h
@@ -10,6 +10,7 @@ struct OprConfig {
   std::string secret;
   Json::Value headers;
   std::string env;
+  std::string logsDirectory = "/mnt/logs";
 };
 
 inline const OprConfig &config() {
@@ -22,6 +23,10 @@ inline const OprConfig &config() {
 
     if (std::getenv("OPEN_RUNTIMES_ENV") != nullptr) {
       config.env = std::getenv("OPEN_RUNTIMES_ENV");
+    }
+
+    if (std::getenv("OPEN_RUNTIMES_LOGS_DIRECTORY") != nullptr) {
+      config.logsDirectory = std::getenv("OPEN_RUNTIMES_LOGS_DIRECTORY");
     }
 
     if (std::getenv("OPEN_RUNTIMES_HEADERS") != nullptr) {

--- a/runtimes/cpp/versions/latest/src/RuntimeLogger.h
+++ b/runtimes/cpp/versions/latest/src/RuntimeLogger.h
@@ -84,17 +84,22 @@ public:
           "... Log truncated due to size limit (8000 characters)";
     }
 
+    // Each sink is guarded on its own so one failing never drops the other
     try {
-      if (stream) {
-        *(stream) << (truncatedMessage + "\n");
-      }
-
       // Bypasses std::cout/std::cerr, which are captured during execution
       std::fputs((truncatedMessage + "\n").c_str(),
                  type == "error" ? stderr : stdout);
     } catch (const std::exception &e) {
       // Silently fail to prevent 500 errors in runtime
       // Log write failures should not crash the runtime
+    }
+
+    try {
+      if (stream) {
+        *(stream) << (truncatedMessage + "\n");
+      }
+    } catch (const std::exception &e) {
+      // Silently fail to prevent 500 errors in runtime
     }
   }
 

--- a/runtimes/cpp/versions/latest/src/RuntimeLogger.h
+++ b/runtimes/cpp/versions/latest/src/RuntimeLogger.h
@@ -85,13 +85,13 @@ public:
     }
 
     try {
-      // Bypasses std::cout/std::cerr, which are captured during execution
-      std::fputs((truncatedMessage + "\n").c_str(),
-                 type == "error" ? stderr : stdout);
-
       if (stream) {
         *(stream) << (truncatedMessage + "\n");
       }
+
+      // Bypasses std::cout/std::cerr, which are captured during execution
+      std::fputs((truncatedMessage + "\n").c_str(),
+                 type == "error" ? stderr : stdout);
     } catch (const std::exception &e) {
       // Silently fail to prevent 500 errors in runtime
       // Log write failures should not crash the runtime

--- a/runtimes/cpp/versions/latest/src/RuntimeLogger.h
+++ b/runtimes/cpp/versions/latest/src/RuntimeLogger.h
@@ -3,6 +3,7 @@
 
 #include "OprConfig.h"
 #include <chrono>
+#include <cstdio>
 #include <cstdlib>
 #include <ctime>
 #include <fstream>
@@ -45,10 +46,14 @@ public:
         id = headerId;
       }
 
-      streamLogs = std::make_shared<std::ofstream>(
-          "/mnt/logs/" + id + "_logs.log", std::ios_base::app);
-      streamErrors = std::make_shared<std::ofstream>(
-          "/mnt/logs/" + id + "_errors.log", std::ios_base::app);
+      const std::string logsDirectory = config().logsDirectory;
+
+      if (!logsDirectory.empty()) {
+        streamLogs = std::make_shared<std::ofstream>(
+            logsDirectory + "/" + id + "_logs.log", std::ios_base::app);
+        streamErrors = std::make_shared<std::ofstream>(
+            logsDirectory + "/" + id + "_errors.log", std::ios_base::app);
+      }
     }
   }
 
@@ -80,7 +85,13 @@ public:
     }
 
     try {
-      *(stream) << (truncatedMessage + "\n");
+      // Bypasses std::cout/std::cerr, which are captured during execution
+      std::fputs((truncatedMessage + "\n").c_str(),
+                 type == "error" ? stderr : stdout);
+
+      if (stream) {
+        *(stream) << (truncatedMessage + "\n");
+      }
     } catch (const std::exception &e) {
       // Silently fail to prevent 500 errors in runtime
       // Log write failures should not crash the runtime
@@ -94,8 +105,10 @@ public:
 
     enabled = false;
 
-    streamLogs->close();
-    streamErrors->close();
+    if (streamLogs) {
+      streamLogs->close();
+      streamErrors->close();
+    }
   }
 
   void overrideNativeLogs() {

--- a/runtimes/dart/versions/latest/src/config.dart
+++ b/runtimes/dart/versions/latest/src/config.dart
@@ -3,6 +3,8 @@ import 'dart:io';
 
 final String secret = Platform.environment['OPEN_RUNTIMES_SECRET'] ?? '';
 final String env = Platform.environment['OPEN_RUNTIMES_ENV'] ?? '';
+final String logsDirectory =
+    Platform.environment['OPEN_RUNTIMES_LOGS_DIRECTORY'] ?? '/mnt/logs';
 final Map<String, dynamic> headers = () {
   try {
     return jsonDecode(Platform.environment['OPEN_RUNTIMES_HEADERS'] ?? '{}')

--- a/runtimes/dart/versions/latest/src/logger.dart
+++ b/runtimes/dart/versions/latest/src/logger.dart
@@ -70,8 +70,8 @@ class Logger {
     }
 
     try {
-      (type == Logger.TYPE_ERROR ? stderr : stdout).write(stringLog + "\n");
       stream?.write(stringLog + "\n");
+      (type == Logger.TYPE_ERROR ? stderr : stdout).write(stringLog + "\n");
     } catch (e) {
       // Silently fail to prevent 500 errors in runtime
       // Log write failures should not crash the runtime

--- a/runtimes/dart/versions/latest/src/logger.dart
+++ b/runtimes/dart/versions/latest/src/logger.dart
@@ -69,12 +69,18 @@ class Logger {
       stringLog += "... Log truncated due to size limit (8000 characters)";
     }
 
+    // Each sink is guarded on its own so one failing never drops the other
     try {
-      stream?.write(stringLog + "\n");
       (type == Logger.TYPE_ERROR ? stderr : stdout).write(stringLog + "\n");
     } catch (e) {
       // Silently fail to prevent 500 errors in runtime
       // Log write failures should not crash the runtime
+    }
+
+    try {
+      stream?.write(stringLog + "\n");
+    } catch (e) {
+      // Silently fail to prevent 500 errors in runtime
     }
   }
 

--- a/runtimes/dart/versions/latest/src/logger.dart
+++ b/runtimes/dart/versions/latest/src/logger.dart
@@ -23,12 +23,14 @@ class Logger {
           ? id
           : (config.env == 'development' ? 'dev' : this.generateId());
 
-      this.streamLogs = File(
-        '/mnt/logs/' + this.id + '_logs.log',
-      ).openWrite(mode: FileMode.append);
-      this.streamErrors = File(
-        '/mnt/logs/' + this.id + '_errors.log',
-      ).openWrite(mode: FileMode.append);
+      if (config.logsDirectory.isNotEmpty) {
+        this.streamLogs = File(
+          config.logsDirectory + '/' + this.id + '_logs.log',
+        ).openWrite(mode: FileMode.append);
+        this.streamErrors = File(
+          config.logsDirectory + '/' + this.id + '_errors.log',
+        ).openWrite(mode: FileMode.append);
+      }
     }
   }
 
@@ -50,10 +52,6 @@ class Logger {
         ? this.streamErrors
         : this.streamLogs;
 
-    if (stream == null) {
-      return;
-    }
-
     String stringLog = "";
 
     if (message is List || message is Map) {
@@ -72,7 +70,8 @@ class Logger {
     }
 
     try {
-      stream.write(stringLog + "\n");
+      (type == Logger.TYPE_ERROR ? stderr : stdout).write(stringLog + "\n");
+      stream?.write(stringLog + "\n");
     } catch (e) {
       // Silently fail to prevent 500 errors in runtime
       // Log write failures should not crash the runtime
@@ -80,7 +79,7 @@ class Logger {
   }
 
   Future<void> end() async {
-    if (!this.enabled || this.streamLogs == null || this.streamErrors == null) {
+    if (!this.enabled) {
       return;
     }
 

--- a/runtimes/deno/versions/latest/src/config.ts
+++ b/runtimes/deno/versions/latest/src/config.ts
@@ -11,4 +11,5 @@ export const config = {
   headers: parseHeaders(),
   entrypoint: Deno.env.get("OPEN_RUNTIMES_ENTRYPOINT") ?? "",
   env: Deno.env.get("OPEN_RUNTIMES_ENV") ?? "",
+  logsDirectory: Deno.env.get("OPEN_RUNTIMES_LOGS_DIRECTORY") ?? "/mnt/logs",
 };

--- a/runtimes/deno/versions/latest/src/logger.ts
+++ b/runtimes/deno/versions/latest/src/logger.ts
@@ -88,13 +88,13 @@ export class Logger {
 
     const encoded = new TextEncoder().encode(stringLog + "\n");
     try {
-      (type === Logger.TYPE_ERROR ? Deno.stderr : Deno.stdout).writeSync(
-        encoded,
-      );
-
       if (stream) {
         this.writePromises.push(stream.write(encoded));
       }
+
+      (type === Logger.TYPE_ERROR ? Deno.stderr : Deno.stdout).writeSync(
+        encoded,
+      );
     } catch (error) {
       // Silently fail to prevent 500 errors in runtime
       // Log write failures should not crash the runtime

--- a/runtimes/deno/versions/latest/src/logger.ts
+++ b/runtimes/deno/versions/latest/src/logger.ts
@@ -27,13 +27,13 @@ export class Logger {
   }
 
   async setup() {
-    if (this.enabled) {
+    if (this.enabled && config.logsDirectory) {
       const [streamLogs, streamErrors] = await Promise.all([
-        Deno.open(`/mnt/logs/${this.id}_logs.log`, {
+        Deno.open(`${config.logsDirectory}/${this.id}_logs.log`, {
           create: true,
           append: true,
         }),
-        Deno.open(`/mnt/logs/${this.id}_errors.log`, {
+        Deno.open(`${config.logsDirectory}/${this.id}_errors.log`, {
           create: true,
           append: true,
         }),
@@ -65,10 +65,6 @@ export class Logger {
       ? this.streamErrors
       : this.streamLogs;
 
-    if (!stream) {
-      return;
-    }
-
     let stringLog = messages
       .map((message) => {
         if (message instanceof Error) {
@@ -92,7 +88,13 @@ export class Logger {
 
     const encoded = new TextEncoder().encode(stringLog + "\n");
     try {
-      this.writePromises.push(stream.write(encoded));
+      (type === Logger.TYPE_ERROR ? Deno.stderr : Deno.stdout).writeSync(
+        encoded,
+      );
+
+      if (stream) {
+        this.writePromises.push(stream.write(encoded));
+      }
     } catch (error) {
       // Silently fail to prevent 500 errors in runtime
       // Log write failures should not crash the runtime
@@ -100,7 +102,7 @@ export class Logger {
   }
 
   async end() {
-    if (!this.enabled || !this.streamLogs || !this.streamErrors) {
+    if (!this.enabled) {
       return;
     }
 
@@ -110,10 +112,8 @@ export class Logger {
       await promise;
     }
 
-    await Promise.all([
-      this.streamLogs.close(),
-      this.streamErrors.close(),
-    ]);
+    this.streamLogs?.close();
+    this.streamErrors?.close();
   }
 
   overrideNativeLogs() {

--- a/runtimes/deno/versions/latest/src/logger.ts
+++ b/runtimes/deno/versions/latest/src/logger.ts
@@ -87,17 +87,22 @@ export class Logger {
     }
 
     const encoded = new TextEncoder().encode(stringLog + "\n");
+    // Each sink is guarded on its own so one failing never drops the other
     try {
-      if (stream) {
-        this.writePromises.push(stream.write(encoded));
-      }
-
       (type === Logger.TYPE_ERROR ? Deno.stderr : Deno.stdout).writeSync(
         encoded,
       );
     } catch (error) {
       // Silently fail to prevent 500 errors in runtime
       // Log write failures should not crash the runtime
+    }
+
+    try {
+      if (stream) {
+        this.writePromises.push(stream.write(encoded));
+      }
+    } catch (error) {
+      // Silently fail to prevent 500 errors in runtime
     }
   }
 

--- a/runtimes/dotnet/versions/latest/src/OprConfig.cs
+++ b/runtimes/dotnet/versions/latest/src/OprConfig.cs
@@ -10,6 +10,8 @@ namespace DotNetRuntime
             Environment.GetEnvironmentVariable("OPEN_RUNTIMES_SECRET") ?? "";
         public static readonly String Env =
             Environment.GetEnvironmentVariable("OPEN_RUNTIMES_ENV") ?? "";
+        public static readonly String LogsDirectory =
+            Environment.GetEnvironmentVariable("OPEN_RUNTIMES_LOGS_DIRECTORY") ?? "/mnt/logs";
         public static readonly Dictionary<string, string> Headers = LoadHeaders();
 
         private static Dictionary<string, string> LoadHeaders()

--- a/runtimes/dotnet/versions/latest/src/RuntimeLogger.cs
+++ b/runtimes/dotnet/versions/latest/src/RuntimeLogger.cs
@@ -118,11 +118,11 @@ namespace DotNetRuntime
 
             try
             {
+                stream?.WriteLine(stringLog);
+
                 var passthrough = type == RuntimeLogger.TYPE_ERROR ? Stderr : Stdout;
                 passthrough.WriteLine(stringLog);
                 passthrough.Flush();
-
-                stream?.WriteLine(stringLog);
             }
             catch (Exception e)
             {

--- a/runtimes/dotnet/versions/latest/src/RuntimeLogger.cs
+++ b/runtimes/dotnet/versions/latest/src/RuntimeLogger.cs
@@ -23,6 +23,10 @@ namespace DotNetRuntime
 
         private StringBuilder? customStdStream = null;
 
+        // Captured before any request can redirect Console.Out/Console.Error
+        private static readonly TextWriter Stdout = Console.Out;
+        private static readonly TextWriter Stderr = Console.Error;
+
         public RuntimeLogger(String? status, String? id)
         {
             if (string.IsNullOrEmpty(status) || status == "enabled")
@@ -53,8 +57,17 @@ namespace DotNetRuntime
                 }
 
                 // Log stream
-                this.streamLogs = new StreamWriter("/mnt/logs/" + this.id + "_logs.log", true);
-                this.streamErrors = new StreamWriter("/mnt/logs/" + this.id + "_errors.log", true);
+                if (!string.IsNullOrEmpty(OprConfig.LogsDirectory))
+                {
+                    this.streamLogs = new StreamWriter(
+                        OprConfig.LogsDirectory + "/" + this.id + "_logs.log",
+                        true
+                    );
+                    this.streamErrors = new StreamWriter(
+                        OprConfig.LogsDirectory + "/" + this.id + "_errors.log",
+                        true
+                    );
+                }
             }
         }
 
@@ -97,23 +110,24 @@ namespace DotNetRuntime
                 stringLog = message.ToString() ?? "";
             }
 
-            if (stream != null)
+            if (stringLog.Length > 8000)
             {
-                if (stringLog.Length > 8000)
-                {
-                    stringLog = stringLog.Substring(0, 8000);
-                    stringLog += "... Log truncated due to size limit (8000 characters)";
-                }
+                stringLog = stringLog.Substring(0, 8000);
+                stringLog += "... Log truncated due to size limit (8000 characters)";
+            }
 
-                try
-                {
-                    stream.WriteLine(stringLog);
-                }
-                catch (Exception e)
-                {
-                    // Silently fail to prevent 500 errors in runtime
-                    // Log write failures should not crash the runtime
-                }
+            try
+            {
+                var passthrough = type == RuntimeLogger.TYPE_ERROR ? Stderr : Stdout;
+                passthrough.WriteLine(stringLog);
+                passthrough.Flush();
+
+                stream?.WriteLine(stringLog);
+            }
+            catch (Exception e)
+            {
+                // Silently fail to prevent 500 errors in runtime
+                // Log write failures should not crash the runtime
             }
         }
 

--- a/runtimes/dotnet/versions/latest/src/RuntimeLogger.cs
+++ b/runtimes/dotnet/versions/latest/src/RuntimeLogger.cs
@@ -116,10 +116,9 @@ namespace DotNetRuntime
                 stringLog += "... Log truncated due to size limit (8000 characters)";
             }
 
+            // Each sink is guarded on its own so one failing never drops the other
             try
             {
-                stream?.WriteLine(stringLog);
-
                 var passthrough = type == RuntimeLogger.TYPE_ERROR ? Stderr : Stdout;
                 passthrough.WriteLine(stringLog);
                 passthrough.Flush();
@@ -128,6 +127,15 @@ namespace DotNetRuntime
             {
                 // Silently fail to prevent 500 errors in runtime
                 // Log write failures should not crash the runtime
+            }
+
+            try
+            {
+                stream?.WriteLine(stringLog);
+            }
+            catch (Exception e)
+            {
+                // Silently fail to prevent 500 errors in runtime
             }
         }
 

--- a/runtimes/java/versions/11.0/src/main/java/io/openruntimes/java/RuntimeLogger.java
+++ b/runtimes/java/versions/11.0/src/main/java/io/openruntimes/java/RuntimeLogger.java
@@ -134,13 +134,13 @@ public class RuntimeLogger {
     }
 
     try {
-      PrintStream passthrough = type == RuntimeLogger.TYPE_ERROR ? stderr : stdout;
-      passthrough.print(stringLog);
-      passthrough.flush();
-
       if (stream != null) {
         stream.write(stringLog);
       }
+
+      PrintStream passthrough = type == RuntimeLogger.TYPE_ERROR ? stderr : stdout;
+      passthrough.print(stringLog);
+      passthrough.flush();
     } catch (IOException e) {
       // Silently fail to prevent 500 errors in runtime
       // Log write failures should not crash the runtime

--- a/runtimes/java/versions/11.0/src/main/java/io/openruntimes/java/RuntimeLogger.java
+++ b/runtimes/java/versions/11.0/src/main/java/io/openruntimes/java/RuntimeLogger.java
@@ -30,6 +30,10 @@ public class RuntimeLogger {
 
   private static final Gson gson = new GsonBuilder().serializeNulls().create();
 
+  // Captured before any request can redirect System.out/System.err
+  private static final PrintStream stdout = System.out;
+  private static final PrintStream stderr = System.err;
+
   public RuntimeLogger(String status, String id) throws IOException {
     this.customStdStream = new ByteArrayOutputStream();
 
@@ -53,6 +57,11 @@ public class RuntimeLogger {
         serverEnv = "";
       }
 
+      String logsDirectory = System.getenv("OPEN_RUNTIMES_LOGS_DIRECTORY");
+      if (logsDirectory == null) {
+        logsDirectory = "/mnt/logs";
+      }
+
       if (id.equals("")) {
         if (serverEnv.equals("development")) {
           this.id = "dev";
@@ -63,8 +72,10 @@ public class RuntimeLogger {
         this.id = id;
       }
 
-      this.streamLogs = new FileWriter("/mnt/logs/" + this.id + "_logs.log", true);
-      this.streamErrors = new FileWriter("/mnt/logs/" + this.id + "_errors.log", true);
+      if (!logsDirectory.isEmpty()) {
+        this.streamLogs = new FileWriter(logsDirectory + "/" + this.id + "_logs.log", true);
+        this.streamErrors = new FileWriter(logsDirectory + "/" + this.id + "_errors.log", true);
+      }
     }
   }
 
@@ -123,7 +134,13 @@ public class RuntimeLogger {
     }
 
     try {
-      stream.write(stringLog);
+      PrintStream passthrough = type == RuntimeLogger.TYPE_ERROR ? stderr : stdout;
+      passthrough.print(stringLog);
+      passthrough.flush();
+
+      if (stream != null) {
+        stream.write(stringLog);
+      }
     } catch (IOException e) {
       // Silently fail to prevent 500 errors in runtime
       // Log write failures should not crash the runtime
@@ -137,8 +154,10 @@ public class RuntimeLogger {
 
     this.enabled = false;
 
-    this.streamLogs.close();
-    this.streamErrors.close();
+    if (this.streamLogs != null) {
+      this.streamLogs.close();
+      this.streamErrors.close();
+    }
   }
 
   public void overrideNativeLogs() {

--- a/runtimes/java/versions/11.0/src/main/java/io/openruntimes/java/RuntimeLogger.java
+++ b/runtimes/java/versions/11.0/src/main/java/io/openruntimes/java/RuntimeLogger.java
@@ -133,14 +133,15 @@ public class RuntimeLogger {
       stringLog += "... Log truncated due to size limit (8000 characters)";
     }
 
+    // PrintStream swallows its own errors, so the file sink stays guarded alone
+    PrintStream passthrough = type == RuntimeLogger.TYPE_ERROR ? stderr : stdout;
+    passthrough.print(stringLog);
+    passthrough.flush();
+
     try {
       if (stream != null) {
         stream.write(stringLog);
       }
-
-      PrintStream passthrough = type == RuntimeLogger.TYPE_ERROR ? stderr : stdout;
-      passthrough.print(stringLog);
-      passthrough.flush();
     } catch (IOException e) {
       // Silently fail to prevent 500 errors in runtime
       // Log write failures should not crash the runtime

--- a/runtimes/java/versions/8.0/src/main/java/io/openruntimes/java/RuntimeLogger.java
+++ b/runtimes/java/versions/8.0/src/main/java/io/openruntimes/java/RuntimeLogger.java
@@ -134,13 +134,13 @@ public class RuntimeLogger {
     }
 
     try {
-      PrintStream passthrough = type == RuntimeLogger.TYPE_ERROR ? stderr : stdout;
-      passthrough.print(stringLog);
-      passthrough.flush();
-
       if (stream != null) {
         stream.write(stringLog);
       }
+
+      PrintStream passthrough = type == RuntimeLogger.TYPE_ERROR ? stderr : stdout;
+      passthrough.print(stringLog);
+      passthrough.flush();
     } catch (IOException e) {
       // Silently fail to prevent 500 errors in runtime
       // Log write failures should not crash the runtime

--- a/runtimes/java/versions/8.0/src/main/java/io/openruntimes/java/RuntimeLogger.java
+++ b/runtimes/java/versions/8.0/src/main/java/io/openruntimes/java/RuntimeLogger.java
@@ -30,6 +30,10 @@ public class RuntimeLogger {
 
   private static final Gson gson = new GsonBuilder().serializeNulls().create();
 
+  // Captured before any request can redirect System.out/System.err
+  private static final PrintStream stdout = System.out;
+  private static final PrintStream stderr = System.err;
+
   public RuntimeLogger(String status, String id) throws IOException {
     this.customStdStream = new ByteArrayOutputStream();
 
@@ -53,6 +57,11 @@ public class RuntimeLogger {
         serverEnv = "";
       }
 
+      String logsDirectory = System.getenv("OPEN_RUNTIMES_LOGS_DIRECTORY");
+      if (logsDirectory == null) {
+        logsDirectory = "/mnt/logs";
+      }
+
       if (id.equals("")) {
         if (serverEnv.equals("development")) {
           this.id = "dev";
@@ -63,8 +72,10 @@ public class RuntimeLogger {
         this.id = id;
       }
 
-      this.streamLogs = new FileWriter("/mnt/logs/" + this.id + "_logs.log", true);
-      this.streamErrors = new FileWriter("/mnt/logs/" + this.id + "_errors.log", true);
+      if (!logsDirectory.isEmpty()) {
+        this.streamLogs = new FileWriter(logsDirectory + "/" + this.id + "_logs.log", true);
+        this.streamErrors = new FileWriter(logsDirectory + "/" + this.id + "_errors.log", true);
+      }
     }
   }
 
@@ -123,7 +134,13 @@ public class RuntimeLogger {
     }
 
     try {
-      stream.write(stringLog);
+      PrintStream passthrough = type == RuntimeLogger.TYPE_ERROR ? stderr : stdout;
+      passthrough.print(stringLog);
+      passthrough.flush();
+
+      if (stream != null) {
+        stream.write(stringLog);
+      }
     } catch (IOException e) {
       // Silently fail to prevent 500 errors in runtime
       // Log write failures should not crash the runtime
@@ -137,8 +154,10 @@ public class RuntimeLogger {
 
     this.enabled = false;
 
-    this.streamLogs.close();
-    this.streamErrors.close();
+    if (this.streamLogs != null) {
+      this.streamLogs.close();
+      this.streamErrors.close();
+    }
   }
 
   public void overrideNativeLogs() {

--- a/runtimes/java/versions/8.0/src/main/java/io/openruntimes/java/RuntimeLogger.java
+++ b/runtimes/java/versions/8.0/src/main/java/io/openruntimes/java/RuntimeLogger.java
@@ -133,14 +133,15 @@ public class RuntimeLogger {
       stringLog += "... Log truncated due to size limit (8000 characters)";
     }
 
+    // PrintStream swallows its own errors, so the file sink stays guarded alone
+    PrintStream passthrough = type == RuntimeLogger.TYPE_ERROR ? stderr : stdout;
+    passthrough.print(stringLog);
+    passthrough.flush();
+
     try {
       if (stream != null) {
         stream.write(stringLog);
       }
-
-      PrintStream passthrough = type == RuntimeLogger.TYPE_ERROR ? stderr : stdout;
-      passthrough.print(stringLog);
-      passthrough.flush();
     } catch (IOException e) {
       // Silently fail to prevent 500 errors in runtime
       // Log write failures should not crash the runtime

--- a/runtimes/java/versions/latest/src/main/java/io/openruntimes/java/OprConfig.java
+++ b/runtimes/java/versions/latest/src/main/java/io/openruntimes/java/OprConfig.java
@@ -10,9 +10,13 @@ public final class OprConfig {
   public static final String SECRET;
   public static final String ENTRYPOINT = System.getenv("OPEN_RUNTIMES_ENTRYPOINT");
   public static final String ENV;
+  public static final String LOGS_DIRECTORY;
   public static final Map<String, String> HEADERS;
 
   static {
+    String logsDirectory = System.getenv("OPEN_RUNTIMES_LOGS_DIRECTORY");
+    LOGS_DIRECTORY = logsDirectory == null ? "/mnt/logs" : logsDirectory;
+
     String secret = System.getenv("OPEN_RUNTIMES_SECRET");
     SECRET = secret == null ? "" : secret;
 

--- a/runtimes/java/versions/latest/src/main/java/io/openruntimes/java/RuntimeLogger.java
+++ b/runtimes/java/versions/latest/src/main/java/io/openruntimes/java/RuntimeLogger.java
@@ -125,14 +125,15 @@ public class RuntimeLogger {
       stringLog += "... Log truncated due to size limit (8000 characters)";
     }
 
+    // PrintStream swallows its own errors, so the file sink stays guarded alone
+    PrintStream passthrough = type == RuntimeLogger.TYPE_ERROR ? stderr : stdout;
+    passthrough.print(stringLog);
+    passthrough.flush();
+
     try {
       if (stream != null) {
         stream.write(stringLog);
       }
-
-      PrintStream passthrough = type == RuntimeLogger.TYPE_ERROR ? stderr : stdout;
-      passthrough.print(stringLog);
-      passthrough.flush();
     } catch (IOException e) {
       // Silently fail to prevent 500 errors in runtime
       // Log write failures should not crash the runtime

--- a/runtimes/java/versions/latest/src/main/java/io/openruntimes/java/RuntimeLogger.java
+++ b/runtimes/java/versions/latest/src/main/java/io/openruntimes/java/RuntimeLogger.java
@@ -126,13 +126,13 @@ public class RuntimeLogger {
     }
 
     try {
-      PrintStream passthrough = type == RuntimeLogger.TYPE_ERROR ? stderr : stdout;
-      passthrough.print(stringLog);
-      passthrough.flush();
-
       if (stream != null) {
         stream.write(stringLog);
       }
+
+      PrintStream passthrough = type == RuntimeLogger.TYPE_ERROR ? stderr : stdout;
+      passthrough.print(stringLog);
+      passthrough.flush();
     } catch (IOException e) {
       // Silently fail to prevent 500 errors in runtime
       // Log write failures should not crash the runtime

--- a/runtimes/java/versions/latest/src/main/java/io/openruntimes/java/RuntimeLogger.java
+++ b/runtimes/java/versions/latest/src/main/java/io/openruntimes/java/RuntimeLogger.java
@@ -30,6 +30,10 @@ public class RuntimeLogger {
 
   private static final Gson gson = new GsonBuilder().serializeNulls().create();
 
+  // Captured before any request can redirect System.out/System.err
+  private static final PrintStream stdout = System.out;
+  private static final PrintStream stderr = System.err;
+
   public RuntimeLogger(String status, String id) throws IOException {
     this.customStdStream = new ByteArrayOutputStream();
 
@@ -58,8 +62,12 @@ public class RuntimeLogger {
         this.id = id;
       }
 
-      this.streamLogs = new FileWriter("/mnt/logs/" + this.id + "_logs.log", true);
-      this.streamErrors = new FileWriter("/mnt/logs/" + this.id + "_errors.log", true);
+      if (!OprConfig.LOGS_DIRECTORY.isEmpty()) {
+        this.streamLogs =
+            new FileWriter(OprConfig.LOGS_DIRECTORY + "/" + this.id + "_logs.log", true);
+        this.streamErrors =
+            new FileWriter(OprConfig.LOGS_DIRECTORY + "/" + this.id + "_errors.log", true);
+      }
     }
   }
 
@@ -118,7 +126,13 @@ public class RuntimeLogger {
     }
 
     try {
-      stream.write(stringLog);
+      PrintStream passthrough = type == RuntimeLogger.TYPE_ERROR ? stderr : stdout;
+      passthrough.print(stringLog);
+      passthrough.flush();
+
+      if (stream != null) {
+        stream.write(stringLog);
+      }
     } catch (IOException e) {
       // Silently fail to prevent 500 errors in runtime
       // Log write failures should not crash the runtime
@@ -132,8 +146,10 @@ public class RuntimeLogger {
 
     this.enabled = false;
 
-    this.streamLogs.close();
-    this.streamErrors.close();
+    if (this.streamLogs != null) {
+      this.streamLogs.close();
+      this.streamErrors.close();
+    }
   }
 
   public void overrideNativeLogs() {

--- a/runtimes/javascript/src/ssr/logger.mjs
+++ b/runtimes/javascript/src/ssr/logger.mjs
@@ -7,6 +7,7 @@ import superjson from "superjson";
 export const loggingNamespace = new AsyncLocalStorage();
 
 const isDevelopment = process.env.OPEN_RUNTIMES_ENV === "development";
+const logsDirectory = process.env.OPEN_RUNTIMES_LOGS_DIRECTORY ?? "/mnt/logs";
 
 export const nativeLog = console.log.bind(console);
 
@@ -45,9 +46,17 @@ export class Logger {
       })
       .join(" ");
 
-    const path = `/mnt/logs/${id}_${type === Logger.TYPE_ERROR ? "errors" : "logs"}.log`;
     try {
-      appendFileSync(path, stringLog + "\n");
+      (type === Logger.TYPE_ERROR ? process.stderr : process.stdout).write(
+        stringLog + "\n",
+      );
+
+      if (logsDirectory) {
+        appendFileSync(
+          `${logsDirectory}/${id}_${type === Logger.TYPE_ERROR ? "errors" : "logs"}.log`,
+          stringLog + "\n",
+        );
+      }
     } catch {
       // Silently ignore write failures to prevent runtime crashes.
     }

--- a/runtimes/javascript/src/ssr/logger.mjs
+++ b/runtimes/javascript/src/ssr/logger.mjs
@@ -47,16 +47,16 @@ export class Logger {
       .join(" ");
 
     try {
-      (type === Logger.TYPE_ERROR ? process.stderr : process.stdout).write(
-        stringLog + "\n",
-      );
-
       if (logsDirectory) {
         appendFileSync(
           `${logsDirectory}/${id}_${type === Logger.TYPE_ERROR ? "errors" : "logs"}.log`,
           stringLog + "\n",
         );
       }
+
+      (type === Logger.TYPE_ERROR ? process.stderr : process.stdout).write(
+        stringLog + "\n",
+      );
     } catch {
       // Silently ignore write failures to prevent runtime crashes.
     }

--- a/runtimes/javascript/src/ssr/logger.mjs
+++ b/runtimes/javascript/src/ssr/logger.mjs
@@ -46,6 +46,15 @@ export class Logger {
       })
       .join(" ");
 
+    // Each sink is guarded on its own so one failing never drops the other
+    try {
+      (type === Logger.TYPE_ERROR ? process.stderr : process.stdout).write(
+        stringLog + "\n",
+      );
+    } catch {
+      // Silently ignore write failures to prevent runtime crashes.
+    }
+
     try {
       if (logsDirectory) {
         appendFileSync(
@@ -53,10 +62,6 @@ export class Logger {
           stringLog + "\n",
         );
       }
-
-      (type === Logger.TYPE_ERROR ? process.stderr : process.stdout).write(
-        stringLog + "\n",
-      );
     } catch {
       // Silently ignore write failures to prevent runtime crashes.
     }

--- a/runtimes/kotlin/versions/latest/src/main/kotlin/io/openruntimes/kotlin/OprConfig.kt
+++ b/runtimes/kotlin/versions/latest/src/main/kotlin/io/openruntimes/kotlin/OprConfig.kt
@@ -13,4 +13,5 @@ object OprConfig {
         }
     val entrypoint: String = System.getenv("OPEN_RUNTIMES_ENTRYPOINT") ?: ""
     val env: String = System.getenv("OPEN_RUNTIMES_ENV") ?: ""
+    val logsDirectory: String = System.getenv("OPEN_RUNTIMES_LOGS_DIRECTORY") ?: "/mnt/logs"
 }

--- a/runtimes/kotlin/versions/latest/src/main/kotlin/io/openruntimes/kotlin/RuntimeLogger.kt
+++ b/runtimes/kotlin/versions/latest/src/main/kotlin/io/openruntimes/kotlin/RuntimeLogger.kt
@@ -115,11 +115,11 @@ class RuntimeLogger(
         }
 
         try {
+            stream?.write(stringLog)
+
             val passthrough = if (type == RuntimeLogger.TYPE_ERROR) stderr else stdout
             passthrough.print(stringLog)
             passthrough.flush()
-
-            stream?.write(stringLog)
         } catch (e: IOException) {
             // Silently fail to prevent 500 errors in runtime
             // Log write failures should not crash the runtime

--- a/runtimes/kotlin/versions/latest/src/main/kotlin/io/openruntimes/kotlin/RuntimeLogger.kt
+++ b/runtimes/kotlin/versions/latest/src/main/kotlin/io/openruntimes/kotlin/RuntimeLogger.kt
@@ -29,6 +29,10 @@ class RuntimeLogger(
 
     companion object {
         private val gson = GsonBuilder().serializeNulls().create()
+
+        // Captured before any request can redirect System.out/System.err
+        private val stdout: PrintStream = System.out
+        private val stderr: PrintStream = System.err
         public val TYPE_ERROR = "error"
         public val TYPE_LOG = "log"
     }
@@ -60,8 +64,10 @@ class RuntimeLogger(
                 }
             }
 
-            this.streamLogs = FileWriter("/mnt/logs/" + this.id + "_logs.log", true)
-            this.streamErrors = FileWriter("/mnt/logs/" + this.id + "_errors.log", true)
+            if (OprConfig.logsDirectory.isNotEmpty()) {
+                this.streamLogs = FileWriter(OprConfig.logsDirectory + "/" + this.id + "_logs.log", true)
+                this.streamErrors = FileWriter(OprConfig.logsDirectory + "/" + this.id + "_errors.log", true)
+            }
         }
     }
 
@@ -103,18 +109,20 @@ class RuntimeLogger(
             i += 1
         }
 
-        if (stream != null) {
-            if (stringLog.length > 8000) {
-                stringLog = stringLog.substring(0, 8000)
-                stringLog += "... Log truncated due to size limit (8000 characters)"
-            }
+        if (stringLog.length > 8000) {
+            stringLog = stringLog.substring(0, 8000)
+            stringLog += "... Log truncated due to size limit (8000 characters)"
+        }
 
-            try {
-                stream.write(stringLog)
-            } catch (e: IOException) {
-                // Silently fail to prevent 500 errors in runtime
-                // Log write failures should not crash the runtime
-            }
+        try {
+            val passthrough = if (type == RuntimeLogger.TYPE_ERROR) stderr else stdout
+            passthrough.print(stringLog)
+            passthrough.flush()
+
+            stream?.write(stringLog)
+        } catch (e: IOException) {
+            // Silently fail to prevent 500 errors in runtime
+            // Log write failures should not crash the runtime
         }
     }
 

--- a/runtimes/kotlin/versions/latest/src/main/kotlin/io/openruntimes/kotlin/RuntimeLogger.kt
+++ b/runtimes/kotlin/versions/latest/src/main/kotlin/io/openruntimes/kotlin/RuntimeLogger.kt
@@ -114,12 +114,13 @@ class RuntimeLogger(
             stringLog += "... Log truncated due to size limit (8000 characters)"
         }
 
+        // PrintStream swallows its own errors, so the file sink stays guarded alone
+        val passthrough = if (type == RuntimeLogger.TYPE_ERROR) stderr else stdout
+        passthrough.print(stringLog)
+        passthrough.flush()
+
         try {
             stream?.write(stringLog)
-
-            val passthrough = if (type == RuntimeLogger.TYPE_ERROR) stderr else stdout
-            passthrough.print(stringLog)
-            passthrough.flush()
         } catch (e: IOException) {
             // Silently fail to prevent 500 errors in runtime
             // Log write failures should not crash the runtime

--- a/runtimes/node/versions/latest/src/config.js
+++ b/runtimes/node/versions/latest/src/config.js
@@ -10,4 +10,5 @@ module.exports = Object.freeze({
   headers,
   entrypoint: process.env.OPEN_RUNTIMES_ENTRYPOINT,
   env: process.env.OPEN_RUNTIMES_ENV,
+  logsDirectory: process.env.OPEN_RUNTIMES_LOGS_DIRECTORY ?? "/mnt/logs",
 });

--- a/runtimes/node/versions/latest/src/logger.js
+++ b/runtimes/node/versions/latest/src/logger.js
@@ -27,15 +27,20 @@ class Logger {
         : config.env === "development"
           ? "dev"
           : this.generateId();
-      this.streamLogs = fs.createWriteStream(`/mnt/logs/${this.id}_logs.log`, {
-        flags: "a",
-      });
-      this.streamErrors = fs.createWriteStream(
-        `/mnt/logs/${this.id}_errors.log`,
-        {
-          flags: "a",
-        },
-      );
+      if (config.logsDirectory) {
+        this.streamLogs = fs.createWriteStream(
+          `${config.logsDirectory}/${this.id}_logs.log`,
+          {
+            flags: "a",
+          },
+        );
+        this.streamErrors = fs.createWriteStream(
+          `${config.logsDirectory}/${this.id}_errors.log`,
+          {
+            flags: "a",
+          },
+        );
+      }
     }
   }
 
@@ -78,7 +83,10 @@ class Logger {
     }
 
     try {
-      stream.write(stringLog + "\n");
+      (type === Logger.TYPE_ERROR ? process.stderr : process.stdout).write(
+        stringLog + "\n",
+      );
+      stream?.write(stringLog + "\n");
     } catch (err) {
       // Silently ignore write failures to prevent runtime crashes
       // The logging system should not cause the main execution to fail
@@ -92,16 +100,15 @@ class Logger {
 
     this.enabled = false;
 
-    await Promise.all([
-      new Promise((res) => {
-        this.streamLogs.on("close", res);
-        this.streamLogs.end();
-      }),
-      new Promise((res) => {
-        this.streamErrors.on("close", res);
-        this.streamErrors.end();
-      }),
-    ]);
+    await Promise.all(
+      [this.streamLogs, this.streamErrors].filter(Boolean).map(
+        (stream) =>
+          new Promise((res) => {
+            stream.on("close", res);
+            stream.end();
+          }),
+      ),
+    );
   }
 
   overrideNativeLogs() {

--- a/runtimes/node/versions/latest/src/logger.js
+++ b/runtimes/node/versions/latest/src/logger.js
@@ -83,10 +83,10 @@ class Logger {
     }
 
     try {
+      stream?.write(stringLog + "\n");
       (type === Logger.TYPE_ERROR ? process.stderr : process.stdout).write(
         stringLog + "\n",
       );
-      stream?.write(stringLog + "\n");
     } catch (err) {
       // Silently ignore write failures to prevent runtime crashes
       // The logging system should not cause the main execution to fail

--- a/runtimes/node/versions/latest/src/logger.js
+++ b/runtimes/node/versions/latest/src/logger.js
@@ -82,14 +82,20 @@ class Logger {
       stringLog += "... Log truncated due to size limit (8000 characters)";
     }
 
+    // Each sink is guarded on its own so one failing never drops the other
     try {
-      stream?.write(stringLog + "\n");
       (type === Logger.TYPE_ERROR ? process.stderr : process.stdout).write(
         stringLog + "\n",
       );
     } catch (err) {
       // Silently ignore write failures to prevent runtime crashes
       // The logging system should not cause the main execution to fail
+    }
+
+    try {
+      stream?.write(stringLog + "\n");
+    } catch (err) {
+      // Silently ignore write failures to prevent runtime crashes
     }
   }
 

--- a/runtimes/php/versions/latest/src/config.php
+++ b/runtimes/php/versions/latest/src/config.php
@@ -6,6 +6,7 @@ final class Config
     public array $headers;
     public string $entrypoint;
     public string $env;
+    public string $logsDirectory;
 
     public function __construct()
     {
@@ -13,5 +14,7 @@ final class Config
         $this->headers = \json_decode(\getenv('OPEN_RUNTIMES_HEADERS') ?: '{}', true) ?: [];
         $this->entrypoint = \getenv('OPEN_RUNTIMES_ENTRYPOINT') ?: '';
         $this->env = \getenv('OPEN_RUNTIMES_ENV') ?: '';
+        $logsDirectory = \getenv('OPEN_RUNTIMES_LOGS_DIRECTORY');
+        $this->logsDirectory = $logsDirectory === false ? '/mnt/logs' : $logsDirectory;
     }
 }

--- a/runtimes/php/versions/latest/src/logger.php
+++ b/runtimes/php/versions/latest/src/logger.php
@@ -62,11 +62,11 @@ class Logger
         }
 
         try {
-            \fwrite($type == Logger::TYPE_ERROR ? \STDERR : \STDOUT, $stringLog . "\n");
-
             if ($stream !== null) {
                 \fwrite($stream, $stringLog . "\n");
             }
+
+            \fwrite($type == Logger::TYPE_ERROR ? \STDERR : \STDOUT, $stringLog . "\n");
         } catch (Exception $e) {
             // Silently fail to prevent 500 errors in runtime
             // Log write failures should not crash the runtime

--- a/runtimes/php/versions/latest/src/logger.php
+++ b/runtimes/php/versions/latest/src/logger.php
@@ -61,15 +61,20 @@ class Logger
             $stringLog .= "... Log truncated due to size limit (8000 characters)";
         }
 
+        // Each sink is guarded on its own so one failing never drops the other
         try {
-            if ($stream !== null) {
-                \fwrite($stream, $stringLog . "\n");
-            }
-
             \fwrite($type == Logger::TYPE_ERROR ? \STDERR : \STDOUT, $stringLog . "\n");
         } catch (Exception $e) {
             // Silently fail to prevent 500 errors in runtime
             // Log write failures should not crash the runtime
+        }
+
+        try {
+            if ($stream !== null) {
+                \fwrite($stream, $stringLog . "\n");
+            }
+        } catch (Exception $e) {
+            // Silently fail to prevent 500 errors in runtime
         }
     }
 

--- a/runtimes/php/versions/latest/src/logger.php
+++ b/runtimes/php/versions/latest/src/logger.php
@@ -12,15 +12,17 @@ class Logger
     private mixed $streamLogs = null;
     private mixed $streamErrors = null;
 
-    public function __construct(?string $status = null, ?string $id = null, ?string $env = null)
+    public function __construct(?string $status = null, ?string $id = null, ?string $env = null, string $logsDirectory = '/mnt/logs')
     {
         $this->enabled = (!empty($status) ? $status : 'enabled') === 'enabled';
 
         if ($this->enabled) {
             $this->id = !empty($id) ? $id : ($env === 'development' ? 'dev' : $this->generateId());
 
-            $this->streamLogs = \fopen('/mnt/logs/' . $this->id . '_logs.log', 'a');
-            $this->streamErrors = \fopen('/mnt/logs/' . $this->id . '_errors.log', 'a');
+            if (!empty($logsDirectory)) {
+                $this->streamLogs = \fopen($logsDirectory . '/' . $this->id . '_logs.log', 'a');
+                $this->streamErrors = \fopen($logsDirectory . '/' . $this->id . '_errors.log', 'a');
+            }
         }
     }
 
@@ -60,7 +62,11 @@ class Logger
         }
 
         try {
-            \fwrite($stream, $stringLog . "\n");
+            \fwrite($type == Logger::TYPE_ERROR ? \STDERR : \STDOUT, $stringLog . "\n");
+
+            if ($stream !== null) {
+                \fwrite($stream, $stringLog . "\n");
+            }
         } catch (Exception $e) {
             // Silently fail to prevent 500 errors in runtime
             // Log write failures should not crash the runtime
@@ -75,8 +81,10 @@ class Logger
 
         $this->enabled = false;
 
-        \fclose($this->streamLogs);
-        \fclose($this->streamErrors);
+        if ($this->streamLogs !== null) {
+            \fclose($this->streamLogs);
+            \fclose($this->streamErrors);
+        }
     }
 
 

--- a/runtimes/php/versions/latest/src/server.php
+++ b/runtimes/php/versions/latest/src/server.php
@@ -275,7 +275,7 @@ $server->on("Request", function ($req, $res) use ($action, $config, &$activeRequ
         return;
     }
 
-    $logger = new Logger($req->header['x-open-runtimes-logging'] ?? '', $req->header['x-open-runtimes-log-id'] ?? '', $config->env);
+    $logger = new Logger($req->header['x-open-runtimes-logging'] ?? '', $req->header['x-open-runtimes-log-id'] ?? '', $config->env, $config->logsDirectory);
     $requestId = \spl_object_id($res);
     $activeRequests[$requestId] = [
         'logger' => $logger,

--- a/runtimes/python/versions/latest/src/config.py
+++ b/runtimes/python/versions/latest/src/config.py
@@ -4,6 +4,7 @@ import os
 SECRET = os.getenv("OPEN_RUNTIMES_SECRET", "")
 ENTRYPOINT = os.getenv("OPEN_RUNTIMES_ENTRYPOINT")
 ENV = os.getenv("OPEN_RUNTIMES_ENV")
+LOGS_DIRECTORY = os.getenv("OPEN_RUNTIMES_LOGS_DIRECTORY", "/mnt/logs")
 
 try:
     HEADERS = json.loads(os.getenv("OPEN_RUNTIMES_HEADERS", "") or "{}")

--- a/runtimes/python/versions/latest/src/logger.py
+++ b/runtimes/python/versions/latest/src/logger.py
@@ -41,8 +41,10 @@ class Logger:
             else:
                 self.id = id
 
-            self.stream_logs = open("/mnt/logs/" + self.id + "_logs.log", "a")
-            self.stream_errors = open("/mnt/logs/" + self.id + "_errors.log", "a")
+            if config.LOGS_DIRECTORY:
+                directory = config.LOGS_DIRECTORY
+                self.stream_logs = open(f"{directory}/{self.id}_logs.log", "a")
+                self.stream_errors = open(f"{directory}/{self.id}_errors.log", "a")
 
     def write(self, messages, xtype=None, is_native=False):
         if xtype is None:
@@ -82,7 +84,14 @@ class Logger:
             string_log += "... Log truncated due to size limit (8000 characters)"
 
         try:
-            stream.write(string_log)
+            passthrough = (
+                sys.__stderr__ if xtype == Logger.TYPE_ERROR else sys.__stdout__
+            )
+            passthrough.write(string_log)
+            passthrough.flush()
+
+            if stream is not None:
+                stream.write(string_log)
         except Exception as e:
             # Silently fail to prevent 500 errors in runtime
             # Log write failures should not crash the runtime

--- a/runtimes/python/versions/latest/src/logger.py
+++ b/runtimes/python/versions/latest/src/logger.py
@@ -84,14 +84,14 @@ class Logger:
             string_log += "... Log truncated due to size limit (8000 characters)"
 
         try:
+            if stream is not None:
+                stream.write(string_log)
+
             passthrough = (
                 sys.__stderr__ if xtype == Logger.TYPE_ERROR else sys.__stdout__
             )
             passthrough.write(string_log)
             passthrough.flush()
-
-            if stream is not None:
-                stream.write(string_log)
         except Exception as e:
             # Silently fail to prevent 500 errors in runtime
             # Log write failures should not crash the runtime

--- a/runtimes/python/versions/latest/src/logger.py
+++ b/runtimes/python/versions/latest/src/logger.py
@@ -83,10 +83,8 @@ class Logger:
             string_log = string_log[:8000]
             string_log += "... Log truncated due to size limit (8000 characters)"
 
+        # Each sink is guarded on its own so one failing never drops the other
         try:
-            if stream is not None:
-                stream.write(string_log)
-
             passthrough = (
                 sys.__stderr__ if xtype == Logger.TYPE_ERROR else sys.__stdout__
             )
@@ -95,6 +93,13 @@ class Logger:
         except Exception as e:
             # Silently fail to prevent 500 errors in runtime
             # Log write failures should not crash the runtime
+            pass
+
+        try:
+            if stream is not None:
+                stream.write(string_log)
+        except Exception as e:
+            # Silently fail to prevent 500 errors in runtime
             pass
 
     def end(self):

--- a/runtimes/python/versions/latest/src/logger.py
+++ b/runtimes/python/versions/latest/src/logger.py
@@ -108,8 +108,9 @@ class Logger:
 
         self.enabled = False
 
-        self.stream_logs.close()
-        self.stream_errors.close()
+        if self.stream_logs is not None:
+            self.stream_logs.close()
+            self.stream_errors.close()
 
     def override_native_logs(self):
         sys.stderr = sys.stdout = self.custom_std = StringIO()

--- a/runtimes/ruby/versions/latest/src/config.rb
+++ b/runtimes/ruby/versions/latest/src/config.rb
@@ -4,6 +4,7 @@ module Config
   SECRET = (ENV['OPEN_RUNTIMES_SECRET'] || '').freeze
   ENTRYPOINT = ENV['OPEN_RUNTIMES_ENTRYPOINT'].freeze
   ENV_NAME = (ENV['OPEN_RUNTIMES_ENV'] || "").freeze
+  LOGS_DIRECTORY = (ENV['OPEN_RUNTIMES_LOGS_DIRECTORY'] || '/mnt/logs').freeze
   HEADERS = begin
     JSON.parse(ENV['OPEN_RUNTIMES_HEADERS'] || '{}')
   rescue JSON::ParserError

--- a/runtimes/ruby/versions/latest/src/logger.rb
+++ b/runtimes/ruby/versions/latest/src/logger.rb
@@ -37,8 +37,10 @@ class RuntimeLogger
         @id = id
       end
 
-      @stream_logs = File.open("/mnt/logs/" + @id + "_logs.log", 'a')
-      @stream_errors = File.open("/mnt/logs/" + @id + "_errors.log", 'a')
+      unless Config::LOGS_DIRECTORY.empty?
+        @stream_logs = File.open(Config::LOGS_DIRECTORY + "/" + @id + "_logs.log", 'a')
+        @stream_errors = File.open(Config::LOGS_DIRECTORY + "/" + @id + "_errors.log", 'a')
+      end
     end
   end
 
@@ -81,7 +83,11 @@ class RuntimeLogger
     end
 
     begin
-      stream.write(string_log)
+      passthrough = type === RuntimeLogger::TYPE_ERROR ? STDERR : STDOUT
+      passthrough.write(string_log)
+      passthrough.flush
+
+      stream.write(string_log) unless stream.nil?
     rescue
       # Silently fail to prevent 500 errors in runtime
       # Log write failures should not crash the runtime
@@ -95,8 +101,8 @@ class RuntimeLogger
 
     @enabled = false
 
-    @stream_logs.close
-    @stream_errors.close
+    @stream_logs&.close
+    @stream_errors&.close
   end
 
   def override_native_logs()

--- a/runtimes/ruby/versions/latest/src/logger.rb
+++ b/runtimes/ruby/versions/latest/src/logger.rb
@@ -83,11 +83,11 @@ class RuntimeLogger
     end
 
     begin
+      stream.write(string_log) unless stream.nil?
+
       passthrough = type === RuntimeLogger::TYPE_ERROR ? STDERR : STDOUT
       passthrough.write(string_log)
       passthrough.flush
-
-      stream.write(string_log) unless stream.nil?
     rescue
       # Silently fail to prevent 500 errors in runtime
       # Log write failures should not crash the runtime

--- a/runtimes/ruby/versions/latest/src/logger.rb
+++ b/runtimes/ruby/versions/latest/src/logger.rb
@@ -82,15 +82,20 @@ class RuntimeLogger
       string_log += "... Log truncated due to size limit (8000 characters)"
     end
 
+    # Each sink is guarded on its own so one failing never drops the other
     begin
-      stream.write(string_log) unless stream.nil?
-
       passthrough = type === RuntimeLogger::TYPE_ERROR ? STDERR : STDOUT
       passthrough.write(string_log)
       passthrough.flush
     rescue
       # Silently fail to prevent 500 errors in runtime
       # Log write failures should not crash the runtime
+    end
+
+    begin
+      stream.write(string_log) unless stream.nil?
+    rescue
+      # Silently fail to prevent 500 errors in runtime
     end
   end
 

--- a/runtimes/swift/versions/latest/Sources/Runtime/OprConfig.swift
+++ b/runtimes/swift/versions/latest/Sources/Runtime/OprConfig.swift
@@ -3,6 +3,8 @@ import Foundation
 enum OprConfig {
     static let secret = ProcessInfo.processInfo.environment["OPEN_RUNTIMES_SECRET"] ?? ""
     static let env = ProcessInfo.processInfo.environment["OPEN_RUNTIMES_ENV"] ?? ""
+    static let logsDirectory = ProcessInfo.processInfo
+        .environment["OPEN_RUNTIMES_LOGS_DIRECTORY"] ?? "/mnt/logs"
 
     static let headers: [String: String] = {
         guard

--- a/runtimes/swift/versions/latest/Sources/Runtime/RuntimeLogger.swift
+++ b/runtimes/swift/versions/latest/Sources/Runtime/RuntimeLogger.swift
@@ -16,6 +16,8 @@ class RuntimeLogger {
         }
 
         if enabled {
+            let logsDirectory = OprConfig.logsDirectory
+
             if id == "" {
                 if OprConfig.env == "development" {
                     self.id = "dev"
@@ -26,8 +28,12 @@ class RuntimeLogger {
                 self.id = id
             }
 
-            let logsUrl = URL(fileURLWithPath: "/mnt/logs/" + self.id + "_logs.log")
-            let errorsUrl = URL(fileURLWithPath: "/mnt/logs/" + self.id + "_errors.log")
+            if logsDirectory == "" {
+                return
+            }
+
+            let logsUrl = URL(fileURLWithPath: logsDirectory + "/" + self.id + "_logs.log")
+            let errorsUrl = URL(fileURLWithPath: logsDirectory + "/" + self.id + "_errors.log")
 
             if !FileManager.default.fileExists(atPath: logsUrl.path) {
                 _ = FileManager.default.createFile(atPath: logsUrl.path, contents: nil, attributes: nil)
@@ -87,6 +93,11 @@ class RuntimeLogger {
         }
 
         if let stringLogTemp = stringLog.data(using: .utf8) {
+            let passthrough = type == RuntimeLogger.TYPE_ERROR
+                ? FileHandle.standardError
+                : FileHandle.standardOutput
+            passthrough.write(stringLogTemp)
+
             if let streamTemp = stream {
                 streamTemp.write(stringLogTemp)
             }

--- a/runtimes/swift/versions/latest/Sources/Runtime/RuntimeLogger.swift
+++ b/runtimes/swift/versions/latest/Sources/Runtime/RuntimeLogger.swift
@@ -93,14 +93,14 @@ class RuntimeLogger {
         }
 
         if let stringLogTemp = stringLog.data(using: .utf8) {
+            if let streamTemp = stream {
+                streamTemp.write(stringLogTemp)
+            }
+
             let passthrough = type == RuntimeLogger.TYPE_ERROR
                 ? FileHandle.standardError
                 : FileHandle.standardOutput
             passthrough.write(stringLogTemp)
-
-            if let streamTemp = stream {
-                streamTemp.write(stringLogTemp)
-            }
         }
     }
 

--- a/runtimes/swift/versions/latest/Sources/Runtime/RuntimeLogger.swift
+++ b/runtimes/swift/versions/latest/Sources/Runtime/RuntimeLogger.swift
@@ -93,14 +93,14 @@ class RuntimeLogger {
         }
 
         if let stringLogTemp = stringLog.data(using: .utf8) {
-            if let streamTemp = stream {
-                streamTemp.write(stringLogTemp)
-            }
-
             let passthrough = type == RuntimeLogger.TYPE_ERROR
                 ? FileHandle.standardError
                 : FileHandle.standardOutput
             passthrough.write(stringLogTemp)
+
+            if let streamTemp = stream {
+                streamTemp.write(stringLogTemp)
+            }
         }
     }
 


### PR DESCRIPTION
## What

Makes the file sink for execution logs configurable, and always mirrors logs to the container's stdout/stderr.

- **New env var `OPEN_RUNTIMES_LOGS_DIRECTORY`**, defaulting to `/mnt/logs`. Default behaviour is unchanged: per-request `<id>_logs.log` / `<id>_errors.log` are still written and flushed per request.
- **Empty value disables the file sink** entirely — no streams are opened, logs go only to stdout/stderr.
- **Passthrough to stdout/stderr is always on**, with no config knob: `context.log()` and captured native logs go to stdout, `context.error()` to stderr, in addition to the log files.

Applied to all 15 logger implementations in this repo: node, bun, deno, the shared JS/SSR logger, python, php, ruby, dart, java (latest/11.0/8.0), kotlin, dotnet, swift, cpp. Go and Rust get their loggers from external crates, so they're untouched here.

## Notes

- The passthrough deliberately writes to the *original* stream handles (`process.stdout`, `sys.__stdout__`, `STDOUT`, `FileHandle.standardOutput`, `fputs(..., stdout)`, and statics captured at class-load time in java/kotlin/dotnet). Every runtime swaps `console` / `System.out` / `$stdout` while executing user code to capture native logs — writing through those would put the passthrough straight back into the capture buffer.
- The directory is read via each runtime's existing config module. PHP passes it into `Logger`'s constructor; java 8.0/11.0 read the env inline, since their loggers predate `OprConfig`.
- `x-open-runtimes-logging: disabled` still suppresses everything, stdout included. "Always" here means "no config knob", not "overrides the disable header" — happy to change that if the intent is different.
- The directory must already exist (as `/mnt/logs` does in the base image); nothing mkdirs it.

## Testing

- `bun ci/test.ts node-latest` → 39/40. The single failure is `testHeadlessBrowser`, puppeteer's Chromium dying under x86 emulation on the dev machine (`Protocol error (Target.setDiscoverTargets): Target closed`), unrelated to this change. All logging tests pass, and `docker logs` now shows the function's own `Debug log` / `Error log` output.
- Manual runs against the built node image: a custom directory produced the expected `<id>_logs.log` / `<id>_errors.log`; an empty value left `/mnt/logs` empty with logs on stdout only, response still 200.
- Formatters clean where installable locally (biome for node/bun, `dart format`, `clang-format`, `swiftformat`), plus `php -l`, `node --check`, `ruby -c`, `py_compile`. ruff, ktlint, csharpier, google-java-format and `deno fmt` weren't available locally — CI's formatter step is the real check for those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)