### PR TITLE
fix(node): size the SSR heap ceiling from the memory allocation

### DIFF
--- a/runtimes/node/versions/latest/helpers/javascript-runner/env.sh
+++ b/runtimes/node/versions/latest/helpers/javascript-runner/env.sh
@@ -6,5 +6,17 @@
 # NODE_OPTIONS       — ensures user-owned http.createServer flows inherit the
 #                      Open Runtimes contract via src/ssr/injections.mjs
 
-export OPR_JAVASCRIPT_RUNNER="node"
+# Left to itself, V8 derives its old-space ceiling from the cgroup limit and
+# lands at roughly half of it, so an SSR site can only reach ~1 GB of heap on a
+# 2 GB allocation before dying with "Ineffective mark-compacts near heap limit"
+# while half its memory sits unused. Size the ceiling from the allocation
+# instead, holding 20% back for the non-heap side (code, buffers, native
+# allocations) so V8 hits its own GC ceiling first — the kernel OOM killer
+# would take the process down with no JS stack trace to debug from.
+#
+# Functions get this via --max_old_space_size in OPEN_RUNTIMES_SERVER_COMMAND
+# (runtimes/node/Dockerfile); SSR entries never go through that command.
+heap_mb="$(echo "$OPEN_RUNTIMES_MEMORY" | awk '{ mb = int($1 * 0.8) } END { print (mb > 0 ? mb : 1638) }')"
+
+export OPR_JAVASCRIPT_RUNNER="node --max_old_space_size=$heap_mb"
 export NODE_OPTIONS='--import "/usr/local/server/src/ssr/injections.mjs"'


### PR DESCRIPTION
Closes #547

## Problem

SSR entries launch through `OPR_JAVASCRIPT_RUNNER`, which was a bare `node`. V8 then derives its old-space ceiling from the cgroup limit and settles at roughly half of it, so a site provisioned 2 GB dies at ~1 GB of heap:

```
[40:0x...] 2511991 ms: Mark-Compact (reduce) 1020.1 (1034.7) -> 1020.0 (1034.4) MB
FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory
```

Half the memory the site was provisioned is unreachable. Found on a production TanStack Start site crash-looping every ~40 minutes on `openruntimes/node:v5-22` with a 2 GiB limit.

Functions are unaffected — their launch command carries `--max_old_space_size=8192` (`runtimes/node/Dockerfile:56`) — but SSR entries never go through `OPEN_RUNTIMES_SERVER_COMMAND`, so the flag never reached them. Every framework helper under `runtimes/javascript/helpers/*/server.sh` shares this runner, so all of them were affected.

## Change

Derive the ceiling from `OPEN_RUNTIMES_MEMORY`, which the orchestrator already exports and which had no consumer in the repo until now:

```bash
heap_mb="$(echo "$OPEN_RUNTIMES_MEMORY" | awk '{ mb = int($1 * 0.8) } END { print (mb > 0 ? mb : 1638) }')"
export OPR_JAVASCRIPT_RUNNER="node --max_old_space_size=$heap_mb"
```

20% is held back for the non-heap side (code, buffers, native allocations) so V8 reaches its own GC ceiling first. Going to 100% would just hand the kill to the kernel OOM killer, which takes the process down with no JS stack trace to debug from.

## Verification

Fallback covers unset and unparseable values, so no environment ends up with `--max_old_space_size=0` (which V8 reads as "use the default"):

| `OPEN_RUNTIMES_MEMORY` | heap |
|---|---|
| `2048` | 1638 |
| `512` | 409 |
| `4096` | 3276 |
| unset | 1638 |
| `abc` | 1638 |

And Node honours it (`node --max_old_space_size=1638` reports a 1734 MB limit including semi-space, vs 4192 MB by default on the test host).

## Notes for review

- **The 80% figure is the main judgement call here** and I'd welcome a second opinion. It's a guess at a reasonable non-heap reserve, not a measured value.
- Bun and Deno set their own `OPR_JAVASCRIPT_RUNNER` and are left alone. Deno would take `--v8-flags=--max-old-space-size=...`; Bun does not use V8. Happy to fold either in if wanted.
- Functions keeping a flat `8192` regardless of allocation is arguably the same bug in the other direction, though benign in practice since the cgroup limit bounds it. Left out of scope.
