### PR TITLE
fix(lifecycle): shell-quote the metadata .open-runtimes carries

### DIFF
--- a/helpers/lifecycle/build.sh
+++ b/helpers/lifecycle/build.sh
@@ -72,14 +72,16 @@ if [ -n "$OPEN_RUNTIMES_OUTPUT_DIRECTORY" ]; then
 	cd "$OPEN_RUNTIMES_OUTPUT_DIRECTORY"
 fi
 
-# Store build metadata. Will be used during start process
+# Store build metadata. Will be used during start process. Values are
+# shell-quoted: the file is sourced at startup and the entrypoint is
+# user-controlled text.
 touch .open-runtimes
-echo "OPEN_RUNTIMES_ENTRYPOINT=$OPEN_RUNTIMES_ENTRYPOINT" >.open-runtimes
-echo "OPEN_RUNTIMES_CLEANUP=${OPEN_RUNTIMES_CLEANUP:-none}" >>.open-runtimes
+echo "OPEN_RUNTIMES_ENTRYPOINT=$(opr_quote "$OPEN_RUNTIMES_ENTRYPOINT")" >.open-runtimes
+echo "OPEN_RUNTIMES_CLEANUP=$(opr_quote "${OPEN_RUNTIMES_CLEANUP:-none}")" >>.open-runtimes
 
 . /usr/local/server/helpers/lifecycle/compression.sh
 
-echo "OPEN_RUNTIMES_COMPRESSION=$COMPRESSION_METHOD" >>.open-runtimes
+echo "OPEN_RUNTIMES_COMPRESSION=$(opr_quote "$COMPRESSION_METHOD")" >>.open-runtimes
 
 OUTPUT_DIR="${OPEN_RUNTIMES_BUILD_OUTPUT_DIR:-/mnt/code}"
 mkdir -p "$OUTPUT_DIR"

--- a/helpers/lifecycle/lib.sh
+++ b/helpers/lifecycle/lib.sh
@@ -19,6 +19,14 @@ opr_uptime() {
 	awk '{print $1}' /proc/uptime
 }
 
+# Single-quote a value so it survives being sourced as shell. .open-runtimes
+# is `. `-sourced at startup, and the entrypoint it carries is user-controlled
+# text: unquoted, `index.php extra` parses as "run `extra` with the var set"
+# and kills the boot with a cryptic "command not found" crash loop.
+opr_quote() {
+	printf "'%s'" "$(printf '%s' "$1" | sed "s/'/'\\\\''/g")"
+}
+
 # Source a runtime's hook if it ships one; missing hook means the phase is a
 # no-op. Hooks are sourced (not executed) on purpose: they set environment
 # that must persist across phases (python's venv activate, OPEN_RUNTIMES_CLEANUP


### PR DESCRIPTION
`.open-runtimes` is `.`-sourced at runtime startup (`extract.sh`, under `set -o allexport`), and the entrypoint it carries is **user-controlled text written unquoted** by `build.sh`:

```sh
echo "OPEN_RUNTIMES_ENTRYPOINT=$OPEN_RUNTIMES_ENTRYPOINT" >.open-runtimes
```

An entrypoint containing a space — e.g. the literal `echo skip-install` currently deployed by a production project — makes line 1 parse as *"run `skip-install` with the var set"*: the boot dies with a cryptic `command not found` crash loop. Shell metacharacters (`;`, `$()`, backticks) execute outright. That execution lands inside the user's own runtime container where their code already runs, so no tenant boundary is crossed — but it bricks deployments with a misleading error, burns pod churn on endless crash loops, and at least one probe-shaped entrypoint is exercising it in prod today.

Values are now single-quoted via a POSIX-safe `opr_quote` helper (`'` → `'\''`), so any entrypoint sources as an inert assignment and the deployment fails later with a sane entrypoint-not-found instead. Verified round-trip in busybox sh (the runtime images' shell) for spaces, `;`-injection, `$()`, backticks, and embedded quotes: value preserved byte-exact, nothing executes.

Applies to new builds only — existing stored artifacts keep their unquoted file (they crash today and would keep crashing either way). Cloud-side entrypoint validation would be a good belt to this suspender.

🤖 Generated with [Claude Code](https://claude.com/claude-code)