### PR TITLE
feat(lifecycle): declare the code location via OPEN_RUNTIMES_CODE_PATH

### DIFF
--- a/helpers/lifecycle/extract.sh
+++ b/helpers/lifecycle/extract.sh
@@ -64,8 +64,38 @@ extract_code_archive() {
 	fi
 }
 
-# Check if code is pre-extracted (e.g., by sidecar)
-if [ -f "/mnt/code/.extracted" ]; then
+# Where the code is, declared by the orchestrator on the runtime container:
+# OPEN_RUNTIMES_CODE_PATH names a directory already holding the servable tree
+# (symlinked in, or served in place when it is the function path itself), or an
+# archive file to extract into the function path. Unset falls back to the
+# legacy signals: the .extracted marker on the code volume, else an archive
+# hunted down in /mnt/code.
+code_path="$OPEN_RUNTIMES_CODE_PATH"
+if [ -z "$code_path" ] && [ -f "/mnt/code/.extracted" ]; then
+	code_path="/mnt/code"
+fi
+
+if [ -n "$code_path" ] && [ ! -e "$code_path" ]; then
+	echo -e "\e[90m$(date +[%H:%M:%S]) \e[31m[\e[0mopen-runtimes\e[31m]\e[97m Code path $code_path not found. \e[0m"
+	exit 1
+fi
+
+if [ -f "$code_path" ]; then
+	# An archive: extract it into the function path.
+	echo -e "\e[90m$(date +[%H:%M:%S]) \e[31m[\e[0mopen-runtimes\e[31m]\e[97m Code extraction started. \e[0m"
+
+	start=$(awk '{print $1}' /proc/uptime)
+	extract_archive "$code_path" /usr/local/server/src/function
+
+	end=$(awk '{print $1}' /proc/uptime)
+	elapsed=$(awk "BEGIN{printf \"%.3f\", $end - $start}")
+	echo "extract=$elapsed" >>/mnt/telemetry/timings.txt
+elif [ "$code_path" = "/usr/local/server/src/function" ]; then
+	# The servable tree already sits at the function path (e.g. the
+	# orchestrator mounted it there) — nothing to clear, link, or extract.
+	echo -e "\e[90m$(date +[%H:%M:%S]) \e[31m[\e[0mopen-runtimes\e[31m]\e[97m Code mounted in place, skipping extraction. \e[0m"
+	echo "symlink=0" >>/mnt/telemetry/timings.txt
+elif [ -n "$code_path" ]; then
 	echo -e "\e[90m$(date +[%H:%M:%S]) \e[31m[\e[0mopen-runtimes\e[31m]\e[97m Code already extracted, skipping extraction. \e[0m"
 
 	start=$(awk '{print $1}' /proc/uptime)
@@ -78,7 +108,7 @@ if [ -f "/mnt/code/.extracted" ]; then
 	rm -rf /usr/local/server/src/function/*
 
 	symlink_failed=false
-	for item in /mnt/code/*; do
+	for item in "$code_path"/*; do
 		# Skip archive files and marker
 		case "$(basename "$item")" in
 		code.sqfs | code.tar | code.tar.gz | code.gz | .extracted) continue ;;

--- a/tests/BuildCompression.php
+++ b/tests/BuildCompression.php
@@ -93,6 +93,18 @@ class BuildCompression extends TestCase
         self::assertStringContainsString('code.sqfs | code.tar | code.tar.gz | code.gz | .extracted', $extract);
     }
 
+    public function testExtractionHonorsCodePathEnvironmentAndMarker(): void
+    {
+        $extract = \file_get_contents(\dirname(__DIR__) . '/helpers/lifecycle/extract.sh');
+
+        self::assertStringContainsString('code_path="$OPEN_RUNTIMES_CODE_PATH"', $extract);
+        self::assertStringContainsString('[ -z "$code_path" ] && [ -f "/mnt/code/.extracted" ]', $extract);
+        self::assertStringContainsString('[ -f "$code_path" ]', $extract);
+        self::assertStringContainsString('extract_archive "$code_path" /usr/local/server/src/function', $extract);
+        self::assertStringContainsString('[ "$code_path" = "/usr/local/server/src/function" ]', $extract);
+        self::assertStringContainsString('for item in "$code_path"/*', $extract);
+    }
+
     private function runCompressionSelection(array $env): array
     {
         $script = \dirname(__DIR__) . '/helpers/lifecycle/compression.sh';


### PR DESCRIPTION
## Problem

Orchestrators that prepare the code themselves (sidecar extraction, or a mounted squashfs image) have to plant an `.extracted` marker **file on the code volume** for `extract.sh` to take the symlink path. For an overlay-mounted tree that's awkward: the image doesn't carry the marker, a pre-mount write lands on the directory the overlay then hides, so writing it needs its own privileged step after the mount is up (in appwrite-labs/edge this cost a dedicated init container per squashfs runtime pod). And the archive location itself is hardcoded — `extract.sh` only ever hunts `/mnt/code/code.*`.

## Change

One env declares where the code is, consistent with the other lifecycle switches:

```sh
OPEN_RUNTIMES_CODE_PATH=<path>
```

- **Directory**: it already holds the servable tree — symlinked into the function path, exactly as the marker's branch does today.
- **The function path itself** (`/usr/local/server/src/function`): nothing to clear, link, or extract — the orchestrator mounted the tree exactly where the server reads it, and the whole pass is skipped.
- **File**: an archive to extract into the function path, format sniffed from magic bytes as usual (tar/gzip/zstd/squashfs).
- A path that names nothing fails loudly instead of serving the wrong tree.

Unset keeps the legacy signals unchanged — the `.extracted` marker (implying `/mnt/code`), else the `/mnt/code/code.*` archive hunt — so existing orchestrators and `skip`-compression builds are unaffected.

Verified end-to-end: edge's K8s executor e2e suite runs green with runtime images carrying this `extract.sh`, the code volume mounted onto the function path, `OPEN_RUNTIMES_CODE_PATH` naming it, and no marker written anywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)