### PR TITLE
perf(ruby): symlink the vendor bundle instead of copying it

### DIFF
--- a/runtimes/ruby/versions/latest/hooks/start-prepare.sh
+++ b/runtimes/ruby/versions/latest/hooks/start-prepare.sh
@@ -8,7 +8,7 @@ if [ -f "/usr/local/server/src/function/Gemfile" ]; then
 	echo "eval_gemfile '/usr/local/server/src/function/Gemfile'" >>/usr/local/server/Gemfile
 fi
 
-# Link dependencies (symlink instead of copy — the bundle can be tens of MB)
+# Link dependencies
 ln -sfn /usr/local/server/src/function/vendor /usr/local/server/vendor
 
 bundle config set --local path 'vendor/bundle'

--- a/runtimes/ruby/versions/latest/hooks/start-prepare.sh
+++ b/runtimes/ruby/versions/latest/hooks/start-prepare.sh
@@ -8,7 +8,7 @@ if [ -f "/usr/local/server/src/function/Gemfile" ]; then
 	echo "eval_gemfile '/usr/local/server/src/function/Gemfile'" >>/usr/local/server/Gemfile
 fi
 
-# Copy dependencies
-cp -R /usr/local/server/src/function/vendor /usr/local/server/vendor
+# Link dependencies (symlink instead of copy — the bundle can be tens of MB)
+ln -sfn /usr/local/server/src/function/vendor /usr/local/server/vendor
 
 bundle config set --local path 'vendor/bundle'


### PR DESCRIPTION
## What

Replaces the start-time `cp -R` of the extracted vendor directory with `ln -sfn /usr/local/server/src/function/vendor /usr/local/server/vendor`.

## Why

The startup baseline from #554 shows Ruby's `prepare` phase at 0.30–0.57 s, spent duplicating the gem bundle that was just extracted into the function directory. Bundler only needs `vendor/bundle` to resolve relative to `/usr/local/server`; a symlink provides the same path instantly. `ln -sfn` also stays idempotent on container restarts, where the old copy would have nested into `vendor/vendor`.

## Test plan

Full Ruby suite on CI; the startup comment should show `prepare` at ~0 for all Ruby versions.

## Measured results

Baseline from #554's CI run vs this PR's CI run. Most of the remaining prepare time is the `bundle config set` ruby VM start, not file work; `ruby-3.2` looks like runner noise.

| Runtime | Prepare (before → after) | Cold start (before → after) |
|---------|---------------------------|------------------------------|
| `ruby-3.0` | 0.43 s → **0.26 s** | 1.667 s → **1.533 s** |
| `ruby-3.1` | 0.57 s → **0.32 s** | 2.436 s → **2.043 s** |
| `ruby-3.2` | 0.54 s → **1.1 s** | 2.135 s → **3.313 s** |
| `ruby-3.3` | 0.51 s → **0.3 s** | 2.235 s → **1.994 s** |
| `ruby-3.4` | 0.3 s → **0.16 s** | 1.651 s → **1.166 s** |
| `ruby-4.0` | 0.49 s → **0.25 s** | 2.052 s → **1.795 s** |
