### PR TITLE
Fix hanging PHP executions after fatal errors

### DIFF
--- a/ci/common.ts
+++ b/ci/common.ts
@@ -103,6 +103,9 @@ export function generateRuntimeObject(runtime: Runtime, key: string): Entry[] {
         if (runtime.entry_no_export) {
             profiles.push('no-export');
         }
+        if (runtimeFolder === 'php') {
+            profiles.push('php-fatal');
+        }
         if ((runtime.test ?? '').startsWith('SSR/') && ['node', 'bun', 'deno'].includes(runtimeFolder)) {
             profiles.push('cleanup-variants');
         }

--- a/runtimes/php/versions/latest/src/server.php
+++ b/runtimes/php/versions/latest/src/server.php
@@ -22,6 +22,50 @@ const USER_CODE_PATH = '/usr/local/server/src/function';
 
 $config = new Config();
 $userFunction = null;
+$activeRequests = [];
+
+$fatalShutdownHandler = function () use (&$activeRequests): void {
+    $error = \error_get_last();
+    $fatalTypes = [E_ERROR, E_PARSE, E_CORE_ERROR, E_COMPILE_ERROR, E_USER_ERROR];
+
+    if ($error === null || !\in_array($error['type'], $fatalTypes, true)) {
+        return;
+    }
+
+    $message = \sprintf(
+        '%s in %s:%d',
+        $error['message'],
+        $error['file'],
+        $error['line']
+    );
+
+    // A fatal error terminates the worker, so none of its active requests can continue.
+    foreach ($activeRequests as $request) {
+        $logger = $request['logger'];
+        $response = $request['response'];
+
+        try {
+            $logger->write([$message], Logger::TYPE_ERROR);
+        } catch (\Throwable) {
+        }
+
+        try {
+            $logger->end();
+        } catch (\Throwable) {
+        }
+
+        try {
+            $response->header('x-open-runtimes-log-id', $logger->id);
+            $response->status(500);
+            $response->end('');
+        } catch (\Throwable) {
+        }
+    }
+};
+
+$server->on('WorkerStart', function () use ($fatalShutdownHandler): void {
+    \register_shutdown_function($fatalShutdownHandler);
+});
 
 $action = function (Logger $logger, mixed $req, mixed $res) use (&$userFunction, $config) {
     $requestHeaders = $req->header;
@@ -217,7 +261,7 @@ $action = function (Logger $logger, mixed $req, mixed $res) use (&$userFunction,
     $res->end($output['body']);
 };
 
-$server->on("Request", function ($req, $res) use ($action, $config) {
+$server->on("Request", function ($req, $res) use ($action, $config, &$activeRequests) {
     if ($req->server['path_info'] === '/__opr/health') {
         $res->status(200);
         $res->end('OK');
@@ -232,6 +276,11 @@ $server->on("Request", function ($req, $res) use ($action, $config) {
     }
 
     $logger = new Logger($req->header['x-open-runtimes-logging'] ?? '', $req->header['x-open-runtimes-log-id'] ?? '', $config->env);
+    $requestId = \spl_object_id($res);
+    $activeRequests[$requestId] = [
+        'logger' => $logger,
+        'response' => $res,
+    ];
 
     try {
         $action($logger, $req, $res);
@@ -247,6 +296,8 @@ $server->on("Request", function ($req, $res) use ($action, $config) {
 
         $res->status(500);
         $res->end('');
+    } finally {
+        unset($activeRequests[$requestId]);
     }
 });
 

--- a/tests/Serverless/PHP.php
+++ b/tests/Serverless/PHP.php
@@ -34,7 +34,7 @@ class PHP extends Serverless
         self::assertArrayHasKey('x-open-runtimes-log-id', $response['headers']);
 
         $errors = Client::getErrors($response['headers']['x-open-runtimes-log-id']);
-        self::assertStringContainsString('Cannot redeclare FatalErrorFixture::updateMFA()', $errors);
+        self::assertStringContainsString('Cannot redeclare FatalErrorFixture::HANDLER()', $errors);
         self::assertStringContainsString('fatal.php', $errors);
     }
 }

--- a/tests/Serverless/PHP.php
+++ b/tests/Serverless/PHP.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Serverless;
 
+use Tests\Client;
 use Tests\Serverless;
 
 class PHP extends Serverless
@@ -9,5 +10,31 @@ class PHP extends Serverless
     public function testSetCookie(): void
     {
         self::assertTrue(true); // Disable test till implemented
+    }
+
+    public function testFatalError(): void
+    {
+        Client::$host = 'open-runtimes-test-serve-php-fatal';
+
+        try {
+            $response = Client::execute(
+                headers: [
+                    'x-action' => 'fatalError',
+                    'x-open-runtimes-logging' => 'enabled',
+                ],
+                timeout: 2,
+            );
+        } finally {
+            Client::$host = 'open-runtimes-test-serve';
+        }
+
+        self::assertNull($response['errorNumber']);
+        self::assertEquals(500, $response['code']);
+        self::assertEmpty($response['body']);
+        self::assertArrayHasKey('x-open-runtimes-log-id', $response['headers']);
+
+        $errors = Client::getErrors($response['headers']['x-open-runtimes-log-id']);
+        self::assertStringContainsString('Cannot redeclare FatalErrorFixture::updateMFA()', $errors);
+        self::assertStringContainsString('fatal.php', $errors);
     }
 }

--- a/tests/compose.yaml
+++ b/tests/compose.yaml
@@ -151,6 +151,21 @@ services:
       - ./.runtime/no-export-build/src/code.tar.gz:/mnt/code/code.tar.gz:ro
     command: ['bash', '-c', 'bash helpers/start.sh "$$START_COMMAND"']
 
+  # PHP fatal-error variant. Kept separate because the test intentionally kills a worker.
+  serve-php-fatal:
+    <<: *runtime
+    profiles: [php-fatal]
+    container_name: open-runtimes-test-serve-php-fatal
+    environment:
+      <<: *serve-env
+      OPEN_RUNTIMES_ENV: production
+      OPEN_RUNTIMES_ENTRYPOINT: ${ENTRYPOINT}
+    volumes:
+      - ./resources/telemetry:/mnt/telemetry
+      - /tmp/logs:/mnt/logs
+      - ./.runtime/code.tar.gz:/mnt/code/code.tar.gz:ro
+    command: ['bash', '-c', 'bash helpers/start.sh "$$START_COMMAND"']
+
   phpunit:
     image: phpswoole/swoole:5.1.2-php8.3-alpine
     platform: ${TEST_PLATFORM:-linux/x86_64}

--- a/tests/resources/functions/php/latest/fatal.php
+++ b/tests/resources/functions/php/latest/fatal.php
@@ -2,7 +2,7 @@
 
 class FatalErrorFixture
 {
-    public function updateMfa(): void {}
+    public function handler(): void {}
 
-    public function updateMFA(): void {}
+    public function HANDLER(): void {}
 }

--- a/tests/resources/functions/php/latest/fatal.php
+++ b/tests/resources/functions/php/latest/fatal.php
@@ -1,0 +1,8 @@
+<?php
+
+class FatalErrorFixture
+{
+    public function updateMfa(): void {}
+
+    public function updateMFA(): void {}
+}

--- a/tests/resources/functions/php/latest/tests.php
+++ b/tests/resources/functions/php/latest/tests.php
@@ -169,6 +169,8 @@ When you can have two!
         case 'errorTest':
             $context->log('Before error...');
             throw new Exception('Error!');
+        case 'fatalError':
+            require __DIR__.'/fatal.php';
         default:
             throw new Exception('Unknown action');
     }


### PR DESCRIPTION
## Summary

- track active PHP execution responses and loggers per Swoole worker
- handle uncatchable PHP fatal shutdowns by writing execution errors and returning HTTP 500 with `x-open-runtimes-log-id`
- add an isolated PHP fatal-error test service and regression fixture

## Why

PHP engine fatals such as `E_COMPILE_ERROR` bypass the existing `Throwable` handlers. The worker exits before finalizing the response, leaving upstream clients waiting until their timeout and putting the error only in container output.

The shutdown handler runs while the worker still owns its active responses. It completes all requests affected by the terminating worker, while normal requests are removed from the registry in `finally`.

Closes #545.

## Tests

- `make format ID=php`
- `bun ci/test.ts php-8.4 --skip-image --skip-formatter`
- `bun ci/test.ts php-8.0 --skip-formatter`

Both PHP 8.4/Swoole 6.1.1 and PHP 8.0/Swoole 4.7.0 completed 40 tests with 355 assertions.
