### PR TITLE
feat: add flutter 3.47 runtime

### DIFF
--- a/ci/runtimes.toml
+++ b/ci/runtimes.toml
@@ -78,7 +78,7 @@ test = "Serverless/Dart.php"
 
 [flutter]
 report_size = false
-versions = ["3.44", "3.41", "3.38", "3.35", "3.32", "3.29", "3.27", "3.24"]
+versions = ["3.47", "3.44", "3.41", "3.38", "3.35", "3.32", "3.29", "3.27", "3.24"]
 commands = { install = "flutter build web", start = "bash helpers/server.sh" }
 formatter = { prepare = "echo \"Using native formatter\"", check = "dart format -o none --set-exit-if-changed .", write = "dart format ." }
 test = "CSR/Flutter.php"
@@ -376,6 +376,7 @@ image = "python-ml"
 "2.16" = { base = "dart:2.16.2" }
 
 [flutter.build.versions]
+"3.47" = { base = "ghcr.io/adrianjagielak/flutter:3.47.1" }
 "3.44" = { base = "ghcr.io/adrianjagielak/flutter:3.44.6" }
 "3.41" = { base = "ghcr.io/cirruslabs/flutter:3.41.2" }
 "3.38" = { base = "ghcr.io/cirruslabs/flutter:3.38.9" }

--- a/docker-bake.json
+++ b/docker-bake.json
@@ -84,6 +84,7 @@
     },
     "flutter": {
       "targets": [
+        "flutter-3_47",
         "flutter-3_44",
         "flutter-3_41",
         "flutter-3_38",
@@ -1166,6 +1167,29 @@
     },
     "_flutter": {
       "dockerfile-inline": "# syntax=docker/dockerfile:1\n# INCLUDE directives below are resolved by `bun ci/bake.ts`, which inlines the\n# referenced *.dockerfile fragments into docker-bake.json (dockerfile-inline).\nARG BASE_IMAGE\nFROM $${BASE_IMAGE}\n\nLABEL maintainer=\"team@appwrite.io\"\nLABEL namespace=\"open-runtimes\"\n\nENV OPEN_RUNTIMES_SECRET=open_runtime_secret\nENV OPEN_RUNTIMES_ENV=production\nENV OPEN_RUNTIMES_HEADERS=\"{}\"\n\nRUN <<EOR\n    if [ -f /etc/alpine-release ]; then\n        apk add --no-cache util-linux zstd squashfs-tools\n    else\n        apt-get update && apt-get install -y util-linux zstd squashfs-tools\n    fi\nEOR\n\nRUN mkdir -p /mnt/code /mnt/logs /mnt/telemetry /usr/local/build /usr/local/server/src/function\n\nWORKDIR /usr/local/server\n\n# Assemble /usr/local/server from named build contexts, in overlay precedence\n# order (later layers overwrite earlier ones):\n#   1. helpers  -> repo helpers/ (global lifecycle runner + shims)\n#   2. shared   -> runtimes/<shared family>/ (e.g. javascript/ for node), or empty\n#   3. latest   -> runtimes/<runtime>/versions/latest/\n#   4. version  -> runtimes/<runtime>/versions/<version>/ extras, or empty\nCOPY --from=helpers . /usr/local/server/helpers/\nCOPY --from=shared . /usr/local/server/\nCOPY --from=latest . /usr/local/server/\nCOPY --from=version . /usr/local/server/\nRUN rm -f /usr/local/server/.gitkeep /usr/local/server/Dockerfile /usr/local/server/build.dockerfile\n\nRUN apt-get update && apt-get install -y bash jq\n\nRUN dart --disable-analytics\n\nRUN chmod -R +x /usr/local/server/helpers\n\nEXPOSE 3000\n\n# Enable web platform\nRUN flutter config --enable-web\n"
+    },
+    "flutter-3_47": {
+      "inherits": [
+        "_base",
+        "_flutter"
+      ],
+      "contexts": {
+        "helpers": "./helpers",
+        "shared": "./docker/empty",
+        "latest": "./runtimes/flutter/versions/latest",
+        "version": "./docker/empty"
+      },
+      "args": {
+        "BASE_IMAGE": "ghcr.io/adrianjagielak/flutter:3.47.1"
+      },
+      "platforms": [
+        "linux/amd64",
+        "linux/arm64"
+      ],
+      "tags": [
+        "${REGISTRY}/flutter:v5-3.47${TAG_SUFFIX}",
+        "${REGISTRY}/flutter:v5-3.47${TAG_SUFFIX}${SHA_SUFFIX}"
+      ]
     },
     "flutter-3_44": {
       "inherits": [


### PR DESCRIPTION
## Summary
- Add Flutter 3.47 (`ghcr.io/adrianjagielak/flutter:3.47.1`), released 2026-08-19

Flutter 3.47.1 bundles Dart 3.13.1, so this pairs with #552, which adds the matching Dart runtime.

Config-only, following the existing pattern — `"3.47"` prepended to the `[flutter]` `versions` array and a matching `[flutter.build.versions]` entry. `docker-bake.json` is regenerated via `bun ci/bake.ts`, not hand-edited; the resulting `flutter-3_47` target is field-identical to `flutter-3_44` apart from `BASE_IMAGE` and the `v5-3.47` tags.

No version overlay directory is needed — `runtimes/flutter/versions/` contains only `latest`, and the generated target correctly points its `version` context at `./docker/empty`, matching `flutter-3_44`.

### On the base image registry

This stays on `ghcr.io/adrianjagielak/flutter` rather than moving back to cirruslabs, because cirruslabs no longer publishes usable tags. Its `flutter` package stops at `3.44.0` and has **nothing at all** for 3.45, 3.46 or 3.47 — only `.pre` beta tags beyond 3.44. `adrianjagielak` is currently the only registry shipping stable Flutter images, which is why 3.44 was switched to it in #496.

Base image verified live: `ghcr.io/adrianjagielak/flutter:3.47.1` returns an OCI image index with `linux/amd64` and `linux/arm64` manifests, covering the platforms the bake target declares.

## Test plan
- [x] `bun ci/bake.ts --check` clean
- [x] `flutter-3_47` target present in `docker-bake.json`, and `versions` / `[flutter.build.versions]` lists in sync (`ci/bake.ts` exits non-zero on drift)
- [x] Merges cleanly with #552 — `git merge-tree` reports no conflict, and `bun ci/bake.ts --check` passes on the merged tree, so whichever lands second does **not** need the bake file regenerated
- [ ] `make test ID=flutter-3.47` — **could not run locally**, leaving to CI. This host has no `docker buildx` plugin and the daemon is inactive, so the bake command fails before any image is built. Confirmed environmental rather than caused by this change: `make test ID=dart-3.12`, an untouched existing version, fails with the byte-identical error.