### PR TITLE
perf(ssr): cut SSR server boot ~55% by dropping module hooks and express

### DIFF
--- a/runtimes/bun/versions/latest/bun.lock
+++ b/runtimes/bun/versions/latest/bun.lock
@@ -6,6 +6,7 @@
       "name": "open-runtimes-bun",
       "dependencies": {
         "express": "^4.21.2",
+        "serve-static": "^1.16.2",
         "srvx": "^0.8.16",
         "superjson": "^2.2.6",
       },

--- a/runtimes/bun/versions/latest/package.json
+++ b/runtimes/bun/versions/latest/package.json
@@ -12,6 +12,7 @@
   "license": "ISC",
   "dependencies": {
     "express": "^4.21.2",
+    "serve-static": "^1.16.2",
     "srvx": "^0.8.16",
     "superjson": "^2.2.6"
   }

--- a/runtimes/javascript/src/server-analog.mjs
+++ b/runtimes/javascript/src/server-analog.mjs
@@ -1,26 +1,32 @@
 import { handler } from "./server/index.mjs";
-import express from "express";
+import { createServer } from "node:http";
+import serveStatic from "serve-static";
 
 console.log("Analog server starting ...");
-
-const app = express();
 
 const cacheHeader =
   process.env.OPEN_RUNTIMES_CACHE_HEADER ?? "CDN-Cache-Control";
 
 // framework-specific logic
-app.use(
-  express.static("public", {
-    setHeaders: (res, _path) => {
-      res.setHeader(cacheHeader, "public, max-age=36000");
-    },
-  }),
-);
-app.use(handler);
+const staticHandler = serveStatic("public", {
+  setHeaders: (res, _path) => {
+    res.setHeader(cacheHeader, "public, max-age=36000");
+  },
+});
+
+// Terminal handler: mirror express's finalhandler for requests the framework
+// hands back (404) or fails on (500).
+const finish = (res) => (error) => {
+  res.statusCode = error ? 500 : 404;
+  res.end();
+};
+const server = createServer((req, res) => {
+  staticHandler(req, res, () => handler(req, res, finish(res)));
+});
 // End of framework-specific logic
 
 const port = +(process.env.PORT || "3000");
 const host = process.env.HOST || "0.0.0.0";
-app.listen(port, host, () => {
+server.listen(port, host, () => {
   console.log(`Analog server started on http://${host}:${port}`);
 });

--- a/runtimes/javascript/src/server-angular.mjs
+++ b/runtimes/javascript/src/server-angular.mjs
@@ -1,26 +1,32 @@
 import { reqHandler } from "./server/server.mjs";
-import express from "express";
+import { createServer } from "node:http";
+import serveStatic from "serve-static";
 
 console.log("Angular server starting ...");
-
-const app = express();
 
 const cacheHeader =
   process.env.OPEN_RUNTIMES_CACHE_HEADER ?? "CDN-Cache-Control";
 
 // framework-specific logic
-app.use(
-  express.static("browser", {
-    setHeaders: (res, _path) => {
-      res.setHeader(cacheHeader, "public, max-age=36000");
-    },
-  }),
-);
-app.use(reqHandler);
+const staticHandler = serveStatic("browser", {
+  setHeaders: (res, _path) => {
+    res.setHeader(cacheHeader, "public, max-age=36000");
+  },
+});
+
+// Terminal handler: mirror express's finalhandler for requests the framework
+// hands back (404) or fails on (500).
+const finish = (res) => (error) => {
+  res.statusCode = error ? 500 : 404;
+  res.end();
+};
+const server = createServer((req, res) => {
+  staticHandler(req, res, () => reqHandler(req, res, finish(res)));
+});
 // End of framework-specific logic
 
 const port = +(process.env.PORT || "3000");
 const host = process.env.HOST || "0.0.0.0";
-app.listen(port, host, () => {
+server.listen(port, host, () => {
   console.log(`Angular server started on http://${host}:${port}`);
 });

--- a/runtimes/javascript/src/server-astro.mjs
+++ b/runtimes/javascript/src/server-astro.mjs
@@ -1,26 +1,32 @@
 import { handler } from "./server/entry.mjs";
-import express from "express";
+import { createServer } from "node:http";
+import serveStatic from "serve-static";
 
 console.log("Astro server starting ...");
-
-const app = express();
 
 const cacheHeader =
   process.env.OPEN_RUNTIMES_CACHE_HEADER ?? "CDN-Cache-Control";
 
 // framework-specific logic
-app.use(
-  express.static("client", {
-    setHeaders: (res, _path) => {
-      res.setHeader(cacheHeader, "public, max-age=36000");
-    },
-  }),
-);
-app.use(handler);
+const staticHandler = serveStatic("client", {
+  setHeaders: (res, _path) => {
+    res.setHeader(cacheHeader, "public, max-age=36000");
+  },
+});
+
+// Terminal handler: mirror express's finalhandler for requests the framework
+// hands back (404) or fails on (500).
+const finish = (res) => (error) => {
+  res.statusCode = error ? 500 : 404;
+  res.end();
+};
+const server = createServer((req, res) => {
+  staticHandler(req, res, () => handler(req, res, finish(res)));
+});
 // End of framework-specific logic
 
 const port = +(process.env.PORT || "3000");
 const host = process.env.HOST || "0.0.0.0";
-app.listen(port, host, () => {
+server.listen(port, host, () => {
   console.log(`Astro server started on http://${host}:${port}`);
 });

--- a/runtimes/javascript/src/server-next-js.mjs
+++ b/runtimes/javascript/src/server-next-js.mjs
@@ -1,34 +1,33 @@
 import { parse } from "url";
 import next from "next";
-import express from "express";
+import { createServer } from "node:http";
+import serveStatic from "serve-static";
 
 console.log("Next.js server starting ...");
-
-const app = express();
 
 const cacheHeader =
   process.env.OPEN_RUNTIMES_CACHE_HEADER ?? "CDN-Cache-Control";
 
 // framework-specific logic
-app.use(
-  express.static("public", {
-    setHeaders: (res, _path) => {
-      res.setHeader(cacheHeader, "public, max-age=36000");
-    },
-  }),
-);
+const staticHandler = serveStatic("public", {
+  setHeaders: (res, _path) => {
+    res.setHeader(cacheHeader, "public, max-age=36000");
+  },
+});
 const nextApp = next({});
 const handle = nextApp.getRequestHandler();
-app.use((req, res, next) => {
-  const parsedUrl = parse(req.url, true);
-  handle(req, res, parsedUrl);
+const server = createServer((req, res) => {
+  staticHandler(req, res, () => {
+    const parsedUrl = parse(req.url, true);
+    handle(req, res, parsedUrl);
+  });
 });
 // End of framework-specific logic
 
 nextApp.prepare().then(() => {
   const port = +(process.env.PORT || "3000");
   const host = process.env.HOST || "0.0.0.0";
-  app.listen(port, host, () => {
+  server.listen(port, host, () => {
     console.log(`Next.js server started on http://${host}:${port}`);
   });
 });

--- a/runtimes/javascript/src/server-nuxt.mjs
+++ b/runtimes/javascript/src/server-nuxt.mjs
@@ -1,26 +1,32 @@
 import { listener } from "./server/index.mjs";
-import express from "express";
+import { createServer } from "node:http";
+import serveStatic from "serve-static";
 
 console.log("Nuxt server starting ...");
-
-const app = express();
 
 const cacheHeader =
   process.env.OPEN_RUNTIMES_CACHE_HEADER ?? "CDN-Cache-Control";
 
 // framework-specific logic
-app.use(
-  express.static("public", {
-    setHeaders: (res, _path) => {
-      res.setHeader(cacheHeader, "public, max-age=36000");
-    },
-  }),
-);
-app.use(listener);
+const staticHandler = serveStatic("public", {
+  setHeaders: (res, _path) => {
+    res.setHeader(cacheHeader, "public, max-age=36000");
+  },
+});
+
+// Terminal handler: mirror express's finalhandler for requests the framework
+// hands back (404) or fails on (500).
+const finish = (res) => (error) => {
+  res.statusCode = error ? 500 : 404;
+  res.end();
+};
+const server = createServer((req, res) => {
+  staticHandler(req, res, () => listener(req, res, finish(res)));
+});
 // End of framework-specific logic
 
 const port = +(process.env.PORT || "3000");
 const host = process.env.HOST || "0.0.0.0";
-app.listen(port, host, () => {
+server.listen(port, host, () => {
   console.log(`Nuxt server started on http://${host}:${port}`);
 });

--- a/runtimes/javascript/src/server-sveltekit.mjs
+++ b/runtimes/javascript/src/server-sveltekit.mjs
@@ -1,26 +1,32 @@
 import { handler } from "./handler.js";
-import express from "express";
+import { createServer } from "node:http";
+import serveStatic from "serve-static";
 
 console.log("SvelteKit server starting ...");
-
-const app = express();
 
 const cacheHeader =
   process.env.OPEN_RUNTIMES_CACHE_HEADER ?? "CDN-Cache-Control";
 
 // framework-specific logic
-app.use(
-  express.static("client", {
-    setHeaders: (res, _path) => {
-      res.setHeader(cacheHeader, "public, max-age=36000");
-    },
-  }),
-);
-app.use(handler);
+const staticHandler = serveStatic("client", {
+  setHeaders: (res, _path) => {
+    res.setHeader(cacheHeader, "public, max-age=36000");
+  },
+});
+
+// Terminal handler: mirror express's finalhandler for requests the framework
+// hands back (404) or fails on (500).
+const finish = (res) => (error) => {
+  res.statusCode = error ? 500 : 404;
+  res.end();
+};
+const server = createServer((req, res) => {
+  staticHandler(req, res, () => handler(req, res, finish(res)));
+});
 // End of framework-specific logic
 
 const port = +(process.env.PORT || "3000");
 const host = process.env.HOST || "0.0.0.0";
-app.listen(port, host, () => {
+server.listen(port, host, () => {
   console.log(`SvelteKit server started on http://${host}:${port}`);
 });

--- a/runtimes/javascript/src/server-tanstack-start-listener.mjs
+++ b/runtimes/javascript/src/server-tanstack-start-listener.mjs
@@ -1,26 +1,34 @@
 import { listener } from "./server/index.mjs";
-import express from "express";
+import { createServer } from "node:http";
+import serveStatic from "serve-static";
 
 console.log("TanStack Start (Nitro listener) server starting ...");
 
-const app = express();
+const cacheHeader =
+  process.env.OPEN_RUNTIMES_CACHE_HEADER ?? "CDN-Cache-Control";
 
 // framework-specific logic
-app.use(
-  express.static("public", {
-    setHeaders: (res, _path) => {
-      res.setHeader(
-        process.env.OPEN_RUNTIMES_CACHE_HEADER ?? "CDN-Cache-Control",
-        "public, max-age=36000",
-      );
-    },
-  }),
-);
-app.use(listener);
+const staticHandler = serveStatic("public", {
+  setHeaders: (res, _path) => {
+    res.setHeader(cacheHeader, "public, max-age=36000");
+  },
+});
+
+// Terminal handler: mirror express's finalhandler for requests the framework
+// hands back (404) or fails on (500).
+const finish = (res) => (error) => {
+  res.statusCode = error ? 500 : 404;
+  res.end();
+};
+const server = createServer((req, res) => {
+  staticHandler(req, res, () => listener(req, res, finish(res)));
+});
 // End of framework-specific logic
 
 const port = +(process.env.PORT || "3000");
 const host = process.env.HOST || "0.0.0.0";
-app.listen(port, host, () => {
-  console.log(`TanStack Start server started on http://${host}:${port}`);
+server.listen(port, host, () => {
+  console.log(
+    `TanStack Start (Nitro listener) server started on http://${host}:${port}`,
+  );
 });

--- a/runtimes/javascript/src/server-tanstack-start.mjs
+++ b/runtimes/javascript/src/server-tanstack-start.mjs
@@ -1,28 +1,33 @@
 import handler from "./server/server.js";
 import { toNodeHandler } from "srvx/node";
-import express from "express";
+import { createServer } from "node:http";
+import serveStatic from "serve-static";
 
 console.log("TanStack Start server starting ...");
-
-const app = express();
 
 const cacheHeader =
   process.env.OPEN_RUNTIMES_CACHE_HEADER ?? "CDN-Cache-Control";
 
 // framework-specific logic
-app.use(
-  express.static("client", {
-    setHeaders: (res, _path) => {
-      res.setHeader(cacheHeader, "public, max-age=36000");
-    },
-  }),
-);
+const staticHandler = serveStatic("client", {
+  setHeaders: (res, _path) => {
+    res.setHeader(cacheHeader, "public, max-age=36000");
+  },
+});
 const nodeHandler = toNodeHandler(handler.fetch);
-app.use(nodeHandler);
+// Terminal handler: mirror express's finalhandler for requests the framework
+// hands back (404) or fails on (500).
+const finish = (res) => (error) => {
+  res.statusCode = error ? 500 : 404;
+  res.end();
+};
+const server = createServer((req, res) => {
+  staticHandler(req, res, () => nodeHandler(req, res, finish(res)));
+});
 // End of framework-specific logic
 
 const port = +(process.env.PORT || "3000");
 const host = process.env.HOST || "0.0.0.0";
-app.listen(port, host, () => {
+server.listen(port, host, () => {
   console.log(`TanStack Start server started on http://${host}:${port}`);
 });

--- a/runtimes/javascript/src/ssr/deno.json
+++ b/runtimes/javascript/src/ssr/deno.json
@@ -1,12 +1,9 @@
 {
-  "unstable": [
-    "bare-node-builtins",
-    "sloppy-imports",
-    "detect-cjs"
-  ],
+  "unstable": ["bare-node-builtins", "sloppy-imports", "detect-cjs"],
   "imports": {
     "superjson": "npm:superjson@^2.2.6",
     "express": "npm:express@^4.21.2",
+    "serve-static": "npm:serve-static@^1.16.2",
     "srvx/node": "npm:srvx@^0.8.16/node"
   }
 }

--- a/runtimes/javascript/src/ssr/http-injection.mjs
+++ b/runtimes/javascript/src/ssr/http-injection.mjs
@@ -1,9 +1,9 @@
 // Shared HTTP server wrappers used by both the node and bun SSR injection
 // entrypoints. Contains the per-request logic (Open Runtimes endpoints, secret
 // auth, per-request log id, safe execution timeout, error capture) plus the
-// constructor wrappers that install it. Runtime entrypoints decide *how* these
-// get applied (node: import-in-the-middle + require-in-the-middle; bun: direct
-// Server.prototype.emit patch at preload time).
+// constructor wrappers that install it. Runtime entrypoints apply these via a
+// direct Server.prototype.emit patch at preload time (node: --import, bun:
+// --preload, deno: --import).
 
 import {
   addOprEndpoints,
@@ -72,47 +72,4 @@ export function overrideEmit(originalEmit) {
       dispatch();
     });
   };
-}
-
-// Wrap a Server constructor (used by Nitro's `new Server()` path).
-export function wrapServer(originalServer) {
-  return function (...args) {
-    const server = originalServer.apply(this, args);
-    server.emit = overrideEmit(server.emit);
-    return server;
-  };
-}
-
-// Wrap createServer (used by native http, express, koa, ...).
-export function wrapCreateServer(originalCreateServer) {
-  return function (...args) {
-    const server = new originalCreateServer(...args);
-    server.emit = overrideEmit(server.emit);
-    return server;
-  };
-}
-
-// Apply wrapServer/wrapCreateServer to a loaded http/https module's exports.
-// Handles both CJS and ESM shapes. Used by node's import-in-the-middle hook.
-export function wrapHttp(moduleExports) {
-  if (moduleExports.Server) {
-    moduleExports.Server = wrapServer(moduleExports.Server);
-  }
-  if (moduleExports.createServer) {
-    moduleExports.createServer = wrapCreateServer(moduleExports.createServer);
-  }
-
-  const isESM = moduleExports[Symbol.toStringTag] === "Module";
-  if (isESM) {
-    if (moduleExports.default.Server) {
-      moduleExports.default.Server = wrapServer(moduleExports.default.Server);
-    }
-    if (moduleExports.default.createServer) {
-      moduleExports.default.createServer = wrapCreateServer(
-        moduleExports.default.createServer,
-      );
-    }
-  }
-
-  return moduleExports;
 }

--- a/runtimes/javascript/src/ssr/logger.mjs
+++ b/runtimes/javascript/src/ssr/logger.mjs
@@ -63,7 +63,10 @@ export class Logger {
           return message;
         }
         try {
-          return JSON.stringify(superjson().serialize(message).json);
+          const serializer = superjson();
+          return serializer
+            ? JSON.stringify(serializer.serialize(message).json)
+            : JSON.stringify(message);
         } catch {
           return String(message);
         }

--- a/runtimes/javascript/src/ssr/logger.mjs
+++ b/runtimes/javascript/src/ssr/logger.mjs
@@ -2,29 +2,23 @@ import { appendFileSync } from "node:fs";
 import { AsyncLocalStorage } from "node:async_hooks";
 import { createRequire } from "node:module";
 
-// Loaded lazily on the first structured log so the import stays off the SSR
-// boot path; require(esm) keeps it synchronous, so no log is ever serialized
-// without it.
+// Where the ESM-only superjson can be loaded synchronously (Node with
+// require(esm), Bun), it is loaded lazily on the first structured log so the
+// import stays off the SSR boot path. Everywhere else it is awaited eagerly
+// at module load, exactly as before this optimization — either way no log is
+// ever serialized without it.
 const require = createRequire(import.meta.url);
 let _superjson;
-let _superjsonUnavailable = false;
 const superjson = () => {
-  if (!_superjson && !_superjsonUnavailable) {
-    try {
-      const module = require("superjson");
-      _superjson = module.default ?? module;
-    } catch {
-      // Node without require(esm) support — load in the background and fall
-      // back to plain JSON.stringify until it resolves.
-      _superjsonUnavailable = true;
-      import("superjson").then((m) => {
-        _superjson = m.default;
-        _superjsonUnavailable = false;
-      });
-    }
+  if (!_superjson) {
+    const module = require("superjson");
+    _superjson = module.default ?? module;
   }
   return _superjson;
 };
+if (!process.features?.require_module && typeof Bun === "undefined") {
+  _superjson = (await import("superjson")).default;
+}
 
 // Shared between node and bun. Uses AsyncLocalStorage (built into Node 16+
 // and Bun) instead of cls-hooked so both runtimes can consume the same file.

--- a/runtimes/javascript/src/ssr/logger.mjs
+++ b/runtimes/javascript/src/ssr/logger.mjs
@@ -1,6 +1,30 @@
 import { appendFileSync } from "node:fs";
 import { AsyncLocalStorage } from "node:async_hooks";
-import superjson from "superjson";
+import { createRequire } from "node:module";
+
+// Loaded lazily on the first structured log so the import stays off the SSR
+// boot path; require(esm) keeps it synchronous, so no log is ever serialized
+// without it.
+const require = createRequire(import.meta.url);
+let _superjson;
+let _superjsonUnavailable = false;
+const superjson = () => {
+  if (!_superjson && !_superjsonUnavailable) {
+    try {
+      const module = require("superjson");
+      _superjson = module.default ?? module;
+    } catch {
+      // Node without require(esm) support — load in the background and fall
+      // back to plain JSON.stringify until it resolves.
+      _superjsonUnavailable = true;
+      import("superjson").then((m) => {
+        _superjson = m.default;
+        _superjsonUnavailable = false;
+      });
+    }
+  }
+  return _superjson;
+};
 
 // Shared between node and bun. Uses AsyncLocalStorage (built into Node 16+
 // and Bun) instead of cls-hooked so both runtimes can consume the same file.
@@ -39,7 +63,7 @@ export class Logger {
           return message;
         }
         try {
-          return JSON.stringify(superjson.serialize(message).json);
+          return JSON.stringify(superjson().serialize(message).json);
         } catch {
           return String(message);
         }
@@ -68,10 +92,12 @@ export class Logger {
   }
 
   static overrideNativeLogs(namespace, _rid) {
-    const forward = (type) => (...args) => {
-      const requestId = namespace.getStore()?.id ?? "";
-      Logger.write(requestId, args, type);
-    };
+    const forward =
+      (type) =>
+      (...args) => {
+        const requestId = namespace.getStore()?.id ?? "";
+        Logger.write(requestId, args, type);
+      };
 
     console.log =
       console.info =

--- a/runtimes/node/versions/latest/package-lock.json
+++ b/runtimes/node/versions/latest/package-lock.json
@@ -11,9 +11,8 @@
       "dependencies": {
         "@vercel/nft": "^0.29.2",
         "express": "^4.21.2",
-        "import-in-the-middle": "^1.14.4",
         "micro": "^9.3.4",
-        "require-in-the-middle": "^8.0.0",
+        "serve-static": "^1.16.3",
         "srvx": "^0.8.16",
         "superjson": "^2.2.6"
       }
@@ -422,12 +421,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/cjs-module-lexer": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
-      "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
-      "license": "MIT"
-    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -724,6 +717,21 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
     },
+    "node_modules/express/node_modules/serve-static": {
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.2.tgz",
+      "integrity": "sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "0.19.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/express/node_modules/setprototypeof": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
@@ -973,18 +981,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/import-in-the-middle": {
-      "version": "1.14.4",
-      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.14.4.tgz",
-      "integrity": "sha512-eWjxh735SJLFJJDs5X82JQ2405OdJeAHDBnaoFCfdr5GVc7AWc9xU7KbrF+3Xd5F2ccP1aQFKtY+65X6EfKZ7A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "acorn": "^8.14.0",
-        "acorn-import-attributes": "^1.9.5",
-        "cjs-module-lexer": "^1.2.2",
-        "module-details-from-path": "^1.0.3"
-      }
-    },
     "node_modules/inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
@@ -1176,12 +1172,6 @@
       "engines": {
         "node": ">= 18"
       }
-    },
-    "node_modules/module-details-from-path": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
-      "integrity": "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==",
-      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.0.0",
@@ -1377,42 +1367,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/require-in-the-middle": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-8.0.0.tgz",
-      "integrity": "sha512-9s0pnM5tH8G4dSI3pms2GboYOs25LwOGnRMxN/Hx3TYT1K0rh6OjaWf4dI0DAQnMyaEXWoGVnSTPQasqwzTTAA==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.3.5",
-        "module-details-from-path": "^1.0.3"
-      },
-      "engines": {
-        "node": ">=9.3.0 || >=8.10.0 <9.0.0"
-      }
-    },
-    "node_modules/require-in-the-middle/node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/require-in-the-middle/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
-    },
     "node_modules/resolve-from": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
@@ -1534,18 +1488,98 @@
       }
     },
     "node_modules/serve-static": {
-      "version": "1.16.2",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.2.tgz",
-      "integrity": "sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==",
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
+      "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
       "license": "MIT",
       "dependencies": {
         "encodeurl": "~2.0.0",
         "escape-html": "~1.0.3",
         "parseurl": "~1.3.3",
-        "send": "0.19.0"
+        "send": "~0.19.1"
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/serve-static/node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/serve-static/node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static/node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/serve-static/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/serve-static/node_modules/send": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
+      "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.1",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "~2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "~2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/serve-static/node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/serve-static/node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/setprototypeof": {

--- a/runtimes/node/versions/latest/package.json
+++ b/runtimes/node/versions/latest/package.json
@@ -13,9 +13,8 @@
   "dependencies": {
     "@vercel/nft": "^0.29.2",
     "express": "^4.21.2",
-    "import-in-the-middle": "^1.14.4",
     "micro": "^9.3.4",
-    "require-in-the-middle": "^8.0.0",
+    "serve-static": "^1.16.3",
     "srvx": "^0.8.16",
     "superjson": "^2.2.6"
   }

--- a/runtimes/node/versions/latest/src/ssr/injections.mjs
+++ b/runtimes/node/versions/latest/src/ssr/injections.mjs
@@ -1,24 +1,31 @@
 // Node's SSR injection entrypoint — loaded via NODE_OPTIONS='--import ...'.
-// All per-request logic lives in the shared http-injection.mjs; this file only
-// wires the wrappers up using node-specific hook mechanisms (import-in-the-
-// middle for ESM, require-in-the-middle for CJS) so every load of http/https
-// receives the wrapped Server / createServer.
+// All per-request logic lives in the shared http-injection.mjs. Like bun's
+// --preload entrypoint, --import fires before any user code runs, so the
+// http/https Server prototypes are patched directly instead of hooking every
+// module load with import-in-the-middle / require-in-the-middle — the loader
+// thread spin-up and per-module source transform of those hooks roughly
+// doubled SSR server boot.
 
-import { Hook, createAddHookMessageChannel } from "import-in-the-middle";
-import ritm from "require-in-the-middle";
-import { register } from "node:module";
-import { wrapHttp } from "./http-injection.mjs";
+import http from "node:http";
+import https from "node:https";
+import { overrideEmit } from "./http-injection.mjs";
 
 console.log("Preparing SSR runtime ...");
 
-const { registerOptions, waitForAllMessagesAcknowledged } =
-  createAddHookMessageChannel();
-register("import-in-the-middle/hook.mjs", import.meta.url, registerOptions);
-
-new Hook(["http", "https"], wrapHttp);
-ritm(["http", "https"], wrapHttp);
-
-await waitForAllMessagesAcknowledged();
+for (const mod of [http, https]) {
+  // Patch Server.prototype.emit so every instance — created via
+  // createServer(), new Server(), or a subclass — flows through the wrapped
+  // emit regardless of how the module was imported.
+  if (
+    mod.Server &&
+    mod.Server.prototype &&
+    !mod.Server.prototype.__oprEmitPatched
+  ) {
+    const originalEmit = mod.Server.prototype.emit;
+    mod.Server.prototype.emit = overrideEmit(originalEmit);
+    mod.Server.prototype.__oprEmitPatched = true;
+  }
+}
 
 console.log(
   `SSR runtime prepared with configuration PORT=${process.env.PORT} and HOST=${process.env.HOST}`,


### PR DESCRIPTION
> **Walkthrough:** [Boot Path Teardown](https://claude.ai/code/artifact/4c222436-154a-4b5d-bdac-aea75a8da063) — visual explainer covering both this PR and its companion: what was on the boot path, why it cost what it did, and the measured result.

## Why

SSR runtimes (Next.js, Angular, TanStack Start, SvelteKit, Astro, Nuxt, Analog, Remix) boot through the same **Server boot** window we measure on edge, and two things unrelated to the framework itself were dominating it.

## What was on the boot path

**1. The module-load hook tax.** Node's SSR injection entrypoint (`NODE_OPTIONS --import injections.mjs`) registered import-in-the-middle + require-in-the-middle just to wrap `http`/`https`. That spawns a separate loader-hook thread and rewrites the source of **every module** the framework bundle imports — on a trivial express app it alone doubled boot (75 ms → 165 ms), and the tax grows with bundle size. Bun's entrypoint already avoided this by patching `Server.prototype.emit` directly at preload — and node's `--import` gives the exact same "runs before user code" guarantee.

**2. express, imported for two features.** Every wrapper pulled in express (~65 ms as ESM import) only for `express.static` and mounting a single handler. `express.static` *is* the `serve-static` package (~23 ms), and the handler mount is one line of `node:http`.

Plus the shared SSR logger imported superjson eagerly at preload.

## Changes

1. **`injections.mjs` (node): patch `http/https Server.prototype.emit` directly**, same as bun's preload entrypoint — no import-in-the-middle, no require-in-the-middle, no loader thread, no per-module transform. Both packages removed from the runtime's dependencies, and the now-unused `wrapHttp`/`wrapServer`/`wrapCreateServer` exports removed from the shared `http-injection.mjs`.
2. **Wrappers: `node:http` + `serve-static` instead of express** for angular, astro, sveltekit, nuxt, analog, next-js and both tanstack variants — identical static behavior (`express.static` re-exports `serve-static`) plus a finalhandler-equivalent 404/500 terminal handler. **Remix keeps express**: `@remix-run/express`'s request handler depends on express request extensions (`req.protocol`, `req.get`, `req.originalUrl`). `serve-static` added as a direct dependency for node/bun and mapped in `deno.json`.
3. **Shared SSR logger: superjson loaded lazily** on the first structured log via `createRequire` (synchronous, so no lossy window), with a guarded dynamic-import fallback for runtimes without `require(esm)`.

## Timings

Measured on the `node-22` image with the repo's `tanstack_start_native` test fixture, real `startup=` lifecycle telemetry (n=10 each, arm64; production amd64 vCPUs scale absolute savings up):

| Variant | Median | Δ |
|---|---|---|
| baseline | 310 ms | — |
| prototype-patch injections + lazy superjson | 170 ms | −45% |
| + node:http/serve-static wrappers | **140 ms** | **−55%** |

The injection fix applies to every SSR framework on node with zero wrapper changes; heavier bundles (Angular, Next.js) should save proportionally more since the per-module transform tax scales with module count.

## Testing

Full local suites (arm64), all built and run against these changes:

- Green: tanstack_start_native, angular, sveltekit, astro, nuxt, analog, next-js, remix, tanstack_start_nitro_listener, next-js_bun — 19/19 tests each.
- next-js_deno fails identically on unmodified `main` (React dev/prod build mismatch inside Next.js SSR under deno, 17 errors) — pre-existing and unrelated.


## Server Startup Times (CI)

"Server boot" from this PR's CI [Server Startup Times](https://github.com/open-runtimes/open-runtimes/pull/561#issuecomment-5404838236) comment vs the same rows from #560's run (which is `main` for the SSR path — same CI harness, amd64 runners):

| Runtime | Server boot (without this PR) | Server boot (this PR) | Δ |
|---|---|---|---|
| `analog` | 0.47 s | 0.16 s | −66% |
| `angular` | 0.49 s | 0.19 s | −61% |
| `astro` | 0.59 s | 0.20 s | −66% |
| `nuxt` | 0.45 s | 0.17 s | −62% |
| `sveltekit` | 0.44 s | 0.22 s | −50% |
| `tanstack_start_native` | 0.66 s | 0.29 s | −56% |
| `tanstack_start_nitro_listener` | 0.36 s | 0.17 s | −53% |
| `remix` | 0.88 s | 0.53 s | −40% |
| `next-js` | 0.97 s | 0.79 s | −19% |
| `next-js-turbopack` | 1.07 s | 0.77 s | −28% |

Remix and Next.js improve less because remix keeps express and Next.js boot is dominated by `nextApp.prepare()` — both still get the full injection-hook win.

