### PR TITLE
fix(lifecycle): propagate the server's exit status past the telemetry reader

### DIFF
--- a/helpers/lifecycle/start.sh
+++ b/helpers/lifecycle/start.sh
@@ -30,7 +30,11 @@ opr_success "Runtime started."
 start_uptime=$(opr_uptime)
 export start_uptime
 
-# Run server and monitor stdout for ready message
+# Run server and monitor stdout for ready message.
+# The reader is the last command in the pipeline, so its exit status is the
+# one bash reports — a server that crashes would otherwise leave the container
+# exiting 0 ("Completed"), indistinguishable from a clean shutdown. Take the
+# server's status off PIPESTATUS and exit with it instead.
 bash -c "$1" 2>&1 | {
 	recorded=false
 	while IFS= read -r line; do
@@ -43,3 +47,5 @@ bash -c "$1" 2>&1 | {
 		fi
 	done
 }
+
+exit "${PIPESTATUS[0]}"


### PR DESCRIPTION
Closes #548

## Problem

`helpers/lifecycle/start.sh` pipes the server into a reader that watches stdout for the ready marker. Bash reports the exit status of the *last* command in a pipeline, so the reader's `0` is what surfaced. A server that crashed — OOM, SIGABRT, uncaught exception — exited the container with `0`, and Kubernetes recorded:

```
lastState: {"terminated": {"exitCode": 0, "reason": "Completed", ...}}
```

`set -e` does not catch this, because the pipeline as a whole succeeded.

Consequences: orchestrators cannot distinguish a crash from a clean shutdown, restart policies and alerting keyed on non-zero exit never fire, and an out-of-memory kill looks like any other failure — in the case that turned this up, a Node heap OOM surfaced to the user as a generic *"The runtime crashed while starting. Check the deployment logs and redeploy."* with no mention of memory, discoverable only by reading the previous container's logs by hand.

## Change

Take the server's status off `PIPESTATUS` and exit with it. One line, plus a comment recording why the obvious reading of the pipeline is wrong.

I went with `PIPESTATUS` over `set -o pipefail` to keep the change scoped to this pipeline — `start.sh` sources `extract.sh` and the per-runtime hooks, and enabling `pipefail` for the whole script would change their behaviour too. `extract.sh:35` already reaches for a scoped `set -o pipefail` subshell for the same reason.

## Verification

Ran the patched tail of the script against a stub server (`/proc/uptime` stubbed, as the test host is macOS):

| server behaviour | before | after |
|---|---|---|
| `kill -ABRT $$` (SIGABRT) | `0` | `134` |
| `exit 3` | `0` | `3` |
| clean exit, ready marker seen | `0` | `0` |

Crash output still drains to stdout before the container exits, so the tail of a crash log — a V8 stack trace, for instance — is not lost. Startup telemetry still records (`startup=12345.670` written on the clean-exit run).
