### PR TITLE
perf(flutter): build versions on a shared base

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -99,7 +99,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
       - name: Run tests
-        timeout-minutes: 15
+        timeout-minutes: 30
         working-directory: ./
         run: bun ci/test.ts ${{ matrix.ID }}
       - name: Upload startup metrics

--- a/.github/workflows/version-audit/src/Local.ts
+++ b/.github/workflows/version-audit/src/Local.ts
@@ -43,6 +43,11 @@ export class Local {
         // Base images live in the [<runtime>.build.versions] tables of
         // ci/runtimes.toml (the source docker-bake.json is generated from)
         const build = data[runtime]?.build;
+        // Some runtimes install their SDK onto a generic base, so the base tag
+        // does not represent the runtime version and cannot be audited as one.
+        if (build?.audit === false) {
+          continue;
+        }
         const versionConfig = build?.versions?.[version];
         const base = versionConfig?.base;
         if (!base) {

--- a/ci/runtimes.toml
+++ b/ci/runtimes.toml
@@ -78,7 +78,6 @@ tools = "dart --version"
 test = "Serverless/Dart.php"
 
 [flutter]
-report_size = false
 versions = ["3.47", "3.44", "3.41", "3.38", "3.35", "3.32", "3.29", "3.27", "3.24"]
 commands = { install = "flutter build web", start = "bash helpers/server.sh" }
 formatter = { prepare = "echo \"Using native formatter\"", check = "dart format -o none --set-exit-if-changed .", write = "dart format ." }
@@ -319,6 +318,7 @@ output = "./.next"
 # published image tag: openruntimes/<runtime>:v5-<version>.
 # Per-version keys: base (FROM image), args (build args), platforms (override),
 # build_base (php: builder-stage base), version_dir (overlay dir override).
+# Set build.audit = false when the runtime version is not supplied by its base.
 # ─────────────────────────────────────────────────────────────────────────────
 
 [node.build.versions]
@@ -377,16 +377,19 @@ image = "python-ml"
 "2.17" = { base = "dart:2.17.7" }
 "2.16" = { base = "dart:2.16.2" }
 
+[flutter.build]
+audit = false
+
 [flutter.build.versions]
-"3.47" = { base = "ghcr.io/adrianjagielak/flutter:3.47.1" }
-"3.44" = { base = "ghcr.io/adrianjagielak/flutter:3.44.6" }
-"3.41" = { base = "ghcr.io/cirruslabs/flutter:3.41.2" }
-"3.38" = { base = "ghcr.io/cirruslabs/flutter:3.38.9" }
-"3.35" = { base = "ghcr.io/cirruslabs/flutter:3.35.7" }
-"3.32" = { base = "ghcr.io/cirruslabs/flutter:3.32.6" }
-"3.29" = { base = "ghcr.io/cirruslabs/flutter:3.29.3" }
-"3.27" = { base = "ghcr.io/cirruslabs/flutter:3.27.3" }
-"3.24" = { base = "ghcr.io/cirruslabs/flutter:3.24.5" }
+"3.47" = { base = "debian:12.15-slim", args = { FLUTTER_VERSION = "3.47.1" } }
+"3.44" = { base = "debian:12.15-slim", args = { FLUTTER_VERSION = "3.44.6" } }
+"3.41" = { base = "debian:12.15-slim", args = { FLUTTER_VERSION = "3.41.2" } }
+"3.38" = { base = "debian:12.15-slim", args = { FLUTTER_VERSION = "3.38.9" } }
+"3.35" = { base = "debian:12.15-slim", args = { FLUTTER_VERSION = "3.35.7" } }
+"3.32" = { base = "debian:12.15-slim", args = { FLUTTER_VERSION = "3.32.6" } }
+"3.29" = { base = "debian:12.15-slim", args = { FLUTTER_VERSION = "3.29.3" } }
+"3.27" = { base = "debian:12.15-slim", args = { FLUTTER_VERSION = "3.27.3" } }
+"3.24" = { base = "debian:12.15-slim", args = { FLUTTER_VERSION = "3.24.5" } }
 
 [ruby.build.versions]
 "4.0" = { base = "ruby:4.0.5-alpine3.23" }

--- a/ci/types.ts
+++ b/ci/types.ts
@@ -7,6 +7,7 @@ export interface BuildVersion {
 }
 
 export interface BuildConfig {
+    audit?: boolean;
     image?: string;
     runtime_dir?: string;
     platforms?: string[];

--- a/docker-bake.json
+++ b/docker-bake.json
@@ -1190,7 +1190,7 @@
       ]
     },
     "_flutter": {
-      "dockerfile-inline": "# syntax=docker/dockerfile:1\n# INCLUDE directives below are resolved by `bun ci/bake.ts`, which inlines the\n# referenced *.dockerfile fragments into docker-bake.json (dockerfile-inline).\nARG BASE_IMAGE\nFROM $${BASE_IMAGE}\n\nLABEL maintainer=\"team@appwrite.io\"\nLABEL namespace=\"open-runtimes\"\n\nENV OPEN_RUNTIMES_SECRET=open_runtime_secret\nENV OPEN_RUNTIMES_ENV=production\nENV OPEN_RUNTIMES_HEADERS=\"{}\"\n\n# Disable registry audit requests while constructing runtime images. Keeping\n# this as an ARG prevents the setting from leaking into the published image.\nARG npm_config_audit=false\n\nRUN <<EOR\n    if [ -f /etc/alpine-release ]; then\n        apk add --no-cache util-linux zstd squashfs-tools\n        # isa-l (igzip) needs alpine 3.19+; older bases get pigz\n        apk add --no-cache isa-l || apk add --no-cache pigz\n    else\n        apt-get update && apt-get install -y util-linux zstd squashfs-tools pigz\n        # isal (igzip) is only packaged on newer debian/ubuntu; pigz covers the rest\n        apt-get install -y isal || true\n    fi\nEOR\n\nRUN mkdir -p /mnt/code /mnt/logs /mnt/telemetry /usr/local/build /usr/local/server/src/function\n\nWORKDIR /usr/local/server\n\n# Assemble /usr/local/server from named build contexts, in overlay precedence\n# order (later layers overwrite earlier ones):\n#   1. helpers  -> repo helpers/ (global lifecycle runner + shims)\n#   2. shared   -> runtimes/<shared family>/ (e.g. javascript/ for node), or empty\n#   3. latest   -> runtimes/<runtime>/versions/latest/\n#   4. version  -> runtimes/<runtime>/versions/<version>/ extras, or empty\nCOPY --from=helpers . /usr/local/server/helpers/\nCOPY --from=shared . /usr/local/server/\nCOPY --from=latest . /usr/local/server/\nCOPY --from=version . /usr/local/server/\nRUN rm -f /usr/local/server/.gitkeep /usr/local/server/Dockerfile /usr/local/server/build.dockerfile\n\nRUN apt-get update && apt-get install -y bash jq\n\nRUN dart --disable-analytics\n\nRUN chmod -R +x /usr/local/server/helpers\n\nEXPOSE 3000\n\n# Enable web platform\nRUN flutter config --enable-web\n\n# Preinstall the static file server; 4.1.0 is the newest release compatible\n# with every Dart SDK in the matrix\nRUN dart pub global activate dhttpd 4.1.0\n"
+      "dockerfile-inline": "# syntax=docker/dockerfile:1\n# INCLUDE directives below are resolved by `bun ci/bake.ts`, which inlines the\n# referenced *.dockerfile fragments into docker-bake.json (dockerfile-inline).\nARG BASE_IMAGE\nFROM $${BASE_IMAGE} AS flutter-base\n\n# Flutter's Linux SDK bundles glibc binaries, so use a slim Debian base rather\n# than Alpine. Keep all OS dependencies in this version-independent layer.\nRUN apt-get update \\\n    && apt-get install -y --no-install-recommends \\\n        bash \\\n        ca-certificates \\\n        curl \\\n        git \\\n        jq \\\n        libglu1-mesa \\\n        unzip \\\n        xz-utils \\\n        zip \\\n    && rm -rf /var/lib/apt/lists/*\n\nENV FLUTTER_HOME=/opt/flutter\nENV FLUTTER_ROOT=$${FLUTTER_HOME}\nENV PUB_CACHE=/root/.pub-cache\nENV PATH=$${FLUTTER_HOME}/bin:$${FLUTTER_HOME}/bin/cache/dart-sdk/bin:$${PUB_CACHE}/bin:$${PATH}\nENV BOT=true\n\n# Build the version-specific SDK separately so changes to runtime helpers do\n# not invalidate the expensive Flutter download and precache step.\nFROM flutter-base AS flutter-sdk\n\nARG FLUTTER_VERSION\n\nRUN git clone --depth 1 --branch \"$${FLUTTER_VERSION}\" \\\n        https://github.com/flutter/flutter.git \"$${FLUTTER_HOME}\" \\\n    && flutter precache --web\n\nFROM flutter-base\n\nLABEL maintainer=\"team@appwrite.io\"\nLABEL namespace=\"open-runtimes\"\n\nENV OPEN_RUNTIMES_SECRET=open_runtime_secret\nENV OPEN_RUNTIMES_ENV=production\nENV OPEN_RUNTIMES_HEADERS=\"{}\"\n\n# Disable registry audit requests while constructing runtime images. Keeping\n# this as an ARG prevents the setting from leaking into the published image.\nARG npm_config_audit=false\n\nRUN <<EOR\n    if [ -f /etc/alpine-release ]; then\n        apk add --no-cache util-linux zstd squashfs-tools\n        # isa-l (igzip) needs alpine 3.19+; older bases get pigz\n        apk add --no-cache isa-l || apk add --no-cache pigz\n    else\n        apt-get update && apt-get install -y util-linux zstd squashfs-tools pigz\n        # isal (igzip) is only packaged on newer debian/ubuntu; pigz covers the rest\n        apt-get install -y isal || true\n    fi\nEOR\n\nRUN mkdir -p /mnt/code /mnt/logs /mnt/telemetry /usr/local/build /usr/local/server/src/function\n\nWORKDIR /usr/local/server\n\n# Assemble /usr/local/server from named build contexts, in overlay precedence\n# order (later layers overwrite earlier ones):\n#   1. helpers  -> repo helpers/ (global lifecycle runner + shims)\n#   2. shared   -> runtimes/<shared family>/ (e.g. javascript/ for node), or empty\n#   3. latest   -> runtimes/<runtime>/versions/latest/\n#   4. version  -> runtimes/<runtime>/versions/<version>/ extras, or empty\nCOPY --from=helpers . /usr/local/server/helpers/\nCOPY --from=shared . /usr/local/server/\nCOPY --from=latest . /usr/local/server/\nCOPY --from=version . /usr/local/server/\nRUN rm -f /usr/local/server/.gitkeep /usr/local/server/Dockerfile /usr/local/server/build.dockerfile\n\nRUN chmod -R +x /usr/local/server/helpers\n\nEXPOSE 3000\n\n# This is the only large version-specific layer in the final image; all OS and\n# Open Runtimes layers above it are shared by every Flutter version.\nCOPY --from=flutter-sdk $${FLUTTER_HOME} $${FLUTTER_HOME}\n\n# Enable web platform\nRUN flutter config --enable-web \\\n    && dart --disable-analytics\n\n# Preinstall the static file server; 4.1.0 is the newest release compatible\n# with every Dart SDK in the matrix\nRUN dart pub global activate dhttpd 4.1.0\n"
     },
     "flutter-3_47": {
       "inherits": [
@@ -1204,7 +1204,8 @@
         "version": "./docker/empty"
       },
       "args": {
-        "BASE_IMAGE": "ghcr.io/adrianjagielak/flutter:3.47.1"
+        "BASE_IMAGE": "debian:12.15-slim",
+        "FLUTTER_VERSION": "3.47.1"
       },
       "platforms": [
         "linux/amd64",
@@ -1227,7 +1228,8 @@
         "version": "./docker/empty"
       },
       "args": {
-        "BASE_IMAGE": "ghcr.io/adrianjagielak/flutter:3.44.6"
+        "BASE_IMAGE": "debian:12.15-slim",
+        "FLUTTER_VERSION": "3.44.6"
       },
       "platforms": [
         "linux/amd64",
@@ -1250,7 +1252,8 @@
         "version": "./docker/empty"
       },
       "args": {
-        "BASE_IMAGE": "ghcr.io/cirruslabs/flutter:3.41.2"
+        "BASE_IMAGE": "debian:12.15-slim",
+        "FLUTTER_VERSION": "3.41.2"
       },
       "platforms": [
         "linux/amd64",
@@ -1273,7 +1276,8 @@
         "version": "./docker/empty"
       },
       "args": {
-        "BASE_IMAGE": "ghcr.io/cirruslabs/flutter:3.38.9"
+        "BASE_IMAGE": "debian:12.15-slim",
+        "FLUTTER_VERSION": "3.38.9"
       },
       "platforms": [
         "linux/amd64",
@@ -1296,7 +1300,8 @@
         "version": "./docker/empty"
       },
       "args": {
-        "BASE_IMAGE": "ghcr.io/cirruslabs/flutter:3.35.7"
+        "BASE_IMAGE": "debian:12.15-slim",
+        "FLUTTER_VERSION": "3.35.7"
       },
       "platforms": [
         "linux/amd64",
@@ -1319,7 +1324,8 @@
         "version": "./docker/empty"
       },
       "args": {
-        "BASE_IMAGE": "ghcr.io/cirruslabs/flutter:3.32.6"
+        "BASE_IMAGE": "debian:12.15-slim",
+        "FLUTTER_VERSION": "3.32.6"
       },
       "platforms": [
         "linux/amd64",
@@ -1342,7 +1348,8 @@
         "version": "./docker/empty"
       },
       "args": {
-        "BASE_IMAGE": "ghcr.io/cirruslabs/flutter:3.29.3"
+        "BASE_IMAGE": "debian:12.15-slim",
+        "FLUTTER_VERSION": "3.29.3"
       },
       "platforms": [
         "linux/amd64",
@@ -1365,7 +1372,8 @@
         "version": "./docker/empty"
       },
       "args": {
-        "BASE_IMAGE": "ghcr.io/cirruslabs/flutter:3.27.3"
+        "BASE_IMAGE": "debian:12.15-slim",
+        "FLUTTER_VERSION": "3.27.3"
       },
       "platforms": [
         "linux/amd64",
@@ -1388,7 +1396,8 @@
         "version": "./docker/empty"
       },
       "args": {
-        "BASE_IMAGE": "ghcr.io/cirruslabs/flutter:3.24.5"
+        "BASE_IMAGE": "debian:12.15-slim",
+        "FLUTTER_VERSION": "3.24.5"
       },
       "platforms": [
         "linux/amd64",

--- a/runtimes/flutter/Dockerfile
+++ b/runtimes/flutter/Dockerfile
@@ -2,18 +2,52 @@
 # INCLUDE directives below are resolved by `bun ci/bake.ts`, which inlines the
 # referenced *.dockerfile fragments into docker-bake.json (dockerfile-inline).
 ARG BASE_IMAGE
-FROM ${BASE_IMAGE}
+FROM ${BASE_IMAGE} AS flutter-base
+
+# Flutter's Linux SDK bundles glibc binaries, so use a slim Debian base rather
+# than Alpine. Keep all OS dependencies in this version-independent layer.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        bash \
+        ca-certificates \
+        curl \
+        git \
+        jq \
+        libglu1-mesa \
+        unzip \
+        xz-utils \
+        zip \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV FLUTTER_HOME=/opt/flutter
+ENV FLUTTER_ROOT=${FLUTTER_HOME}
+ENV PUB_CACHE=/root/.pub-cache
+ENV PATH=${FLUTTER_HOME}/bin:${FLUTTER_HOME}/bin/cache/dart-sdk/bin:${PUB_CACHE}/bin:${PATH}
+ENV BOT=true
+
+# Build the version-specific SDK separately so changes to runtime helpers do
+# not invalidate the expensive Flutter download and precache step.
+FROM flutter-base AS flutter-sdk
+
+ARG FLUTTER_VERSION
+
+RUN git clone --depth 1 --branch "${FLUTTER_VERSION}" \
+        https://github.com/flutter/flutter.git "${FLUTTER_HOME}" \
+    && flutter precache --web
+
+FROM flutter-base
 
 INCLUDE ./docker/base-before
 
-RUN apt-get update && apt-get install -y bash jq
-
-RUN dart --disable-analytics
-
 INCLUDE ./docker/base-after
 
+# This is the only large version-specific layer in the final image; all OS and
+# Open Runtimes layers above it are shared by every Flutter version.
+COPY --from=flutter-sdk ${FLUTTER_HOME} ${FLUTTER_HOME}
+
 # Enable web platform
-RUN flutter config --enable-web
+RUN flutter config --enable-web \
+    && dart --disable-analytics
 
 # Preinstall the static file server; 4.1.0 is the newest release compatible
 # with every Dart SDK in the matrix


### PR DESCRIPTION
## Summary

- build every Flutter version on a common, version-tagged `debian:12.15-slim` base instead of inheriting two third-party Flutter image families
- install only Flutter's Linux prerequisites and precache web artifacts, avoiding the Android SDK inherited by the previous images
- isolate each version-specific SDK in a build stage, leaving the OS and Open Runtimes layers reusable across the entire matrix
- re-enable Flutter image-size reporting
- exclude Flutter from the Docker-base version audit because the generic Debian base no longer represents the Flutter SDK version
- regenerate the committed Docker Bake configuration

## Measured results

All nine Flutter CI builds and functional tests pass. CI image sizes are 1,132.60–1,328.58 MiB (1,239.92 MiB average; 11,159.31 MiB summed uncompressed). Median cold start is 0.575 s.

An apples-to-apples arm64 OCI manifest comparison gives:

| Metric | Published matrix | This PR | Change |
|---|---:|---:|---:|
| Sum of individual compressed images | 14,647.20 MiB | 4,032.76 MiB | -72.47% |
| Unique compressed union | 11,084.93 MiB | 3,412.85 MiB | -69.21% |
| Total layer references | 180 | 126 | -30.00% |
| Unique layer blobs | 139 | 37 | -73.38% |
| Blobs shared by all nine | 1 empty blob | 10 blobs / 77.49 MiB | matrix-wide reuse |

The old matrix has a higher reuse percentage (24.32% versus 15.37%) because subsets of its images share several very large, irrelevant Android SDK layers. Removing those layers reduces the unique compressed matrix footprint by 7,672.08 MiB while establishing a consistent shared base across all nine versions.

## Verification

- all Flutter 3.24–3.47 CI jobs passed
- `bun ci/bake.ts --check`
- built all nine targets locally for `linux/arm64`
- pushed the local matrix through a temporary OCI registry for compressed layer measurement
- verified `debian:12.15-slim` publishes both `linux/amd64` and `linux/arm64` manifests
- verified generic Flutter bases are excluded from runtime version auditing
- `git diff --check`