### PR TITLE
fix(java): use jammy bases for JDK 8/11/17 to restore arm64 builds

### DIFF
--- a/ci/runtimes.toml
+++ b/ci/runtimes.toml
@@ -421,14 +421,15 @@ platforms = ["linux/amd64"]
 
 [java.build.versions]
 "25" = { base = "eclipse-temurin:25-jdk-alpine-3.23", args = { SYSTEM_PACKAGES = "curl" } }
-# Temurin does not publish Alpine 3.23 variants for EOL JDK 18 or 22.
-# The frozen JDK 18 Alpine image is also amd64-only, so keep Jammy for multi-arch builds.
+# Temurin publishes multi-arch Alpine images only for JDK 21+. The Alpine
+# variants of JDK 8/11/17 are amd64-only and JDK 18/22 have no Alpine 3.23
+# build at all, so those five stay on Jammy for linux/arm64 support.
 "22" = { base = "eclipse-temurin:22-jdk-jammy", args = { SYSTEM_PACKAGES = "curl" } }
 "21.0" = { base = "eclipse-temurin:21-jdk-alpine-3.23" }
 "18.0" = { base = "eclipse-temurin:18-jdk-jammy" }
-"17.0" = { base = "eclipse-temurin:17-jdk-alpine-3.23" }
-"11.0" = { base = "eclipse-temurin:11-jdk-alpine-3.23" }
-"8.0" = { base = "eclipse-temurin:8-jdk-alpine-3.23" }
+"17.0" = { base = "eclipse-temurin:17-jdk-jammy" }
+"11.0" = { base = "eclipse-temurin:11-jdk-jammy" }
+"8.0" = { base = "eclipse-temurin:8-jdk-jammy" }
 
 [cpp.build.versions]
 "23" = { base = "alpine:3.23.5" }

--- a/docker-bake.json
+++ b/docker-bake.json
@@ -2009,7 +2009,7 @@
         "version": "./runtimes/java/versions/17.0"
       },
       "args": {
-        "BASE_IMAGE": "eclipse-temurin:17-jdk-alpine-3.23"
+        "BASE_IMAGE": "eclipse-temurin:17-jdk-jammy"
       },
       "platforms": [
         "linux/amd64",
@@ -2032,7 +2032,7 @@
         "version": "./runtimes/java/versions/11.0"
       },
       "args": {
-        "BASE_IMAGE": "eclipse-temurin:11-jdk-alpine-3.23"
+        "BASE_IMAGE": "eclipse-temurin:11-jdk-jammy"
       },
       "platforms": [
         "linux/amd64",
@@ -2055,7 +2055,7 @@
         "version": "./runtimes/java/versions/8.0"
       },
       "args": {
-        "BASE_IMAGE": "eclipse-temurin:8-jdk-alpine-3.23"
+        "BASE_IMAGE": "eclipse-temurin:8-jdk-jammy"
       },
       "platforms": [
         "linux/amd64",


### PR DESCRIPTION
## What

Moves java 8.0/11.0/17.0 from `eclipse-temurin:<v>-jdk-alpine-3.23` to `eclipse-temurin:<v>-jdk-jammy` and updates the comment explaining the constraint.

## Why

The 0.13.25 release workflow failed on `java-8_0/11_0/17_0 (linux/arm64)` with `no match for platform in manifest: not found`: Temurin only publishes multi-arch Alpine images for JDK 21+ — the JDK 8/11/17 Alpine tags are amd64-only (verified against Docker Hub manifests). Jammy is what JDK 18 and 22 already use for exactly this reason. As a result the v5 java 8/11/17 tags on Docker Hub are still the pre-0.13.25 build.

## Test plan

Built all three images locally on an arm64 host with `docker buildx bake java-{8,11,17}_0 --set '*.platform=linux/arm64'` — all succeed (they fail on main with the manifest error). CI runs the java suite; image-size report will show the alpine→jammy size increase, the same tradeoff 18/22 already carry. Needs a patch release after merge to actually publish the fixed images.