### PR TITLE
feat: add bun 1.4 runtime

### DIFF
--- a/ci/runtimes.toml
+++ b/ci/runtimes.toml
@@ -168,7 +168,7 @@ test = "Serverless/Go.php"
 [bun]
 entry = "tests.ts"
 entry_no_export = "no-export.ts"
-versions = ["1.3", "1.2", "1.1", "1.0"]
+versions = ["1.4", "1.3", "1.2", "1.1", "1.0"]
 commands = { install = "bun install", start = "bash helpers/server.sh" }
 formatter = { prepare = "echo \"Using bunx biome formatter\"", check = "bunx @biomejs/biome format .", write = "bunx @biomejs/biome format --write ." }
 tools = "bun --version && npm --version && npx --version && pnpm --version && yarn --version && modclean --version"
@@ -445,6 +445,7 @@ platforms = ["linux/amd64"]
 "1.23" = { base = "golang:1.23.12-alpine3.22" }
 
 [bun.build.versions]
+"1.4" = { base = "oven/bun:1.4.0-alpine", args = { NPM_VERSION = "12.0.2" } }
 "1.3" = { base = "oven/bun:1.3.8-alpine", args = { NPM_VERSION = "12.0.2" } }
 "1.2" = { base = "oven/bun:1.2.23-alpine", args = { NPM_VERSION = "10.9.9" } }
 "1.1" = { base = "oven/bun:1.1.45-alpine", args = { NPM_VERSION = "10.9.9" } }

--- a/docker-bake.json
+++ b/docker-bake.json
@@ -171,6 +171,7 @@
     },
     "bun": {
       "targets": [
+        "bun-1_4",
         "bun-1_3",
         "bun-1_2",
         "bun-1_1",
@@ -2281,6 +2282,30 @@
     },
     "_bun": {
       "dockerfile-inline": "# syntax=docker/dockerfile:1\n# INCLUDE directives below are resolved by `bun ci/bake.ts`, which inlines the\n# referenced *.dockerfile fragments into docker-bake.json (dockerfile-inline).\nARG BASE_IMAGE\nFROM $${BASE_IMAGE}\n\nLABEL maintainer=\"team@appwrite.io\"\nLABEL namespace=\"open-runtimes\"\n\nENV OPEN_RUNTIMES_SECRET=open_runtime_secret\nENV OPEN_RUNTIMES_ENV=production\nENV OPEN_RUNTIMES_HEADERS=\"{}\"\n\nRUN <<EOR\n    if [ -f /etc/alpine-release ]; then\n        apk add --no-cache util-linux zstd squashfs-tools\n    else\n        apt-get update && apt-get install -y util-linux zstd squashfs-tools\n    fi\nEOR\n\nRUN mkdir -p /mnt/code /mnt/logs /mnt/telemetry /usr/local/build /usr/local/server/src/function\n\nWORKDIR /usr/local/server\n\n# Assemble /usr/local/server from named build contexts, in overlay precedence\n# order (later layers overwrite earlier ones):\n#   1. helpers  -> repo helpers/ (global lifecycle runner + shims)\n#   2. shared   -> runtimes/<shared family>/ (e.g. javascript/ for node), or empty\n#   3. latest   -> runtimes/<runtime>/versions/latest/\n#   4. version  -> runtimes/<runtime>/versions/<version>/ extras, or empty\nCOPY --from=helpers . /usr/local/server/helpers/\nCOPY --from=shared . /usr/local/server/\nCOPY --from=latest . /usr/local/server/\nCOPY --from=version . /usr/local/server/\nRUN rm -f /usr/local/server/.gitkeep /usr/local/server/Dockerfile /usr/local/server/build.dockerfile\n\nENV OPEN_RUNTIMES_ENTRYPOINT=index.ts\n# Bun 1.0 arm64 includes glibc, whose /usr/lib/libc.so conflicts with musl-dev from g++.\nRUN APK_ADD_FLAGS=\"\" \\\n  && if apk info -e glibc > /dev/null 2>&1; then APK_ADD_FLAGS=\"--force-overwrite\"; fi \\\n  && apk add --no-cache $${APK_ADD_FLAGS} bash npm nss font-noto ca-certificates python3 make g++ gcc git\nARG NPM_VERSION\nRUN npm install npm@$${NPM_VERSION} -g && \\\n  hash -r && \\\n  test \"$(npm --version)\" = \"$${NPM_VERSION}\" && \\\n  test \"$(npx --version)\" = \"$${NPM_VERSION}\" && \\\n  rm -rf /root/.npm\nRUN npm install pnpm@9.15.9 yarn modclean@2.1.2 -g\nRUN bun install && npm install --no-save --prefix /usr/local/server @vercel/nft@^0.29.2\n\nENV OPEN_RUNTIMES_SERVER_COMMAND=\"bun src/server.ts\"\n\nRUN chmod -R +x /usr/local/server/helpers\n\nEXPOSE 3000\n"
+    },
+    "bun-1_4": {
+      "inherits": [
+        "_base",
+        "_bun"
+      ],
+      "contexts": {
+        "helpers": "./helpers",
+        "shared": "./runtimes/javascript",
+        "latest": "./runtimes/bun/versions/latest",
+        "version": "./docker/empty"
+      },
+      "args": {
+        "BASE_IMAGE": "oven/bun:1.4.0-alpine",
+        "NPM_VERSION": "12.0.2"
+      },
+      "platforms": [
+        "linux/amd64",
+        "linux/arm64"
+      ],
+      "tags": [
+        "${REGISTRY}/bun:v5-1.4${TAG_SUFFIX}",
+        "${REGISTRY}/bun:v5-1.4${TAG_SUFFIX}${SHA_SUFFIX}"
+      ]
     },
     "bun-1_3": {
       "inherits": [


### PR DESCRIPTION
## Summary
- Add Bun 1.4 (`oven/bun:1.4.0-alpine`), released 2026-08-20

Bun 1.4 brings Node.js 26.3.0 compatibility (1,517 newly passing tests), parallel test/run, and Windows ARM64. Release notes: https://bun.com/blog/bun-v1.4

Both edits follow the existing pattern — `versions` array plus a `[bun.build.versions]` entry copying the arg shape of `1.3`. `NPM_VERSION` stays `12.0.2` (still the latest published npm). `docker-bake.json` is regenerated via `bun ci/bake.ts`, not hand-edited.

No new test fixtures or version overlay needed — bun uses `versions/latest` only, and the test suite has no version-specific branching.

## Test plan
- [x] `bun ci/bake.ts --check` clean
- [x] `docker buildx bake bun-1_4` builds successfully
- [x] Tools contract (`bun`/`npm`/`npx`/`pnpm`/`yarn`/`modclean` versions) — could not run locally, leaving to CI