### PR TITLE
fix(python): make build virtualenv portable

### DIFF
--- a/runtimes/python/versions/latest/hooks/build-prepare.sh
+++ b/runtimes/python/versions/latest/hooks/build-prepare.sh
@@ -3,6 +3,8 @@
 set -e
 shopt -s dotglob
 
-# Create virtual env
-python3 -m venv runtime-env
+# The build output is archived and restored in a fresh runtime container.
+# Copies keep the interpreter inside the artifact instead of leaving an
+# absolute link to the build container's /usr/local/bin/python3.
+python3 -m venv --copies runtime-env
 source runtime-env/bin/activate

--- a/runtimes/python/versions/ml-3.11/hooks/build-prepare.sh
+++ b/runtimes/python/versions/ml-3.11/hooks/build-prepare.sh
@@ -3,6 +3,8 @@
 set -e
 shopt -s dotglob
 
-# Create virtual env
-python3 -m venv runtime-env
+# The build output is archived and restored in a fresh runtime container.
+# Copies keep the interpreter inside the artifact instead of leaving an
+# absolute link to the build container's /usr/local/bin/python3.
+python3 -m venv --copies runtime-env
 . runtime-env/bin/activate # OVERRIDE: Cant use source here

--- a/runtimes/python/versions/ml-3.12/hooks/build-prepare.sh
+++ b/runtimes/python/versions/ml-3.12/hooks/build-prepare.sh
@@ -3,6 +3,8 @@
 set -e
 shopt -s dotglob
 
-# Create virtual env
-python3 -m venv runtime-env
+# The build output is archived and restored in a fresh runtime container.
+# Copies keep the interpreter inside the artifact instead of leaving an
+# absolute link to the build container's /usr/local/bin/python3.
+python3 -m venv --copies runtime-env
 . runtime-env/bin/activate # OVERRIDE: Cant use source here

--- a/runtimes/python/versions/ml-3.13/hooks/build-prepare.sh
+++ b/runtimes/python/versions/ml-3.13/hooks/build-prepare.sh
@@ -3,6 +3,8 @@
 set -e
 shopt -s dotglob
 
-# Create virtual env
-python3 -m venv runtime-env
+# The build output is archived and restored in a fresh runtime container.
+# Copies keep the interpreter inside the artifact instead of leaving an
+# absolute link to the build container's /usr/local/bin/python3.
+python3 -m venv --copies runtime-env
 . runtime-env/bin/activate # OVERRIDE: Cant use source here


### PR DESCRIPTION
## Summary

- create Python build virtualenvs with python -m venv --copies
- apply the change to latest Python and all maintained Python-ML hooks
- keep the interpreter inside future build artifacts instead of depending on an absolute link into the build container

## Why

Build output is archived and restored in a fresh runtime container. The default venv layout links runtime-env/bin/python3 to /usr/local/bin/python3. That external link is both non-portable and incompatible with strict archive extraction. Copied interpreters make new artifacts self-contained; the orchestrator compatibility fix handles already-built artifacts.

## Validation

- bash -n on all four changed hooks
- shellcheck (only the existing dynamic activate-file SC1091 notices)
- verified with Homebrew CPython 3.14 that --copies produces regular python, python3, and versioned interpreter files and that the environment runs

Full runtime image tests require Docker and will run in CI.