### PR TITLE
perf(python): expose server-env via .pth instead of copying it

### DIFF
--- a/runtimes/python/versions/latest/hooks/server.sh
+++ b/runtimes/python/versions/latest/hooks/server.sh
@@ -14,7 +14,7 @@ if [ "$workers" -eq 0 ]; then
 fi
 
 echo "HTTP server successfully started!"
-python3 /usr/local/server/src/function/runtime-env/bin/gunicorn \
+python3 /usr/local/server/server-env/bin/gunicorn \
 	-b 0.0.0.0:3000 \
 	--log-level='warning' \
 	-w $workers \

--- a/runtimes/python/versions/latest/hooks/start-prepare.sh
+++ b/runtimes/python/versions/latest/hooks/start-prepare.sh
@@ -3,8 +3,9 @@
 set -e
 shopt -s dotglob
 
-# Copy contents of the server-env virtual env to the runtime-env virtual env
-cp -r /usr/local/server/server-env/* /usr/local/server/src/function/runtime-env
+# Hardlink the server-env virtual env into the runtime-env virtual env
+# (same filesystem, so -l makes this near-instant instead of a full copy)
+cp -rl /usr/local/server/server-env/* /usr/local/server/src/function/runtime-env
 
 # Activate virtual env
 source /usr/local/server/src/function/runtime-env/bin/activate

--- a/runtimes/python/versions/latest/hooks/start-prepare.sh
+++ b/runtimes/python/versions/latest/hooks/start-prepare.sh
@@ -3,10 +3,8 @@
 set -e
 shopt -s dotglob
 
-# Hardlink the server-env virtual env into the runtime-env virtual env
-# (same filesystem, so -l makes this near-instant instead of a full copy).
-# Pre-extracted deployments can resolve runtime-env onto a separate mount,
-# where hardlinks fail with EXDEV — fall back to a plain copy there.
+# Hardlink the server-env virtual env into runtime-env; fall back to a
+# copy when runtime-env resolves onto a different filesystem
 cp -rl /usr/local/server/server-env/* /usr/local/server/src/function/runtime-env 2>/dev/null ||
 	cp -r /usr/local/server/server-env/* /usr/local/server/src/function/runtime-env
 

--- a/runtimes/python/versions/latest/hooks/start-prepare.sh
+++ b/runtimes/python/versions/latest/hooks/start-prepare.sh
@@ -4,8 +4,11 @@ set -e
 shopt -s dotglob
 
 # Hardlink the server-env virtual env into the runtime-env virtual env
-# (same filesystem, so -l makes this near-instant instead of a full copy)
-cp -rl /usr/local/server/server-env/* /usr/local/server/src/function/runtime-env
+# (same filesystem, so -l makes this near-instant instead of a full copy).
+# Pre-extracted deployments can resolve runtime-env onto a separate mount,
+# where hardlinks fail with EXDEV — fall back to a plain copy there.
+cp -rl /usr/local/server/server-env/* /usr/local/server/src/function/runtime-env 2>/dev/null ||
+	cp -r /usr/local/server/server-env/* /usr/local/server/src/function/runtime-env
 
 # Activate virtual env
 source /usr/local/server/src/function/runtime-env/bin/activate

--- a/runtimes/python/versions/latest/hooks/start-prepare.sh
+++ b/runtimes/python/versions/latest/hooks/start-prepare.sh
@@ -3,10 +3,11 @@
 set -e
 shopt -s dotglob
 
-# Hardlink the server-env virtual env into runtime-env; fall back to a
-# copy when runtime-env resolves onto a different filesystem
-cp -rl /usr/local/server/server-env/* /usr/local/server/src/function/runtime-env 2>/dev/null ||
-	cp -r /usr/local/server/server-env/* /usr/local/server/src/function/runtime-env
+# Expose the server-env packages to the runtime-env interpreter via a .pth
+# file instead of copying the whole virtual env on every cold start
+server_site=$(echo /usr/local/server/server-env/lib/python*/site-packages)
+runtime_site=$(echo /usr/local/server/src/function/runtime-env/lib/python*/site-packages)
+echo "$server_site" >"$runtime_site/server-env.pth"
 
 # Activate virtual env
 source /usr/local/server/src/function/runtime-env/bin/activate

--- a/runtimes/python/versions/ml-3.11/hooks/start-prepare.sh
+++ b/runtimes/python/versions/ml-3.11/hooks/start-prepare.sh
@@ -3,10 +3,11 @@
 set -e
 shopt -s dotglob
 
-# Hardlink the server-env virtual env into runtime-env; fall back to a
-# copy when runtime-env resolves onto a different filesystem
-cp -rl /usr/local/server/server-env/* /usr/local/server/src/function/runtime-env 2>/dev/null ||
-	cp -r /usr/local/server/server-env/* /usr/local/server/src/function/runtime-env
+# Expose the server-env packages to the runtime-env interpreter via a .pth
+# file instead of copying the whole virtual env on every cold start
+server_site=$(echo /usr/local/server/server-env/lib/python*/site-packages)
+runtime_site=$(echo /usr/local/server/src/function/runtime-env/lib/python*/site-packages)
+echo "$server_site" >"$runtime_site/server-env.pth"
 
 # Activate virtual env
 . /usr/local/server/src/function/runtime-env/bin/activate # OVERRIDE: Cant use source here

--- a/runtimes/python/versions/ml-3.11/hooks/start-prepare.sh
+++ b/runtimes/python/versions/ml-3.11/hooks/start-prepare.sh
@@ -3,10 +3,8 @@
 set -e
 shopt -s dotglob
 
-# Hardlink the server-env virtual env into the runtime-env virtual env
-# (same filesystem, so -l makes this near-instant instead of a full copy).
-# Pre-extracted deployments can resolve runtime-env onto a separate mount,
-# where hardlinks fail with EXDEV — fall back to a plain copy there.
+# Hardlink the server-env virtual env into runtime-env; fall back to a
+# copy when runtime-env resolves onto a different filesystem
 cp -rl /usr/local/server/server-env/* /usr/local/server/src/function/runtime-env 2>/dev/null ||
 	cp -r /usr/local/server/server-env/* /usr/local/server/src/function/runtime-env
 

--- a/runtimes/python/versions/ml-3.11/hooks/start-prepare.sh
+++ b/runtimes/python/versions/ml-3.11/hooks/start-prepare.sh
@@ -3,8 +3,9 @@
 set -e
 shopt -s dotglob
 
-# Copy contents of the server-env virtual env to the runtime-env virtual env
-cp -r /usr/local/server/server-env/* /usr/local/server/src/function/runtime-env
+# Hardlink the server-env virtual env into the runtime-env virtual env
+# (same filesystem, so -l makes this near-instant instead of a full copy)
+cp -rl /usr/local/server/server-env/* /usr/local/server/src/function/runtime-env
 
 # Activate virtual env
 . /usr/local/server/src/function/runtime-env/bin/activate # OVERRIDE: Cant use source here

--- a/runtimes/python/versions/ml-3.11/hooks/start-prepare.sh
+++ b/runtimes/python/versions/ml-3.11/hooks/start-prepare.sh
@@ -4,8 +4,11 @@ set -e
 shopt -s dotglob
 
 # Hardlink the server-env virtual env into the runtime-env virtual env
-# (same filesystem, so -l makes this near-instant instead of a full copy)
-cp -rl /usr/local/server/server-env/* /usr/local/server/src/function/runtime-env
+# (same filesystem, so -l makes this near-instant instead of a full copy).
+# Pre-extracted deployments can resolve runtime-env onto a separate mount,
+# where hardlinks fail with EXDEV — fall back to a plain copy there.
+cp -rl /usr/local/server/server-env/* /usr/local/server/src/function/runtime-env 2>/dev/null ||
+	cp -r /usr/local/server/server-env/* /usr/local/server/src/function/runtime-env
 
 # Activate virtual env
 . /usr/local/server/src/function/runtime-env/bin/activate # OVERRIDE: Cant use source here

--- a/runtimes/python/versions/ml-3.12/hooks/start-prepare.sh
+++ b/runtimes/python/versions/ml-3.12/hooks/start-prepare.sh
@@ -3,10 +3,11 @@
 set -e
 shopt -s dotglob
 
-# Hardlink the server-env virtual env into runtime-env; fall back to a
-# copy when runtime-env resolves onto a different filesystem
-cp -rl /usr/local/server/server-env/* /usr/local/server/src/function/runtime-env 2>/dev/null ||
-	cp -r /usr/local/server/server-env/* /usr/local/server/src/function/runtime-env
+# Expose the server-env packages to the runtime-env interpreter via a .pth
+# file instead of copying the whole virtual env on every cold start
+server_site=$(echo /usr/local/server/server-env/lib/python*/site-packages)
+runtime_site=$(echo /usr/local/server/src/function/runtime-env/lib/python*/site-packages)
+echo "$server_site" >"$runtime_site/server-env.pth"
 
 # Activate virtual env
 . /usr/local/server/src/function/runtime-env/bin/activate # OVERRIDE: Cant use source here

--- a/runtimes/python/versions/ml-3.12/hooks/start-prepare.sh
+++ b/runtimes/python/versions/ml-3.12/hooks/start-prepare.sh
@@ -3,10 +3,8 @@
 set -e
 shopt -s dotglob
 
-# Hardlink the server-env virtual env into the runtime-env virtual env
-# (same filesystem, so -l makes this near-instant instead of a full copy).
-# Pre-extracted deployments can resolve runtime-env onto a separate mount,
-# where hardlinks fail with EXDEV — fall back to a plain copy there.
+# Hardlink the server-env virtual env into runtime-env; fall back to a
+# copy when runtime-env resolves onto a different filesystem
 cp -rl /usr/local/server/server-env/* /usr/local/server/src/function/runtime-env 2>/dev/null ||
 	cp -r /usr/local/server/server-env/* /usr/local/server/src/function/runtime-env
 

--- a/runtimes/python/versions/ml-3.12/hooks/start-prepare.sh
+++ b/runtimes/python/versions/ml-3.12/hooks/start-prepare.sh
@@ -3,8 +3,9 @@
 set -e
 shopt -s dotglob
 
-# Copy contents of the server-env virtual env to the runtime-env virtual env
-cp -r /usr/local/server/server-env/* /usr/local/server/src/function/runtime-env
+# Hardlink the server-env virtual env into the runtime-env virtual env
+# (same filesystem, so -l makes this near-instant instead of a full copy)
+cp -rl /usr/local/server/server-env/* /usr/local/server/src/function/runtime-env
 
 # Activate virtual env
 . /usr/local/server/src/function/runtime-env/bin/activate # OVERRIDE: Cant use source here

--- a/runtimes/python/versions/ml-3.12/hooks/start-prepare.sh
+++ b/runtimes/python/versions/ml-3.12/hooks/start-prepare.sh
@@ -4,8 +4,11 @@ set -e
 shopt -s dotglob
 
 # Hardlink the server-env virtual env into the runtime-env virtual env
-# (same filesystem, so -l makes this near-instant instead of a full copy)
-cp -rl /usr/local/server/server-env/* /usr/local/server/src/function/runtime-env
+# (same filesystem, so -l makes this near-instant instead of a full copy).
+# Pre-extracted deployments can resolve runtime-env onto a separate mount,
+# where hardlinks fail with EXDEV — fall back to a plain copy there.
+cp -rl /usr/local/server/server-env/* /usr/local/server/src/function/runtime-env 2>/dev/null ||
+	cp -r /usr/local/server/server-env/* /usr/local/server/src/function/runtime-env
 
 # Activate virtual env
 . /usr/local/server/src/function/runtime-env/bin/activate # OVERRIDE: Cant use source here

--- a/runtimes/python/versions/ml-3.13/hooks/start-prepare.sh
+++ b/runtimes/python/versions/ml-3.13/hooks/start-prepare.sh
@@ -3,10 +3,11 @@
 set -e
 shopt -s dotglob
 
-# Hardlink the server-env virtual env into runtime-env; fall back to a
-# copy when runtime-env resolves onto a different filesystem
-cp -rl /usr/local/server/server-env/* /usr/local/server/src/function/runtime-env 2>/dev/null ||
-	cp -r /usr/local/server/server-env/* /usr/local/server/src/function/runtime-env
+# Expose the server-env packages to the runtime-env interpreter via a .pth
+# file instead of copying the whole virtual env on every cold start
+server_site=$(echo /usr/local/server/server-env/lib/python*/site-packages)
+runtime_site=$(echo /usr/local/server/src/function/runtime-env/lib/python*/site-packages)
+echo "$server_site" >"$runtime_site/server-env.pth"
 
 # Activate virtual env
 . /usr/local/server/src/function/runtime-env/bin/activate # OVERRIDE: Cant use source here

--- a/runtimes/python/versions/ml-3.13/hooks/start-prepare.sh
+++ b/runtimes/python/versions/ml-3.13/hooks/start-prepare.sh
@@ -3,10 +3,8 @@
 set -e
 shopt -s dotglob
 
-# Hardlink the server-env virtual env into the runtime-env virtual env
-# (same filesystem, so -l makes this near-instant instead of a full copy).
-# Pre-extracted deployments can resolve runtime-env onto a separate mount,
-# where hardlinks fail with EXDEV — fall back to a plain copy there.
+# Hardlink the server-env virtual env into runtime-env; fall back to a
+# copy when runtime-env resolves onto a different filesystem
 cp -rl /usr/local/server/server-env/* /usr/local/server/src/function/runtime-env 2>/dev/null ||
 	cp -r /usr/local/server/server-env/* /usr/local/server/src/function/runtime-env
 

--- a/runtimes/python/versions/ml-3.13/hooks/start-prepare.sh
+++ b/runtimes/python/versions/ml-3.13/hooks/start-prepare.sh
@@ -3,8 +3,9 @@
 set -e
 shopt -s dotglob
 
-# Copy contents of the server-env virtual env to the runtime-env virtual env
-cp -r /usr/local/server/server-env/* /usr/local/server/src/function/runtime-env
+# Hardlink the server-env virtual env into the runtime-env virtual env
+# (same filesystem, so -l makes this near-instant instead of a full copy)
+cp -rl /usr/local/server/server-env/* /usr/local/server/src/function/runtime-env
 
 # Activate virtual env
 . /usr/local/server/src/function/runtime-env/bin/activate # OVERRIDE: Cant use source here

--- a/runtimes/python/versions/ml-3.13/hooks/start-prepare.sh
+++ b/runtimes/python/versions/ml-3.13/hooks/start-prepare.sh
@@ -4,8 +4,11 @@ set -e
 shopt -s dotglob
 
 # Hardlink the server-env virtual env into the runtime-env virtual env
-# (same filesystem, so -l makes this near-instant instead of a full copy)
-cp -rl /usr/local/server/server-env/* /usr/local/server/src/function/runtime-env
+# (same filesystem, so -l makes this near-instant instead of a full copy).
+# Pre-extracted deployments can resolve runtime-env onto a separate mount,
+# where hardlinks fail with EXDEV — fall back to a plain copy there.
+cp -rl /usr/local/server/server-env/* /usr/local/server/src/function/runtime-env 2>/dev/null ||
+	cp -r /usr/local/server/server-env/* /usr/local/server/src/function/runtime-env
 
 # Activate virtual env
 . /usr/local/server/src/function/runtime-env/bin/activate # OVERRIDE: Cant use source here


### PR DESCRIPTION
## What

Stops copying the server virtual env into the function's runtime-env on every cold start. Instead, `start-prepare.sh` writes a single `server-env.pth` file into runtime-env's site-packages pointing at server-env's site-packages, and `server.sh` launches gunicorn from server-env directly (still under the runtime-env interpreter, so user dependencies keep precedence).

## Why

The startup baseline from #554 shows `prepare` at 0.22–0.36 s for plain Python and ~3 s for python-ml — all of it the `cp -r` of server-env. A first attempt with `cp -rl` hardlinks actually regressed (hardlinking image-layer files on overlayfs forces a per-file copy-up), which the PR's own startup-metrics comment caught. The `.pth` approach does no file copying at all: one small file write per cold start.

## Test plan

Full Python/PythonML suites on CI; the startup comment should show `prepare` collapsing to ~0 for all Python runtimes. Verified the mechanism in a container: a venv-installed gunicorn from server-env resolves and runs under the runtime-env interpreter via the `.pth`.


## Measured results

Baseline from #554's CI run vs this PR's CI run (python-ml is not in this PR's CI matrix; it shares the same hook change):

| Runtime | Prepare (before → after) | Cold start (before → after) |
|---------|---------------------------|------------------------------|
| `python-3.10` | 0.22 s → **0.01 s** | 1.971 s → **1.396 s** |
| `python-3.11` | 0.36 s → **0 s** | 2.338 s → **1.226 s** |
| `python-3.12` | 0.23 s → **0.01 s** | 2.346 s → **1.413 s** |
| `python-3.13` | 0.22 s → **0.01 s** | 2.654 s → **1.287 s** |
| `python-3.14` | 0.22 s → **0.01 s** | 2.377 s → **1.586 s** |
| `python-3.8` | 0.27 s → **0.01 s** | 1.757 s → **1.29 s** |
| `python-3.9` | 0.36 s → **0 s** | 2.422 s → **1.445 s** |
