### PR TITLE
feat(ci): measure server startup time and report it on PRs

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -178,7 +178,9 @@ jobs:
               if (!fs.existsSync(file)) continue;
               try {
                 fresh[dir.replace(/^startup-metrics-/, '')] = JSON.parse(fs.readFileSync(file, 'utf8'));
-              } catch {}
+              } catch (e) {
+                console.warn(`Skipping unreadable metrics file ${file}: ${e.message}`);
+              }
             }
             if (Object.keys(fresh).length === 0) return;
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -102,45 +102,13 @@ jobs:
         timeout-minutes: 15
         working-directory: ./
         run: bun ci/test.ts ${{ matrix.ID }}
-      - name: Report startup time
+      - name: Upload startup metrics
         if: always()
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          script: |
-            const fs = require('fs');
-            if (!fs.existsSync('/tmp/startup-metrics.json')) return;
-            const metrics = JSON.parse(fs.readFileSync('/tmp/startup-metrics.json', 'utf8'));
-            if (!metrics.cold_start) return;
-
-            const marker = '<!-- startup-time-check ';
-            const id = '${{ matrix.ID }}';
-            const pr = context.payload.pull_request.number;
-            const fmt = (v) => typeof v === 'number' ? v.toFixed(2) + ' s' : '—';
-
-            for (let attempt = 0; attempt < 5; attempt++) {
-              if (attempt > 0)
-                await new Promise(r => setTimeout(r, Math.floor(Math.random() * 5000) + 2000));
-
-              const { data: comments } = await github.rest.issues.listComments({ ...context.repo, issue_number: pr });
-              const comment = comments.find(c => c.body?.includes(marker));
-
-              const b64 = comment?.body?.match(/<!-- startup-time-check (.+?) -->/)?.[1];
-              const state = b64 ? JSON.parse(Buffer.from(b64, 'base64').toString()) : {};
-              state[id] = metrics;
-
-              const encoded = Buffer.from(JSON.stringify(state)).toString('base64');
-              let body = `<!-- startup-time-check ${encoded} -->\n## Server Startup Times\n\nCold start is the wall time from container start until \`/__opr/health\` responds; the breakdown comes from \`/__opr/timings\`.\n\n| Runtime | Cold start | Extract | Prepare | Server boot |\n|---------|-----------|---------|---------|-------------|\n`;
-              for (const [n, m] of Object.entries(state).sort((a, b) => a[0].localeCompare(b[0]))) body += `| \`${n}\` | ${fmt(m.cold_start)} | ${fmt(m.extract)} | ${fmt(m.prepare)} | ${fmt(m.startup)} |\n`;
-
-              if (comment)
-                await github.rest.issues.updateComment({ ...context.repo, comment_id: comment.id, body });
-              else
-                await github.rest.issues.createComment({ ...context.repo, issue_number: pr, body });
-
-              await new Promise(r => setTimeout(r, 1000));
-              const { data: verify } = await github.rest.issues.listComments({ ...context.repo, issue_number: pr });
-              if (verify.find(c => c.body?.includes(marker))?.body?.includes(`\`${id}\``)) break;
-            }
+          name: startup-metrics-${{ matrix.ID }}
+          path: /tmp/startup-metrics.json
+          if-no-files-found: ignore
       - name: Report image size
         if: always() && matrix.REPORT_SIZE
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
@@ -179,3 +147,57 @@ jobs:
               const { data: verify } = await github.rest.issues.listComments({ ...context.repo, issue_number: pr });
               if (verify.find(c => c.body?.includes(marker))?.body?.includes(id)) break;
             }
+
+  # Aggregates the per-runtime startup metrics after every matrix job finishes.
+  # A single writer avoids the read-modify-write races a per-job comment update
+  # would have; the base64 marker carries rows forward across pushes that only
+  # re-test a subset of runtimes.
+  report-startup-time:
+    needs: open-runtimes
+    if: always()
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Download startup metrics
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          pattern: startup-metrics-*
+          path: startup-metrics
+      - name: Report startup time
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        with:
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+
+            const fresh = {};
+            const root = 'startup-metrics';
+            for (const dir of fs.existsSync(root) ? fs.readdirSync(root) : []) {
+              const file = path.join(root, dir, 'startup-metrics.json');
+              if (!fs.existsSync(file)) continue;
+              try {
+                fresh[dir.replace(/^startup-metrics-/, '')] = JSON.parse(fs.readFileSync(file, 'utf8'));
+              } catch {}
+            }
+            if (Object.keys(fresh).length === 0) return;
+
+            const marker = '<!-- startup-time-check ';
+            const pr = context.payload.pull_request.number;
+            const comments = await github.paginate(github.rest.issues.listComments, { ...context.repo, issue_number: pr, per_page: 100 });
+            const comment = comments.find(c => c.body?.includes(marker));
+
+            const b64 = comment?.body?.match(/<!-- startup-time-check (.+?) -->/)?.[1];
+            let state = {};
+            try { state = b64 ? JSON.parse(Buffer.from(b64, 'base64').toString()) : {}; } catch {}
+            Object.assign(state, fresh);
+
+            const fmt = (v) => typeof v === 'number' ? v.toFixed(2) + ' s' : '—';
+            const encoded = Buffer.from(JSON.stringify(state)).toString('base64');
+            let body = `<!-- startup-time-check ${encoded} -->\n## Server Startup Times\n\nCold start is the wall time from container start until \`/__opr/health\` responds; the breakdown comes from \`/__opr/timings\`.\n\n| Runtime | Cold start | Extract | Prepare | Server boot |\n|---------|-----------|---------|---------|-------------|\n`;
+            for (const [n, m] of Object.entries(state).sort((a, b) => a[0].localeCompare(b[0]))) body += `| \`${n}\` | ${fmt(m.cold_start)} | ${fmt(m.extract)} | ${fmt(m.prepare)} | ${fmt(m.startup)} |\n`;
+
+            if (comment)
+              await github.rest.issues.updateComment({ ...context.repo, comment_id: comment.id, body });
+            else
+              await github.rest.issues.createComment({ ...context.repo, issue_number: pr, body });

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -102,6 +102,45 @@ jobs:
         timeout-minutes: 15
         working-directory: ./
         run: bun ci/test.ts ${{ matrix.ID }}
+      - name: Report startup time
+        if: always()
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        with:
+          script: |
+            const fs = require('fs');
+            if (!fs.existsSync('/tmp/startup-metrics.json')) return;
+            const metrics = JSON.parse(fs.readFileSync('/tmp/startup-metrics.json', 'utf8'));
+            if (!metrics.cold_start) return;
+
+            const marker = '<!-- startup-time-check ';
+            const id = '${{ matrix.ID }}';
+            const pr = context.payload.pull_request.number;
+            const fmt = (v) => typeof v === 'number' ? v.toFixed(2) + ' s' : '—';
+
+            for (let attempt = 0; attempt < 5; attempt++) {
+              if (attempt > 0)
+                await new Promise(r => setTimeout(r, Math.floor(Math.random() * 5000) + 2000));
+
+              const { data: comments } = await github.rest.issues.listComments({ ...context.repo, issue_number: pr });
+              const comment = comments.find(c => c.body?.includes(marker));
+
+              const b64 = comment?.body?.match(/<!-- startup-time-check (.+?) -->/)?.[1];
+              const state = b64 ? JSON.parse(Buffer.from(b64, 'base64').toString()) : {};
+              state[id] = metrics;
+
+              const encoded = Buffer.from(JSON.stringify(state)).toString('base64');
+              let body = `<!-- startup-time-check ${encoded} -->\n## Server Startup Times\n\nCold start is the wall time from container start until \`/__opr/health\` responds; the breakdown comes from \`/__opr/timings\`.\n\n| Runtime | Cold start | Extract | Prepare | Server boot |\n|---------|-----------|---------|---------|-------------|\n`;
+              for (const [n, m] of Object.entries(state).sort((a, b) => a[0].localeCompare(b[0]))) body += `| \`${n}\` | ${fmt(m.cold_start)} | ${fmt(m.extract)} | ${fmt(m.prepare)} | ${fmt(m.startup)} |\n`;
+
+              if (comment)
+                await github.rest.issues.updateComment({ ...context.repo, comment_id: comment.id, body });
+              else
+                await github.rest.issues.createComment({ ...context.repo, issue_number: pr, body });
+
+              await new Promise(r => setTimeout(r, 1000));
+              const { data: verify } = await github.rest.issues.listComments({ ...context.repo, issue_number: pr });
+              if (verify.find(c => c.body?.includes(marker))?.body?.includes(`\`${id}\``)) break;
+            }
       - name: Report image size
         if: always() && matrix.REPORT_SIZE
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7

--- a/ci/test.ts
+++ b/ci/test.ts
@@ -147,9 +147,13 @@ async function measureStartup(): Promise<void> {
     let ready = 0;
     while (ready === 0) {
         try {
-            await fetch(`${base}/__opr/health`, { headers, signal: AbortSignal.timeout(1000) });
-            ready = Date.now();
-            break;
+            // Any sub-500 response counts as ready: flutter's dhttpd has no
+            // health route (404) but is serving; 5xx means not healthy yet.
+            const response = await fetch(`${base}/__opr/health`, { headers, signal: AbortSignal.timeout(1000) });
+            if (response.status < 500) {
+                ready = Date.now();
+                break;
+            }
         } catch {
             // Server not accepting connections yet
         }

--- a/ci/test.ts
+++ b/ci/test.ts
@@ -11,7 +11,7 @@
 // tools -> build (+ variants by profile) -> serve trio -> startup metrics ->
 // phpunit -> down.
 
-import { existsSync, cpSync, rmSync, mkdirSync, writeFileSync, readdirSync } from 'fs';
+import { existsSync, cpSync, rmSync, mkdirSync, writeFileSync, readdirSync, readFileSync } from 'fs';
 import { join, dirname } from 'path';
 import { resolveEntry, type Entry } from './common';
 
@@ -171,16 +171,28 @@ async function measureStartup(): Promise<void> {
         cold_start: Number(((ready - startedAt) / 1000).toFixed(3)),
     };
 
-    try {
-        const timings = await (await fetch(`${base}/__opr/timings`, { headers, signal: AbortSignal.timeout(5000) })).text();
-        for (const line of timings.trim().split('\n')) {
-            const [key, value] = line.split('=', 2);
-            if (['extract', 'prepare', 'startup'].includes(key) && !Number.isNaN(parseFloat(value))) {
-                metrics[key] = parseFloat(value);
+    // The lifecycle scripts append extract/prepare/startup to the telemetry
+    // file all serve containers mount from the host. Read it directly rather
+    // than via /__opr/timings — static-serving runtimes (flutter, static)
+    // either lack the route or snapshot the file before the server boots.
+    // startup= lands only once the ready log line is processed, so allow it
+    // a moment to appear.
+    const telemetry = join(repoRoot, 'tests/resources/telemetry/timings.txt');
+    for (let attempt = 0; attempt < 10; attempt++) {
+        try {
+            for (const line of readFileSync(telemetry, 'utf8').trim().split('\n')) {
+                const [key, value] = line.split('=', 2);
+                if (['extract', 'prepare', 'startup'].includes(key) && !Number.isNaN(parseFloat(value))) {
+                    metrics[key] = parseFloat(value);
+                }
             }
+        } catch {
+            // Breakdown is best-effort; cold start alone is still worth reporting
         }
-    } catch {
-        // Breakdown is best-effort; cold start alone is still worth reporting
+        if ('startup' in metrics) {
+            break;
+        }
+        await Bun.sleep(200);
     }
 
     const summary = Object.entries(metrics).map(([key, value]) => `${key}=${value.toFixed(3)}s`).join(' ');

--- a/ci/test.ts
+++ b/ci/test.ts
@@ -8,7 +8,8 @@
 //   bun ci/test.ts node-25 --format-write  run formatters in write mode and exit
 //
 // Flow: bake image -> formatter check (latest only) -> stage fixtures ->
-// tools -> build (+ variants by profile) -> serve trio -> phpunit -> down.
+// tools -> build (+ variants by profile) -> serve trio -> startup metrics ->
+// phpunit -> down.
 
 import { existsSync, cpSync, rmSync, mkdirSync, writeFileSync, readdirSync } from 'fs';
 import { join, dirname } from 'path';
@@ -123,6 +124,69 @@ function stageVariant(variant: string): void {
     }
 }
 
+// Measure the primary serve container's startup: wall time from the container
+// start until /__opr/health responds, plus the extract/prepare/startup
+// breakdown the runtime reports on /__opr/timings. Results land in
+// /tmp/startup-metrics.json for the CI comment step; failures are left to
+// phpunit, which waits longer and reports container logs.
+async function measureStartup(): Promise<void> {
+    const port = process.env.HOST_PORT_MAIN ?? '3000';
+    const base = `http://127.0.0.1:${port}`;
+    const deadline = Date.now() + 120_000;
+
+    // The compose file sets OPEN_RUNTIMES_SECRET=test-secret-key on the main
+    // serve container; the static runtime gates every route (health included)
+    // behind basic auth, so authenticate and count any HTTP response as ready.
+    const secret = 'test-secret-key';
+    const headers = {
+        'x-open-runtimes-secret': secret,
+        'authorization': `Basic ${Buffer.from(`opr:${secret}`).toString('base64')}`,
+    };
+
+    let ready = 0;
+    while (ready === 0) {
+        try {
+            await fetch(`${base}/__opr/health`, { headers, signal: AbortSignal.timeout(1000) });
+            ready = Date.now();
+            break;
+        } catch {
+            // Server not accepting connections yet
+        }
+        if (Date.now() > deadline) {
+            console.warn('Startup measurement skipped: server not ready within 120s.');
+            return;
+        }
+        await Bun.sleep(50);
+    }
+
+    const inspect = Bun.spawnSync(['docker', 'inspect', '--format', '{{.State.StartedAt}}', 'open-runtimes-test-serve'], { env: composeEnv });
+    const startedAt = Date.parse(inspect.stdout.toString().trim());
+    if (Number.isNaN(startedAt)) {
+        console.warn('Startup measurement skipped: could not inspect container start time.');
+        return;
+    }
+
+    const metrics: Record<string, number> = {
+        cold_start: Number(((ready - startedAt) / 1000).toFixed(3)),
+    };
+
+    try {
+        const timings = await (await fetch(`${base}/__opr/timings`, { headers, signal: AbortSignal.timeout(5000) })).text();
+        for (const line of timings.trim().split('\n')) {
+            const [key, value] = line.split('=', 2);
+            if (['extract', 'prepare', 'startup'].includes(key) && !Number.isNaN(parseFloat(value))) {
+                metrics[key] = parseFloat(value);
+            }
+        }
+    } catch {
+        // Breakdown is best-effort; cold start alone is still worth reporting
+    }
+
+    const summary = Object.entries(metrics).map(([key, value]) => `${key}=${value.toFixed(3)}s`).join(' ');
+    console.log(`Startup metrics: ${summary}`);
+    writeFileSync('/tmp/startup-metrics.json', JSON.stringify(metrics));
+}
+
 function down(): void {
     Bun.spawnSync([...compose, 'down', '--remove-orphans'], { cwd: repoRoot, env: composeEnv });
     // Also remove any open-runtimes-* containers not created by compose
@@ -185,6 +249,9 @@ if (entry.COMPOSE_PROFILES.includes('cleanup-variants')) {
 
 console.log('Starting runtime servers ...');
 run([...compose, 'up', '-d']);
+
+console.log('Measuring startup time ...');
+await measureStartup();
 
 console.log('Running tests ...');
 run([...compose, 'run', '--rm', 'phpunit']);

--- a/ci/test.ts
+++ b/ci/test.ts
@@ -104,6 +104,7 @@ function stageFixtures(): void {
 
     rmSync('/tmp/logs', { recursive: true, force: true });
     mkdirSync('/tmp/logs', { recursive: true });
+    rmSync('/tmp/startup-metrics.json', { force: true });
 }
 
 // Variant build directories: copies of tests/.runtime, staged AFTER the main


### PR DESCRIPTION
## What

Measures how long each OPR server takes to become ready and posts the results as a PR comment, alongside the existing image-size report.

- `ci/test.ts` gains a `measureStartup()` step that runs right after `compose up -d`: it polls the primary serve container's `/__opr/health` (authenticated, since the static runtime gates every route behind basic auth) every 50ms and records **cold start** — wall time from the container's `StartedAt` until the first HTTP response. It then reads `/__opr/timings` for the breakdown the lifecycle scripts already record (`extract`, `prepare`, and `startup` — the server-boot time `helpers/lifecycle/start.sh` writes when the ready log line appears) and saves everything to `/tmp/startup-metrics.json`.
- The workflow posts/updates a single **Server Startup Times** comment per PR (same marker + retry/verify pattern as the image-size comment), one row per runtime in the matrix: cold start, extract, prepare, and server boot.

A missing measurement never fails the job — readiness failures are left to phpunit, which waits longer and dumps container logs.

## Example (measured locally)

| Runtime | Cold start | Extract | Prepare | Server boot |
|---------|-----------|---------|---------|-------------|
| `node-latest` | 2.17 s | 1.13 s | 0.00 s | 0.81 s |
| `static-1` | 0.68 s | 0.04 s | 0.01 s | — |

(Static shows — for server boot because it snapshots `timings.txt` into the served directory before the server starts.)

## Test plan

- `bun ci/test.ts static-1` and `bun ci/test.ts node` locally: metrics logged and written to `/tmp/startup-metrics.json`, full phpunit suite passes (the one node failure, `testHeadlessBrowser`, is x86 Chromium crashing under Rosetta emulation on an ARM host — unrelated, passes on CI's native runners).
- The comment step on this PR should populate the table for the runtimes CI selects.

Fixes CLO-4754 (first half — once we have a baseline from CI we can chase the easy wins).